### PR TITLE
provide resultCount translation

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -1,4 +1,6 @@
 {
+  "resultCount": "{count, number} {count, plural, one {Record found} other {Records found}}",
+
   "user.name": "Name",
   "user.username": "Username",
   "user.barcode": "Barcode",


### PR DESCRIPTION
This key is used by SearchAndSort and is required for some tests that
inspect the value to be sure the number of requests changes as they are
processed. Full translation will be handled later.

Refs [UIREQ-69](https://issues.folio.org/browse/UIREQ-69)