### PR TITLE
pull Row and Col from stripes-components. Refs STRIPES-490

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Favor react-intl date/time formatters. Refs STCOR-109.
 * Updates validation to use redux-form's asyncValidate approach.
 * Switch out magnifying glass for "Requester look-up" link. Fixes UIREQ-47.
+* Pull Row and Col from stripes-components. Refs STRIPES-490.
 
 ## [1.0.0](https://github.com/folio-org/ui-requests/tree/v1.0.0) (2017-09-26)
 

--- a/ItemDetail.js
+++ b/ItemDetail.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-flexbox-grid';
 import { Link } from 'react-router-dom';
 
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 
 const ItemDetail = ({ item, error, patronGroups, dateFormatter }) => {
   let recordLink;

--- a/RequestForm.js
+++ b/RequestForm.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-flexbox-grid';
 import { Field } from 'redux-form';
 
 import Button from '@folio/stripes-components/lib/Button';
@@ -13,6 +12,7 @@ import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import Pluggable from '@folio/stripes-components/lib/Pluggable';
 import Select from '@folio/stripes-components/lib/Select';
 import TextField from '@folio/stripes-components/lib/TextField';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 
 import stripesForm from '@folio/stripes-form';
 

--- a/ViewRequest.js
+++ b/ViewRequest.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
-import { Row, Col } from 'react-flexbox-grid';
 import { Link } from 'react-router-dom';
 
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
@@ -13,6 +12,7 @@ import IconButton from '@folio/stripes-components/lib/IconButton';
 import transitionToParams from '@folio/stripes-components/util/transitionToParams';
 import removeQueryParam from '@folio/stripes-components/util/removeQueryParam';
 import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 
 import RequestForm from './RequestForm';
 import { fulfilmentTypes, requestTypes, toUserAddress } from './constants';

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "prop-types": "^15.5.10",
     "query-string": "^4.3.2",
     "react": "^15.4.2",
-    "react-flexbox-grid": "^1.1.3",
     "react-intl": "^2.4.0",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"


### PR DESCRIPTION
Refs [STRIPES-490](https://issues.folio.org/browse/STRIPES-490). Purging local copies of `react-flexbox-grid` in favor of pulling `<Row>` and `<Col>` from `stripes-components`. `react-flexbox-grid` is pegged at v1.1.3 in `stripes-components` because newer versions behave badly and we'd rather not have to manage this dependency all over the place. 