### PR TITLE
Remove npm-folioci build number from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^1.0.10007",
+    "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-form": "^0.8.1",
     "@folio/stripes-smart-components": "^1.4.19",


### PR DESCRIPTION
A fix was made to react-intl-safe-html, bumping the patch version to 1.0.2.  However, ui-requests is targeting "^1.0.10007" which is a padded CI build number version only valid on the npm-folioci registry.  Technically 1.0.10007 would satisfy ^1.0.2 even though its actually a build of 1.0.1.  We should avoid using CI build numbers as dependencies.