### PR TITLE
re-debug the itemDetails. Refs UIREQ-55

### DIFF
--- a/RequestForm.js
+++ b/RequestForm.js
@@ -133,7 +133,7 @@ class RequestForm extends React.Component {
       selectedDelivery: fulfilmentPreference === 'Delivery',
       selectedAddressTypeId: deliveryAddressTypeId,
       selectedItem: item ? {
-        item: item,
+        item,
         itemBarcode: item.barcode,
         itemId: item.id,
       } : null,

--- a/RequestForm.js
+++ b/RequestForm.js
@@ -133,7 +133,9 @@ class RequestForm extends React.Component {
       selectedDelivery: fulfilmentPreference === 'Delivery',
       selectedAddressTypeId: deliveryAddressTypeId,
       selectedItem: item ? {
-        itemRecord: item,
+        item: item,
+        itemBarcode: item.barcode,
+        itemId: item.id,
       } : null,
       selectedUser: requester ? {
         patronGroup: requester.patronGroup,
@@ -419,7 +421,7 @@ class RequestForm extends React.Component {
                       }
                       { this.state.selectedItem &&
                         <ItemDetail
-                          request={this.props.initialValues}
+                          request={this.state.selectedItem}
                           dateFormatter={this.props.dateFormatter}
                         />
                       }


### PR DESCRIPTION
itemRecord and item, plain,
Were both perhaps present in selectedItem.
And itemBarcode contained in selectedItem.
In in selectedItem, item, plain, is expunged, and other eternally present,
Request-New and Request-Edit are all clickable.
Passing tests will be no more an abstraction,
becoming a perpetual possibility
in a world of speculative compilation.
What might have passed and what has passed
point to ui-inventory and ui-requests; it is always my fault.
Bug reports echo in the ticket tracker
To the continuous integration server we do not like
Towards the green line we never see
Into the slack-channel. My fix echoes
thus, in your code.