### PR TITLE
 Fix exportCsv import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-requests
 
+## 1.4.1 (https://github.com/folio-org/ui-requests/tree/v1.4.1) (2018-10-05)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.4.0...v1.4.1)
+
+* Fix `exportCsv` import
+
 ## 1.4.0 (https://github.com/folio-org/ui-requests/tree/v1.4.0) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.3.0...v1.4.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/requests",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Requests manager",
   "repository": "folio-org/ui-requests",
   "publishConfig": {

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -4,7 +4,7 @@ import fetch from 'isomorphic-fetch';
 import moment from 'moment-timezone';
 import { filters2cql } from '@folio/stripes/components';
 import { SearchAndSort } from '@folio/stripes/smart-components';
-import { exportToCsv } from '@folio/stripes/util';
+import { exportCsv } from '@folio/stripes/util';
 
 import ViewRequest from './ViewRequest';
 import RequestForm from './RequestForm';
@@ -206,7 +206,7 @@ class Requests extends React.Component {
       const recordsLoaded = this.props.resources.records.records;
       const numTotalRecords = this.props.resources.records.other.totalRecords;
       if (recordsLoaded.length === numTotalRecords) {
-        exportToCsv(recordsLoaded, {
+        exportCsv(recordsLoaded, {
           excludeFields: ['id'],
           explicitlyIncludeFields: ['proxy.firstName', 'proxy.lastName', 'proxy.barcode']
         });


### PR DESCRIPTION
Fixes 
```
WARNING in ./node_modules/@folio/requests/src/Requests.js 104:10-21
"export 'exportToCsv' was not found in '@folio/stripes/util' 
```
for https://issues.folio.org/browse/FOLIO-1547

Includes `v1.4.1` release.