### PR TITLE
Fix filters2cql import

### DIFF
--- a/src/Requests.js
+++ b/src/Requests.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import fetch from 'isomorphic-fetch';
 import moment from 'moment-timezone';
-import { FilterGroups } from '@folio/stripes/components';
+import { filters2cql } from '@folio/stripes/components';
 import { SearchAndSort } from '@folio/stripes/smart-components';
 import { exportToCsv } from '@folio/stripes/util';
 
@@ -11,8 +11,6 @@ import RequestForm from './RequestForm';
 import { requestTypes, fulfilmentTypes } from './constants';
 import { getFullName } from './utils';
 import packageInfo from '../package';
-
-const { filters2cql } = FilterGroups;
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;


### PR DESCRIPTION
```
import { FilterGroups } from '@folio/stripes/components';
const { filters2cql } = FilterGroups;
```
didn't work:

<img width="961" alt="screen shot 2018-10-04 at 11 38 41 am" src="https://user-images.githubusercontent.com/230597/46489134-3ae1d500-c7ca-11e8-95d9-cf17e6101bb0.png">

`filters2cql` is now exported at the root: https://github.com/folio-org/stripes-components/pull/640