### PR TITLE
Fix bug that caused a JS error when certain items or users were selected (UIREQ-30)

### DIFF
--- a/ItemDetail.js
+++ b/ItemDetail.js
@@ -19,7 +19,11 @@ const ItemDetail = ({ item, error, patronGroups, dateFormatter }) => {
     ({ itemRecord, loanRecord, borrowerRecord } = item);
 
     borrowerName = `${_.get(borrowerRecord, ['personal', 'firstName'], '')} ${_.get(borrowerRecord, ['personal', 'lastName'], '')}`;
-    borrowerGroup = (borrowerRecord && patronGroups.records && patronGroups.records.length > 0) ? patronGroups.records.find(g => g.id === borrowerRecord.patronGroup).group : '';
+    borrowerGroup = (borrowerRecord &&
+                     borrowerRecord.patronGroup &&
+                     patronGroups.records &&
+                     patronGroups.records.length > 0) ?
+      patronGroups.records.find(g => g.id === borrowerRecord.patronGroup).group : '';
 
     if (itemRecord) {
       recordLink = <Link to={`/items/view/${itemRecord.id}`}>{_.get(itemRecord, ['barcode'], '')}</Link>;

--- a/RequestForm.js
+++ b/RequestForm.js
@@ -314,7 +314,7 @@ class RequestForm extends React.Component {
                       </Col>
                       <Col xs={3}>
                         <Button
-			  id="clickable-select-item"
+                          id="clickable-select-item"
                           buttonStyle="primary noRadius"
                           fullWidth
                           onClick={this.onItemClick}
@@ -350,7 +350,7 @@ class RequestForm extends React.Component {
                       </Col>
                       <Col xs={3}>
                         <Button
-			  id="clickable-select-requester"
+                          id="clickable-select-requester"
                           buttonStyle="primary noRadius"
                           fullWidth
                           onClick={this.onUserClick}

--- a/Requests.js
+++ b/Requests.js
@@ -391,7 +391,7 @@ class Requests extends React.Component {
           lastMenu={
             <PaneMenu>
               <Button
-	        id="clickable-new-request"
+                id="clickable-new-request"
                 title="Add New Request"
                 onClick={this.onClickAddNewRequest}
                 buttonStyle="primary paneHeaderNewButton"

--- a/UserDetail.js
+++ b/UserDetail.js
@@ -12,7 +12,11 @@ const UserDetail = ({ user, error, patronGroups }) => {
 
   if (user) {
     recordLink = <Link to={`/users/view/${user.id}`}>{userName}</Link>;
-    requesterGroup = (user && patronGroups.records && patronGroups.records.length > 0) ? patronGroups.records.find(g => g.id === user.patronGroup).group : '';
+    requesterGroup = (user &&
+                      user.patronGroup &&
+                      patronGroups.records &&
+                      patronGroups.records.length > 0) ?
+      patronGroups.records.find(g => g.id === user.patronGroup).group : '';
   }
 
   if (error) {


### PR DESCRIPTION


Execution would crash on the request form if the barcode for a user, or
an item that was currently checked out by a user, who wasn't assigned to
a patron group.