### PR TITLE
STCOR-226: Add request item's title to doc.title

### DIFF
--- a/RequestForm.js
+++ b/RequestForm.js
@@ -389,7 +389,7 @@ class RequestForm extends React.Component {
           disabled={pristine || submitting}
           onClick={handleSubmit}
         >
-          <FormattedMessage id="ui-requests.requestForm.newRequest" />
+          <FormattedMessage id="ui-requests.actions.newRequest" />
         </Button>
       </PaneMenu>;
     const editRequestLastMenu =

--- a/ViewRequest.js
+++ b/ViewRequest.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 
+import TitleManager from '@folio/stripes-core/src/components/TitleManager';
 import { Accordion, AccordionSet } from '@folio/stripes-components/lib/Accordion';
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
 import Layer from '@folio/stripes-components/lib/Layer';
@@ -308,6 +309,7 @@ class ViewRequest extends React.Component {
         dismissible
         onClose={this.props.onClose}
       >
+        <TitleManager record={_.get(request, ['item', 'title'])} />
         <AccordionSet accordionStatus={this.state.accordions} onToggle={this.onToggleSection}>
           <Accordion
             open


### PR DESCRIPTION
Adds the currently-selected request's item title to the tab/window bar via `document.title`.

Also fixes a bug where the newRequest i18n key was referring to a non-existent string.