### PR TITLE
UIU-424: Updated tests to handle empty users list onload

### DIFF
--- a/test/ui-testing/new_request.js
+++ b/test/ui-testing/new_request.js
@@ -22,11 +22,13 @@ module.exports.test = function uiTest(uiTestCtx) {
           .use(openApp(nightmare, config, done, 'requests', testVersion))
           .then(result => result);
       });
-      it('should find a user barcode', (done) => {
+      it('should find an active user barcode', (done) => {
         const listitem = '#list-users div[role="listitem"] > a:not([aria-label*="Barcode: undef"])';
         const bcodeNode = `${listitem} > div:nth-child(3)`;
         nightmare
           .click('#clickable-users-module')
+          .wait(1000)
+          .click('#clickable-filter-active-Active')
           .wait(listitem)
           .evaluate((bcode) => {
             const bc = document.querySelector(bcode);


### PR DESCRIPTION
The Users module was changed to not show any users on initial load. This PR changes the tests to check the 'Active' filter to ensure that a list of users is fetched and displayed.