### PR TITLE
handle empty results list in filter tests

### DIFF
--- a/src/Requests.js
+++ b/src/Requests.js
@@ -75,7 +75,7 @@ class Requests extends React.Component {
               'Request Date': 'requestDate',
             },
             filterConfig,
-            2,
+            2, // do not fetch unless we have a query or a filter
           ),
         },
         staticFallback: { params: {} },

--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -7,7 +7,7 @@ module.exports.test = function uiTest(uiTestCtx) {
 
     this.timeout(Number(config.test_timeout));
     const requestTypes = ['Holds', 'Recalls'];
-    let hitCount = null;
+
     describe('Login > Open module "Requests" > Get hit counts > Click filters > Logout', () => {
       before((done) => {
         login(nightmare, config, done); // logs in with the default admin credentials
@@ -15,25 +15,20 @@ module.exports.test = function uiTest(uiTestCtx) {
       after((done) => {
         logout(nightmare, config, done);
       });
+
       it('should open module "Requests" and find version tag ', (done) => {
         nightmare
           .use(openApp(nightmare, config, done, 'requests', testVersion))
           .then(result => result);
       });
-      it('should find hit count with no filters applied ', (done) => {
+
+      it('should find "choose a filter" message', (done) => {
         nightmare
-          .wait('p[title*="records found"]:not([title^="0 "]')
-          .evaluate(() => {
-            let count = document.querySelector('p[title*="records found"]').title;
-            count = count.replace(/^(\d+).+/, '$1');
-            return count;
-          })
-          .then((result) => {
-            done();
-            hitCount = result;
-          })
+          .wait('div[class^="emptyMessage"]')
+          .then(done)
           .catch(done);
       });
+
       requestTypes.forEach((filter) => {
         it(`should click ${filter} and change hit count`, (done) => {
           nightmare
@@ -43,10 +38,9 @@ module.exports.test = function uiTest(uiTestCtx) {
             .click('#clickable-reset-all')
             .wait(`#clickable-filter-requestType-${filter}`)
             .click(`#clickable-filter-requestType-${filter}`)
-            .wait('#clickable-reset-all')
-            .wait(`p[title*="records found"]:not([title^="${hitCount} "]`)
-            .click(`#clickable-filter-requestType-${filter}`)
-            .wait(`p[title="${hitCount} records found"]`)
+            .wait('#list-requests:not([data-total-count^="0"])')
+            .click('#clickable-reset-all')
+            .wait('div[class^="emptyMessage"]')
             .then(done)
             .catch(done);
         });


### PR DESCRIPTION
[UIREQ-150](https://issues.folio.org/browse/UIREQ-150) prevents the display of any requests unless a query or filter is active. The tests now reflect this.