### PR TITLE
pass full item details to ItemDetails. Refs UIREQ-55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Remove notes-related permissions. Fixes UIREQ-73.
 * Ignore yarn-error.log. Refs STRIPES-517.
 * Bug fix: pass MCL keys, not values, to patron lookup. Fixes UIREQ-76.
+* Bug fix: display item-details on request-edit pane. Refs UIREQ-55.
 
 ## [1.1.0](https://github.com/folio-org/ui-requests/tree/v1.1.0) (2018-01-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.0.0...v1.1.0)

--- a/RequestForm.js
+++ b/RequestForm.js
@@ -419,7 +419,7 @@ class RequestForm extends React.Component {
                       }
                       { this.state.selectedItem &&
                         <ItemDetail
-                          request={this.state.selectedItem}
+                          request={this.props.initialValues}
                           dateFormatter={this.props.dateFormatter}
                         />
                       }


### PR DESCRIPTION
RequestForm was not passing the correct prop to ItemDetails in order to display those details on the request-edit pane. 

Refs [UIREQ-55](https://issues.folio.org/browse/UIREQ-55)