### PR TITLE
accommodate "show active users" filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Prefer metadata over metaData. One case to rule them all! Refs UIREQ-80.
 * Refactor fetching and structure of extended request object.
 * Implement request by proxy. Completes UIREQ-50.
+* Accommodate ui-users "show inactive users" filter. Refs UIU-400.
 
 ## [1.1.0](https://github.com/folio-org/ui-requests/tree/v1.1.0) (2018-01-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.0.0...v1.1.0)

--- a/test/ui-testing/new_request.js
+++ b/test/ui-testing/new_request.js
@@ -29,7 +29,8 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait(1111)
           .click('#clickable-users-module')
           .wait(1111)
-          .click('#clickable-filter-active-Active')
+          .wait('#input-user-search')
+          .type('#input-user-search', '0')
           .wait(listitem)
           .evaluate((bcode) => {
             const bc = document.querySelector(bcode);
@@ -48,8 +49,8 @@ module.exports.test = function uiTest(uiTestCtx) {
           .click('#clickable-checkout-module')
           .wait('#section-patron button[title*="Find"]')
           .click('#section-patron button[title*="Find"]')
-          .wait('#clickable-filter-active-Active')
-          .click('#clickable-filter-active-Active')
+          .wait('#input-user-search')
+          .type('#input-user-search', '0')
           .wait('#list-users div[role="listitem"]:nth-of-type(9)')
           .click('#list-users div[role="listitem"]:nth-of-type(9) a')
           .wait(2222)


### PR DESCRIPTION
The active/inactive users filters are deprecated and will be replaced
with a single "Show inactive users" filter; active users will be
returned in all search/filter results. This update accommodates the new
filters.

Refs [UIU-400](https://issues.folio.org/browse/UIU-400)