### PR TITLE
Add stripes serve to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,12 @@
     ]
   },
   "scripts": {
+    "start": "stripes serve",
     "lint": "eslint *.js lib settings test/ui-testing"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^1.1.0",
+    "@folio/stripes-cli": "^1.2.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^8.0.0",
     "babel-preset-es2015": "^6.18.0",


### PR DESCRIPTION
[Stripes CLI](https://github.com/folio-org/stripes-cli) provides a `serve` command that can be used to run a module by itself, without defining an entire platform to run in a `workspace`.

This is handy for:
- working on a single module
- testing a module in isolation
- cutting down the `node` process overhead of running several actively building modules in a local `webpack` server

To use (after a `yarn install`):
```
yarn start
```

By default, `http://localhost:3000` will attempt to connect to a back end at `http://localhost:9130`. To connect to a different Okapi cluster:
```
yarn start --okapi https://my-okapi-cluster.folio.org
```

[Full list of available `stripes serve` options](https://github.com/folio-org/stripes-cli/blob/master/doc/commands.md#serve-command)

Related to https://github.com/folio-org/ui-checkin/pull/51