### PR TITLE
csv export: ensure to include proxy fields

### DIFF
--- a/Requests.js
+++ b/Requests.js
@@ -206,7 +206,10 @@ class Requests extends React.Component {
       const recordsLoaded = this.props.resources.records.records;
       const numTotalRecords = this.props.resources.records.other.totalRecords;
       if (recordsLoaded.length === numTotalRecords) {
-        exportToCsv(recordsLoaded, ['id']);
+        exportToCsv(recordsLoaded, {
+          excludeFields: ['id'],
+          explicitlyIncludeFields: ['proxy.firstName', 'proxy.lastName', 'proxy.barcode']
+        });
         this.csvExportPending = false;
       }
     }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-form": "^1.0.0",
     "@folio/stripes-smart-components": "^1.4.19",
-    "@folio/stripes-util": "^1.0.0",
+    "@folio/stripes-util": "^1.0.1",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.14",


### PR DESCRIPTION
The request objects are mostly uniform in shape, but sometimes they can have `proxy` fields. I added an option to explicitly include those fields. 

Related PR https://github.com/folio-org/stripes-util/pull/7