### PR TITLE
use current stripes-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 1.3.0 (IN PROGRESS)
+
+* Update to stripes-form 0.9.0. Refs STRIPES-555.
+
 ## 1.2.0 (https://github.com/folio-org/ui-requests/tree/v1.2.0) (2018-09-10)
 
 * Refactor code to use `<SearchAndSort>` component. Completes UIREQ-49.

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-form": "^0.8.1",
+    "@folio/stripes-form": "^0.9.0",
     "@folio/stripes-smart-components": "^1.4.19",
     "@folio/stripes-util": "^1.0.0",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
Because stripes-form has not been released as a v1.0.x package,
this means ^0.8.0 is effectively ~0.8.0, meaning those packages
are locked at 0.8.x, not 0.x.x as intended. stripes-form 0.8.0
pulled in an old version of stripes-components which pulled in
an old version of React which brought darkness upon the land.

Refs [STRIPES-555](https://issues.folio.org/browse/STRIPES-555)