### PR TITLE
click submit when searching

### DIFF
--- a/test/ui-testing/new_request.js
+++ b/test/ui-testing/new_request.js
@@ -91,7 +91,9 @@ module.exports.test = function uiTest(uiTestCtx) {
         nightmare
           .wait('#input-request-search')
           .insert('#input-request-search', itembc)
-          .wait(`#list-requests div[title="${itembc}"]`)
+          .wait('button[type="submit"]')
+          .click('button[type="submit"]')
+          .wait('#list-requests[data-total-count="1"]')
           .then(done)
           .catch(done);
       });


### PR DESCRIPTION
For forms to be accessible, they must not return results until a user
clicks a search button. Ergo, click the search button. This didn't 
show up until now because we used to show all requests on the landing 
page, allowing the final test to succeed even though it never submitted
the search query, but as of UIREQ-150, the landing page now loads without
results.

Refs [STCOM-354](https://issues.folio.org/browse/STCOM-354), [UIREQ-150](https://issues.folio.org/browse/UIREQ-150), 