### PR TITLE
Revert folio-org/ui-requests#76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Change 'Author' label to 'Contributor'. Fixes UIREQ-93.
 * Add a guard against calling setState after component is unmounted. Fixes UIREQ-26.
 * Use perm or temp location in item summary. Fixes UIREQ-29.
+* Restore "active/inactive" filters since UIU-400 remains incomplete.
 
 ## [1.1.0](https://github.com/folio-org/ui-requests/tree/v1.1.0) (2018-01-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.0.0...v1.1.0)

--- a/test/ui-testing/new_request.js
+++ b/test/ui-testing/new_request.js
@@ -29,8 +29,8 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait(1111)
           .click('#clickable-users-module')
           .wait(1111)
-          .wait('#input-user-search')
-          .type('#input-user-search', '0')
+          .wait('#clickable-filter-active-Active')
+          .click('#clickable-filter-active-Active')
           .wait(listitem)
           .evaluate((bcode) => {
             const bc = document.querySelector(bcode);
@@ -49,8 +49,8 @@ module.exports.test = function uiTest(uiTestCtx) {
           .click('#clickable-checkout-module')
           .wait('#section-patron button[title*="Find"]')
           .click('#section-patron button[title*="Find"]')
-          .wait('#input-user-search')
-          .type('#input-user-search', '0')
+          .wait('#clickable-filter-active-Active')
+          .click('#clickable-filter-active-Active')
           .wait('#list-users div[role="listitem"]:nth-of-type(9)')
           .click('#list-users div[role="listitem"]:nth-of-type(9) a')
           .wait(2222)


### PR DESCRIPTION
The active/inactive users filters _will be_ deprecated, but they aren't yet because the [UIU-400](https://issues.folio.org/browse/UIU-400)-related changes in ui-users itself haven't been merged. Until they are, existing tests must be left as-is.