### PR TITLE
handle undefined instance.contributors[0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Use perm or temp location in item summary. Fixes UIREQ-29.
 * Bug fix: make proxy modal cancellable (is that a word?). Fixes UIREQ-94.
 * Restore "active/inactive" filters since UIU-400 remains incomplete.
+* Don't choke on undefined instance.contributors[0].
 
 ## [1.1.0](https://github.com/folio-org/ui-requests/tree/v1.1.0) (2018-01-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.0.0...v1.1.0)

--- a/ItemDetail.js
+++ b/ItemDetail.js
@@ -12,7 +12,7 @@ const ItemDetail = ({ item, instance, holding, dateFormatter, loan, requestCount
   const barcode = item.barcode;
   const recordLink = barcode ? <Link to={`/inventory/view/${item.instanceId}/${item.holdingsRecordId}/${item.itemId}`}>{barcode}</Link> : '';
   const status = _.get(item, ['status', 'name'], '');
-  const contributor = instance && instance.contributors ? instance.contributors[0].name : '-';
+  const contributor = _.get(instance, ['contributors', '0', 'name'], '-');
   const location = _.get(item, ['tempLocation', 'name']) ||
                    _.get(item, ['permLocation', 'name']) || '';
 


### PR DESCRIPTION
Previous implmentations did not adequately guard against
`instance.contributors[0]` being undefined, which would cause a
low-level error trapped by React and showing a warning that the page
would need to reload to continue.