### PR TITLE
pass keys, not values, to MCL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add validation for holds. Fixes UIREQ-52.
 * Remove notes-related permissions. Fixes UIREQ-73.
 * Ignore yarn-error.log. Refs STRIPES-517.
+* Bug fix: pass MCL keys, not values, to patron lookup. Fixes UIREQ-76.
 
 ## [1.1.0](https://github.com/folio-org/ui-requests/tree/v1.1.0) (2018-01-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.0.0...v1.1.0)

--- a/RequestForm.js
+++ b/RequestForm.js
@@ -79,6 +79,9 @@ function asyncValidate(values, dispatch, props, blurredField) {
 
 class RequestForm extends React.Component {
   static propTypes = {
+    stripes: PropTypes.shape({
+      intl: PropTypes.object.isRequired,
+    }).isRequired,
     change: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     findUser: PropTypes.func,
@@ -297,6 +300,7 @@ class RequestForm extends React.Component {
       patronGroups,
       pristine,
       submitting,
+      stripes: { intl },
     } = this.props;
 
     const { selectedUser } = this.state;
@@ -325,6 +329,14 @@ class RequestForm extends React.Component {
     if (this.state.selectedAddressTypeId) {
       addressDetail = toUserAddress(deliveryLocationsDetail[this.state.selectedAddressTypeId]);
     }
+
+    // map column-IDs to table-header-values
+    const columnMapping = {
+      name: intl.formatMessage({ id: 'ui-requests.user.name' }),
+      patronGroup: intl.formatMessage({ id: 'ui-requests.user.patronGroup' }),
+      username: intl.formatMessage({ id: 'ui-requests.user.username' }),
+      barcode: intl.formatMessage({ id: 'ui-requests.user.barcode' }),
+    };
 
     return (
       <form id="form-requests" style={{ height: '100%', overflow: 'auto' }}>
@@ -446,7 +458,8 @@ class RequestForm extends React.Component {
                               dataKey="users"
                               selectUser={this.onSelectUser}
                               disableRecordCreation={disableRecordCreation}
-                              visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
+                              visibleColumns={['name', 'patronGroup', 'username', 'barcode']}
+                              columnMapping={columnMapping}
                             />
 
                           </Col>

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,0 +1,6 @@
+{
+  "user.name": "Name",
+  "user.username": "Username",
+  "user.barcode": "Barcode",
+  "user.patronGroup": "Patron group"
+}


### PR DESCRIPTION
Now that table headers may be i18n'ed, they must be referred to by their
keys, which are constant, rather than their values, which will change
with each translation.

Fixes UIREQ-76