### PR TITLE
Tests: Don't look for "active" checkbox when searching for user

### DIFF
--- a/test/ui-testing/new_request.js
+++ b/test/ui-testing/new_request.js
@@ -29,8 +29,8 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait(1111)
           .click('#clickable-users-module')
           .wait(1111)
-          .wait('#clickable-filter-active-Active')
-          .click('#clickable-filter-active-Active')
+          .wait('#clickable-filter-pg-faculty')
+          .click('#clickable-filter-pg-faculty')
           .wait(listitem)
           .evaluate((bcode) => {
             const bc = document.querySelector(bcode);
@@ -49,8 +49,8 @@ module.exports.test = function uiTest(uiTestCtx) {
           .click('#clickable-checkout-module')
           .wait('#section-patron button[title*="Find"]')
           .click('#section-patron button[title*="Find"]')
-          .wait('#clickable-filter-active-Active')
-          .click('#clickable-filter-active-Active')
+          .wait('#clickable-filter-pg-faculty')
+          .click('#clickable-filter-pg-faculty')
           .wait('#list-users div[role="listitem"]:nth-of-type(9)')
           .click('#list-users div[role="listitem"]:nth-of-type(9) a')
           .wait(2222)


### PR DESCRIPTION
The "Active" checkbox no longer exists so we shouldn't wait for it to be in place before clicking and selecting from the (no longer automatically shown) list of users.