### PR TITLE
UIREQ-135: Use documented react-intl patterns instead of stripes.intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Configure 'Requests: All permissions' permission set. Fixes UIREQ-106.
 * Show No Requests By Default. Fixes UIREQ-150.
 * Support circulation v5.0, requiring service-point information on loans. Refs UIREQ-161.
+* Use documented react-intl patterns instead of stripes.intl. UIREQ-135
 
 ## 1.4.1 (https://github.com/folio-org/ui-requests/tree/v1.4.1) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.4.0...v1.4.1)

--- a/src/CancelRequestDialog.js
+++ b/src/CancelRequestDialog.js
@@ -1,12 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import {
-  injectIntl,
-  intlShape,
-  FormattedMessage,
-} from 'react-intl';
-
+import { FormattedMessage } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   Button,
@@ -26,7 +21,6 @@ class CancelRequestDialog extends React.Component {
   }
 
   static propTypes = {
-    intl: intlShape,
     onCancelRequest: PropTypes.func.isRequired,
     onClose: PropTypes.func,
     open: PropTypes.bool,
@@ -108,8 +102,19 @@ class CancelRequestDialog extends React.Component {
   }
 
   render() {
-    const { request, intl: { formatMessage } } = this.props;
-    const { reason, reasons, /* notify, */ additionalInfo } = this.state;
+    const {
+      request,
+    } = this.props;
+
+    const {
+      reason,
+      reasons,
+      additionalInfo,
+    } = this.state;
+
+    const additionalInfoPlaceholder = reason.requiresAdditionalInformation
+      ? 'ui-requests.cancel.additionalInfoPlaceholderRequired'
+      : 'ui-requests.cancel.additionalInfoPlaceholderOptional';
 
     if (!request) return null;
 
@@ -139,23 +144,23 @@ class CancelRequestDialog extends React.Component {
           onChange={this.onChangeNotify}
         />
         */}
-        <TextArea
-          label={
-            <FormattedMessage
-              id="ui-requests.cancel.additionalInfoLabel"
-              values={{
-                required: reason.requiresAdditionalInformation ? '*' : ' '
-              }}
+        <FormattedMessage id={additionalInfoPlaceholder}>
+          {placeholder => (
+            <TextArea
+              label={
+                <FormattedMessage
+                  id="ui-requests.cancel.additionalInfoLabel"
+                  values={{
+                    required: reason.requiresAdditionalInformation ? '*' : ' '
+                  }}
+                />
+              }
+              placeholder={placeholder}
+              value={additionalInfo}
+              onChange={this.onChangeAdditionalInfo}
             />
-          }
-          placeholder={
-            reason.requiresAdditionalInformation ?
-              formatMessage({ id: 'ui-requests.cancel.additionalInfoPlaceholderRequired' }) :
-              formatMessage({ id: 'ui-requests.cancel.additionalInfoPlaceholderOptional' })
-          }
-          value={additionalInfo}
-          onChange={this.onChangeAdditionalInfo}
-        />
+          )}
+        </FormattedMessage>
         <Layout className="textRight">
           <Button onClick={this.props.onClose}>
             <FormattedMessage id="stripes-core.button.back" />
@@ -174,4 +179,4 @@ class CancelRequestDialog extends React.Component {
   }
 }
 
-export default injectIntl(CancelRequestDialog);
+export default CancelRequestDialog;

--- a/src/CancelRequestDialog.js
+++ b/src/CancelRequestDialog.js
@@ -104,6 +104,8 @@ class CancelRequestDialog extends React.Component {
   render() {
     const {
       request,
+      open,
+      onClose,
     } = this.props;
 
     const {
@@ -121,8 +123,8 @@ class CancelRequestDialog extends React.Component {
     return (
       <Modal
         label={<FormattedMessage id="ui-requests.cancel.modalLabel" />}
-        open={this.props.open}
-        onClose={this.props.onClose}
+        open={open}
+        onClose={onClose}
       >
         <p>
           <SafeHTMLMessage
@@ -162,7 +164,7 @@ class CancelRequestDialog extends React.Component {
           )}
         </FormattedMessage>
         <Layout className="textRight">
-          <Button onClick={this.props.onClose}>
+          <Button onClick={onClose}>
             <FormattedMessage id="stripes-core.button.back" />
           </Button>
           <Button

--- a/src/CancelRequestDialog.js
+++ b/src/CancelRequestDialog.js
@@ -1,10 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { injectIntl, intlShape } from 'react-intl';
+import {
+  injectIntl,
+  intlShape,
+  FormattedMessage,
+} from 'react-intl';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { Button, Layout, Modal, Select, TextArea } from '@folio/stripes/components';
+import {
+  Button,
+  Layout,
+  Modal,
+  Select,
+  TextArea,
+} from '@folio/stripes/components';
 
 class CancelRequestDialog extends React.Component {
   static manifest = {
@@ -105,7 +115,7 @@ class CancelRequestDialog extends React.Component {
 
     return (
       <Modal
-        label={formatMessage({ id: 'ui-requests.cancel.modalLabel' })}
+        label={<FormattedMessage id="ui-requests.cancel.modalLabel" />}
         open={this.props.open}
         onClose={this.props.onClose}
       >
@@ -116,7 +126,7 @@ class CancelRequestDialog extends React.Component {
           />
         </p>
         <Select
-          label={formatMessage({ id: 'ui-requests.cancel.reasonLabel' })}
+          label={<FormattedMessage id="ui-requests.cancel.reasonLabel" />}
           dataOptions={reasons}
           value={reason.value}
           onChange={this.onChangeReason}
@@ -130,10 +140,14 @@ class CancelRequestDialog extends React.Component {
         />
         */}
         <TextArea
-          label={formatMessage(
-            { id: 'ui-requests.cancel.additionalInfoLabel' },
-            { required: reason.requiresAdditionalInformation ? '*' : ' ' }
-          )}
+          label={
+            <FormattedMessage
+              id="ui-requests.cancel.additionalInfoLabel"
+              values={{
+                required: reason.requiresAdditionalInformation ? '*' : ' '
+              }}
+            />
+          }
           placeholder={
             reason.requiresAdditionalInformation ?
               formatMessage({ id: 'ui-requests.cancel.additionalInfoPlaceholderRequired' }) :
@@ -144,14 +158,14 @@ class CancelRequestDialog extends React.Component {
         />
         <Layout className="textRight">
           <Button onClick={this.props.onClose}>
-            {formatMessage({ id: 'stripes-core.button.back' })}
+            <FormattedMessage id="stripes-core.button.back" />
           </Button>
           <Button
             buttonStyle="primary"
             disabled={reason.requiresAdditionalInformation && !additionalInfo}
             onClick={this.onCancelRequest}
           >
-            {formatMessage({ id: 'stripes-core.button.confirm' })}
+            <FormattedMessage id="stripes-core.button.confirm" />
           </Button>
         </Layout>
       </Modal>

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -368,7 +368,7 @@ class RequestForm extends React.Component {
     const { selectedUser } = this.state;
     const isEditForm = (item && item.id);
 
-    const addRequestFirstMenu =
+    const addRequestFirstMenu = (
       <PaneMenu>
         <FormattedMessage id="ui-requests.actions.closeNewRequest">
           {title => (
@@ -381,8 +381,9 @@ class RequestForm extends React.Component {
             </Button>
           )}
         </FormattedMessage>
-      </PaneMenu>;
-    const addRequestLastMenu =
+      </PaneMenu>
+    );
+    const addRequestLastMenu = (
       <PaneMenu>
         <FormattedMessage id="ui-requests.actions.createNewRequest">
           {title => (
@@ -397,8 +398,9 @@ class RequestForm extends React.Component {
             </Button>
           )}
         </FormattedMessage>
-      </PaneMenu>;
-    const editRequestLastMenu =
+      </PaneMenu>
+    );
+    const editRequestLastMenu = (
       <PaneMenu>
         <FormattedMessage id="ui-requests.actions.updateRequest">
           {title => (
@@ -413,7 +415,8 @@ class RequestForm extends React.Component {
             </Button>
           )}
         </FormattedMessage>
-      </PaneMenu>;
+      </PaneMenu>
+    );
     const requestTypeOptions = _.sortBy(optionLists.requestTypes || [], ['label']).map(t => ({ label: t.label, value: t.id, selected: requestType === t.id }));
     const fulfilmentTypeOptions = _.sortBy(optionLists.fulfilmentTypes || [], ['label']).map(t => ({ label: t.label, value: t.id, selected: t.id === fulfilmentPreference }));
     const labelAsterisk = isEditForm ? '' : ' *';

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -370,37 +370,49 @@ class RequestForm extends React.Component {
 
     const addRequestFirstMenu =
       <PaneMenu>
-        <Button
-          onClick={onCancel}
-          title={formatMessage({ id: 'ui-requests.actions.closeNewRequest' })}
-          aria-label={<FormattedMessage id="ui-requests.actions.closeNewRequest" />}
-        >
-          <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
-        </Button>
+        <FormattedMessage id="ui-requests.actions.closeNewRequest">
+          {title => (
+            <Button
+              onClick={onCancel}
+              title={title}
+              aria-label={title}
+            >
+              <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
+            </Button>
+          )}
+        </FormattedMessage>
       </PaneMenu>;
     const addRequestLastMenu =
       <PaneMenu>
-        <Button
-          id="clickable-create-request"
-          type="button"
-          title={formatMessage({ id: 'ui-requests.actions.createNewRequest' })}
-          disabled={pristine || submitting}
-          onClick={handleSubmit}
-        >
-          <FormattedMessage id="ui-requests.actions.newRequest" />
-        </Button>
+        <FormattedMessage id="ui-requests.actions.createNewRequest">
+          {title => (
+            <Button
+              id="clickable-create-request"
+              type="button"
+              title={title}
+              disabled={pristine || submitting}
+              onClick={handleSubmit}
+            >
+              <FormattedMessage id="ui-requests.actions.newRequest" />
+            </Button>
+          )}
+        </FormattedMessage>
       </PaneMenu>;
     const editRequestLastMenu =
       <PaneMenu>
-        <Button
-          id="clickable-update-request"
-          type="button"
-          title={formatMessage({ id: 'ui-requests.actions.updateRequest' })}
-          disabled={pristine || submitting}
-          onClick={handleSubmit}
-        >
-          <FormattedMessage id="ui-requests.actions.updateRequest" />
-        </Button>
+        <FormattedMessage id="ui-requests.actions.updateRequest">
+          {title => (
+            <Button
+              id="clickable-update-request"
+              type="button"
+              title={title}
+              disabled={pristine || submitting}
+              onClick={handleSubmit}
+            >
+              <FormattedMessage id="ui-requests.actions.updateRequest" />
+            </Button>
+          )}
+        </FormattedMessage>
       </PaneMenu>;
     const requestTypeOptions = _.sortBy(optionLists.requestTypes || [], ['label']).map(t => ({ label: t.label, value: t.id, selected: requestType === t.id }));
     const fulfilmentTypeOptions = _.sortBy(optionLists.fulfilmentTypes || [], ['label']).map(t => ({ label: t.label, value: t.id, selected: t.id === fulfilmentPreference }));
@@ -469,9 +481,9 @@ class RequestForm extends React.Component {
               icon: 'cancel',
             }] : undefined}
             paneTitle={
-              isEditForm ?
-                <FormattedMessage id="ui-requests.actions.editRequest" /> :
-                <FormattedMessage id="ui-requests.actions.newRequest" />
+              isEditForm
+                ? <FormattedMessage id="ui-requests.actions.editRequest" />
+                : <FormattedMessage id="ui-requests.actions.newRequest" />
             }
           >
             <AccordionSet accordionStatus={this.state.accordions} onToggle={this.onToggleSection}>
@@ -571,18 +583,22 @@ class RequestForm extends React.Component {
                       {!isEditForm &&
                         <Row>
                           <Col xs={9}>
-                            <Field
-                              name="item.barcode"
-                              placeholder={formatMessage({ id: 'ui-requests.item.scanOrEnterBarcode' })}
-                              aria-label={<FormattedMessage id="ui-requests.item.barcode" />}
-                              fullWidth
-                              component={TextField}
-                              withRef
-                              ref={this.itemBarcodeRef}
-                              onInput={this.onItemClick}
-                              onKeyDown={e => this.onKeyDown(e, 'item')}
-                              validate={this.requireItem}
-                            />
+                            <FormattedMessage id="ui-requests.item.scanOrEnterBarcode">
+                              {placeholder => (
+                                <Field
+                                  name="item.barcode"
+                                  placeholder={placeholder}
+                                  aria-label={<FormattedMessage id="ui-requests.item.barcode" />}
+                                  fullWidth
+                                  component={TextField}
+                                  withRef
+                                  ref={this.itemBarcodeRef}
+                                  onInput={this.onItemClick}
+                                  onKeyDown={e => this.onKeyDown(e, 'item')}
+                                  validate={this.requireItem}
+                                />
+                              )}
+                            </FormattedMessage>
                           </Col>
                           <Col xs={3}>
                             <Button
@@ -624,18 +640,22 @@ class RequestForm extends React.Component {
                       {!isEditForm &&
                         <Row>
                           <Col xs={9}>
-                            <Field
-                              name="requester.barcode"
-                              placeholder={formatMessage({ id: 'ui-requests.requester.scanOrEnterBarcode' })}
-                              aria-label={<FormattedMessage id="ui-requests.requester.barcode" />}
-                              fullWidth
-                              component={TextField}
-                              withRef
-                              ref={this.requesterBarcodeRef}
-                              onInput={this.onUserClick}
-                              onKeyDown={e => this.onKeyDown(e, 'requester')}
-                              validate={this.requireUser}
-                            />
+                            <FormattedMessage id="ui-requests.requester.scanOrEnterBarcode">
+                              {placeholder => (
+                                <Field
+                                  name="requester.barcode"
+                                  placeholder={placeholder}
+                                  aria-label={<FormattedMessage id="ui-requests.requester.barcode" />}
+                                  fullWidth
+                                  component={TextField}
+                                  withRef
+                                  ref={this.requesterBarcodeRef}
+                                  onInput={this.onUserClick}
+                                  onKeyDown={e => this.onKeyDown(e, 'requester')}
+                                  validate={this.requireUser}
+                                />
+                              )}
+                            </FormattedMessage>
                             <Pluggable
                               aria-haspopup="true"
                               type="find-user"

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -2,7 +2,12 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import {
+  FormattedMessage,
+  FormattedDate,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
 import { Link } from 'react-router-dom';
 import { Pluggable } from '@folio/stripes/core';
 import {
@@ -344,7 +349,9 @@ class RequestForm extends React.Component {
       patronGroups,
       pristine,
       submitting,
-      intl: { formatDate, formatMessage }
+      intl: {
+        formatMessage,
+      },
     } = this.props;
 
     let requestMeta;
@@ -366,7 +373,7 @@ class RequestForm extends React.Component {
         <Button
           onClick={onCancel}
           title={formatMessage({ id: 'ui-requests.actions.closeNewRequest' })}
-          aria-label={formatMessage({ id: 'ui-requests.actions.closeNewRequest' })}
+          aria-label={<FormattedMessage id="ui-requests.actions.closeNewRequest" />}
         >
           <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
         </Button>
@@ -397,7 +404,7 @@ class RequestForm extends React.Component {
       </PaneMenu>;
     const requestTypeOptions = _.sortBy(optionLists.requestTypes || [], ['label']).map(t => ({ label: t.label, value: t.id, selected: requestType === t.id }));
     const fulfilmentTypeOptions = _.sortBy(optionLists.fulfilmentTypes || [], ['label']).map(t => ({ label: t.label, value: t.id, selected: t.id === fulfilmentPreference }));
-    const labelAsterisk = isEditForm ? '' : '*';
+    const labelAsterisk = isEditForm ? '' : ' *';
     const disableRecordCreation = true;
 
     let deliveryLocations;
@@ -421,8 +428,9 @@ class RequestForm extends React.Component {
       if (group) { patronGroupName = group.desc; }
     }
 
-    const holdShelfExpireDate = (_.get(requestMeta, ['status'], '') === 'Open - Awaiting pickup') ?
-      formatDate(_.get(requestMeta, ['holdShelfExpirationDate'], '')) : '-';
+    const holdShelfExpireDate = (_.get(requestMeta, ['status'], '') === 'Open - Awaiting pickup')
+      ? <FormattedDate value={_.get(requestMeta, ['holdShelfExpirationDate'], '')} />
+      : '-';
 
     // map column-IDs to table-header-values
     const columnMapping = {
@@ -441,7 +449,7 @@ class RequestForm extends React.Component {
           &nbsp;
         </span>
         <Link to={`/requests?filters=requestStatus.open%20-%20not%20yet%20filled%2CrequestStatus.open%20-%20awaiting%20pickup&query=${requestMeta.item.barcode}&sort=Request%20Date`}>
-          {formatMessage({ id: 'ui-requests.actions.viewRequestsInQueue' })}
+          <FormattedMessage id="ui-requests.actions.viewRequestsInQueue" />
         </Link>
       </div> : '-';
 
@@ -456,16 +464,20 @@ class RequestForm extends React.Component {
             actionMenuItems={isEditForm ? [{
               id: 'clickable-cancel-request',
               title: formatMessage({ id: 'ui-requests.cancel.cancelRequest' }),
-              label: formatMessage({ id: 'ui-requests.cancel.cancelRequest' }),
+              label: <FormattedMessage id="ui-requests.cancel.cancelRequest" />,
               onClick: () => this.setState({ isCancellingRequest: true }),
               icon: 'cancel',
             }] : undefined}
-            paneTitle={isEditForm ? formatMessage({ id: 'ui-requests.actions.editRequest' }) : formatMessage({ id: 'ui-requests.actions.newRequest' })}
+            paneTitle={
+              isEditForm ?
+                <FormattedMessage id="ui-requests.actions.editRequest" /> :
+                <FormattedMessage id="ui-requests.actions.newRequest" />
+            }
           >
             <AccordionSet accordionStatus={this.state.accordions} onToggle={this.onToggleSection}>
               <Accordion
                 id="request-info"
-                label={formatMessage({ id: 'ui-requests.requestMeta.information' })}
+                label={<FormattedMessage id="ui-requests.requestMeta.information" />}
               >
                 { isEditForm && requestMeta && requestMeta.metadata &&
                   <Col xs={12}>
@@ -478,7 +490,7 @@ class RequestForm extends React.Component {
                       <Col xs={3}>
                         { !isEditForm &&
                           <Field
-                            label={formatMessage({ id: 'ui-requests.requestMeta.type' })}
+                            label={<FormattedMessage id="ui-requests.requestMeta.type" />}
                             name="requestType"
                             component={Select}
                             fullWidth
@@ -486,20 +498,26 @@ class RequestForm extends React.Component {
                             disabled={isEditForm}
                           />
                         }
-                        { isEditForm &&
-                          <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.type' })} value={requestMeta.requestType} />
+                        {isEditForm &&
+                          <KeyValue
+                            label={<FormattedMessage id="ui-requests.requestMeta.type" />}
+                            value={requestMeta.requestType}
+                          />
                         }
                       </Col>
                       <Col xs={3}>
-                        { isEditForm &&
-                          <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.status' })} value={requestMeta.status} />
+                        {isEditForm &&
+                          <KeyValue
+                            label={<FormattedMessage id="ui-requests.requestMeta.status" />}
+                            value={requestMeta.status}
+                          />
                         }
                       </Col>
                       <Col xs={3}>
                         <Field
                           name="requestExpirationDate"
-                          label={formatMessage({ id: 'ui-requests.requestMeta.expirationDate' })}
-                          aria-label={formatMessage({ id: 'ui-requests.requestMeta.expirationDate' })}
+                          label={<FormattedMessage id="ui-requests.requestMeta.expirationDate" />}
+                          aria-label={<FormattedMessage id="ui-requests.requestMeta.expirationDate" />}
                           backendDateStandard="YYYY-MM-DD"
                           component={Datepicker}
                           dateFormat="YYYY-MM-DD"
@@ -509,8 +527,8 @@ class RequestForm extends React.Component {
                         <Col xs={3}>
                           <Field
                             name="holdShelfExpirationDate"
-                            label={formatMessage({ id: 'ui-requests.requestMeta.holdShelfExpirationDate' })}
-                            aria-label={formatMessage({ id: 'ui-requests.requestMeta.holdShelfExpirationDate' })}
+                            label={<FormattedMessage id="ui-requests.requestMeta.holdShelfExpirationDate" />}
+                            aria-label={<FormattedMessage id="ui-requests.requestMeta.holdShelfExpirationDate" />}
                             backendDateStandard="YYYY-MM-DD"
                             component={Datepicker}
                             dateFormat="YYYY-MM-DD"
@@ -519,14 +537,20 @@ class RequestForm extends React.Component {
                       }
                       { isEditForm && requestMeta.status !== 'Open - Awaiting pickup' &&
                         <Col xs={3}>
-                          <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.holdShelfExpirationDate' })} value={holdShelfExpireDate} />
+                          <KeyValue
+                            label={<FormattedMessage id="ui-requests.requestMeta.holdShelfExpirationDate" />}
+                            value={holdShelfExpireDate}
+                          />
                         </Col>
                       }
                     </Row>
                     { isEditForm &&
                       <Row>
                         <Col xs={3}>
-                          <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.queuePosition' })} value={positionLink} />
+                          <KeyValue
+                            label={<FormattedMessage id="ui-requests.requestMeta.queuePosition" />}
+                            value={positionLink}
+                          />
                         </Col>
                       </Row>
                     }
@@ -535,7 +559,11 @@ class RequestForm extends React.Component {
               </Accordion>
               <Accordion
                 id="item-info"
-                label={`${formatMessage({ id: 'ui-requests.item.information' })} ${labelAsterisk}`}
+                label={
+                  <FormattedMessage id="ui-requests.item.information">
+                    {message => message + labelAsterisk}
+                  </FormattedMessage>
+                }
               >
                 <div id="section-item-info">
                   <Row>
@@ -546,7 +574,7 @@ class RequestForm extends React.Component {
                             <Field
                               name="item.barcode"
                               placeholder={formatMessage({ id: 'ui-requests.item.scanOrEnterBarcode' })}
-                              aria-label={formatMessage({ id: 'ui-requests.item.barcode' })}
+                              aria-label={<FormattedMessage id="ui-requests.item.barcode" />}
                               fullWidth
                               component={TextField}
                               withRef
@@ -584,7 +612,11 @@ class RequestForm extends React.Component {
               </Accordion>
               <Accordion
                 id="requester-info"
-                label={`${formatMessage({ id: 'ui-requests.requester.information' })} ${labelAsterisk}`}
+                label={
+                  <FormattedMessage id="ui-requests.requester.information">
+                    {message => message + labelAsterisk}
+                  </FormattedMessage>
+                }
               >
                 <div id="section-requester-info">
                   <Row>
@@ -595,7 +627,7 @@ class RequestForm extends React.Component {
                             <Field
                               name="requester.barcode"
                               placeholder={formatMessage({ id: 'ui-requests.requester.scanOrEnterBarcode' })}
-                              aria-label={formatMessage({ id: 'ui-requests.requester.barcode' })}
+                              aria-label={<FormattedMessage id="ui-requests.requester.barcode" />}
                               fullWidth
                               component={TextField}
                               withRef
@@ -607,7 +639,7 @@ class RequestForm extends React.Component {
                             <Pluggable
                               aria-haspopup="true"
                               type="find-user"
-                              searchLabel={formatMessage({ id: 'ui-requests.requester.findUserPluginLabel' })}
+                              searchLabel={<FormattedMessage id="ui-requests.requester.findUserPluginLabel" />}
                               marginTop0
                               searchButtonStyle="link"
                               {...this.props}

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -2,7 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import fetch from 'isomorphic-fetch';
 import moment from 'moment-timezone';
-import { FormattedTime, injectIntl, intlShape } from 'react-intl';
+import {
+  FormattedTime,
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
 import { makeQueryFunction, SearchAndSort } from '@folio/stripes/smart-components';
 import { exportCsv } from '@folio/stripes/util';
 
@@ -155,7 +160,6 @@ class Requests extends React.Component {
     super(props);
 
     this.okapiUrl = props.stripes.okapi.url;
-    this.formatDate = props.stripes.formatDate;
     this.httpHeaders = Object.assign({}, {
       'X-Okapi-Tenant': props.stripes.okapi.tenant,
       'X-Okapi-Token': props.stripes.store.getState().okapi.token,
@@ -233,7 +237,10 @@ class Requests extends React.Component {
   create = data => this.props.mutator.records.POST(data).then(() => this.props.mutator.query.update({ layer: null }));
 
   render() {
-    const { resources, stripes, intl: { formatMessage } } = this.props;
+    const {
+      resources,
+      stripes,
+    } = this.props;
     const patronGroups = (resources.patronGroups || {}).records || [];
     const addressTypes = (resources.addressTypes || {}).records || [];
     const servicePoints = (resources.servicePoints || {}).records || [];
@@ -252,7 +259,7 @@ class Requests extends React.Component {
 
     const actionMenuItems = [
       {
-        label: formatMessage({ id: 'stripes-components.exportToCsv' }),
+        label: <FormattedMessage id="stripes-components.exportToCsv" />,
         onClick: (() => {
           if (!this.csvExportPending) {
             this.props.mutator.resultCount.replace(this.props.resources.records.other.totalRecords);

--- a/src/UserDetail.js
+++ b/src/UserDetail.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Col, KeyValue, Row } from '@folio/stripes/components';
 import { getFullName, userHighlightBox } from './utils';
 
@@ -14,7 +14,6 @@ class UserDetail extends React.Component {
     requestMeta: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,
     selectedDelivery: PropTypes.bool,
-    intl: intlShape
   };
 
   static defaultProps = {
@@ -27,7 +26,6 @@ class UserDetail extends React.Component {
 
   render() {
     const {
-      intl: { formatMessage },
       user,
       proxy,
       requestMeta,
@@ -50,22 +48,36 @@ class UserDetail extends React.Component {
       proxyId = proxy.id || requestMeta.proxyUserId;
     }
 
-    const proxySection = proxyId ? userHighlightBox(formatMessage({ id: 'ui-requests.requester.proxy' }), proxyName, proxyId, proxyBarcode) : '';
+    const proxySection = proxyId
+      ? userHighlightBox(<FormattedMessage id="ui-requests.requester.proxy" />, proxyName, proxyId, proxyBarcode)
+      : '';
 
     return (
       <div>
-        {userHighlightBox(formatMessage({ id: 'ui-requests.requester.requester' }), name, id, barcode)}
+        {userHighlightBox(<FormattedMessage id="ui-requests.requester.requester" />, name, id, barcode)}
         <Row>
           <Col xs={4}>
-            <KeyValue label={formatMessage({ id: 'ui-requests.requester.patronGroup' })} value={patronGroup || '-'} />
+            <KeyValue
+              label={<FormattedMessage id="ui-requests.requester.patronGroup" />}
+              value={patronGroup || '-'}
+            />
           </Col>
           <Col xs={4}>
-            <KeyValue label={formatMessage({ id: 'ui-requests.requester.fulfilmentPref' })} value={_.get(requestMeta, ['fulfilmentPreference'], '-')} />
+            <KeyValue
+              label={<FormattedMessage id="ui-requests.requester.fulfilmentPref" />}
+              value={_.get(requestMeta, ['fulfilmentPreference'], '-')}
+            />
           </Col>
           <Col xs={4}>
-            { selectedDelivery
-              ? <KeyValue label={formatMessage({ id: 'ui-requests.requester.deliveryAddress' })} value={deliveryAddress || '-'} />
-              : <KeyValue label={formatMessage({ id: 'ui-requests.requester.pickupServicePoint' })} value={pickupServicePoint || '-'} />
+            { selectedDelivery ?
+              <KeyValue
+                label={<FormattedMessage id="ui-requests.requester.deliveryAddress" />}
+                value={deliveryAddress || '-'}
+              /> :
+              <KeyValue
+                label={<FormattedMessage id="ui-requests.requester.pickupServicePoint" />}
+                value={pickupServicePoint || '-'}
+              />
             }
           </Col>
         </Row>
@@ -75,4 +87,4 @@ class UserDetail extends React.Component {
   }
 }
 
-export default injectIntl(UserDetail);
+export default UserDetail;

--- a/src/UserDetail.js
+++ b/src/UserDetail.js
@@ -50,7 +50,7 @@ class UserDetail extends React.Component {
 
     const proxySection = proxyId
       ? userHighlightBox(<FormattedMessage id="ui-requests.requester.proxy" />, proxyName, proxyId, proxyBarcode)
-      : '';
+      : null;
 
     return (
       <div>

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -2,8 +2,6 @@ import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  injectIntl,
-  intlShape,
   FormattedMessage,
 } from 'react-intl';
 import { Field } from 'redux-form';
@@ -26,8 +24,7 @@ class UserForm extends React.Component {
     stripes: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,
     selectedDelivery: PropTypes.bool,
-    servicePoints: PropTypes.arrayOf(PropTypes.object),
-    intl: intlShape
+    servicePoints: PropTypes.arrayOf(PropTypes.object)
   };
 
   static defaultProps = {
@@ -46,9 +43,64 @@ class UserForm extends React.Component {
     this.connectedProxyManager = props.stripes.connect(ProxyManager);
   }
 
+  renderDeliveryAddressSelect() {
+    const {
+      onChangeAddress,
+      deliveryLocations,
+    } = this.props;
+
+    return (
+      <Field
+        name="deliveryAddressTypeId"
+        label={<FormattedMessage id="ui-requests.requester.deliveryAddress" />}
+        component={Select}
+        fullWidth
+        onChange={onChangeAddress}
+      >
+        <FormattedMessage id="ui-requests.actions.selectAddressType">
+          {(optionLabel) => <option value="">{optionLabel}</option>}
+        </FormattedMessage>
+        {deliveryLocations.map(location => {
+          const {
+            value,
+            label,
+          } = location;
+
+          return <option value={value}>{label}</option>;
+        })}
+      </Field>
+    );
+  }
+
+  renderPickupServicePointSelect() {
+    const {
+      servicePoints,
+    } = this.props;
+
+    return (
+      <Field
+        name="pickupServicePointId"
+        label={<FormattedMessage id="ui-requests.requester.pickupServicePoint" />}
+        component={Select}
+        fullWidth
+      >
+        <FormattedMessage id="ui-requests.actions.selectPickupSp">
+          {optionLabel => <option value="">{optionLabel}</option>}
+        </FormattedMessage>
+        {servicePoints.map(servicePoint => {
+          const {
+            id,
+            name,
+          } = servicePoint;
+
+          return <option value={id}>{name}</option>;
+        })}
+      </Field>
+    );
+  }
+
   render() {
     const {
-      intl: { formatMessage },
       user,
       proxy,
       requestMeta,
@@ -57,9 +109,7 @@ class UserForm extends React.Component {
       deliveryLocations,
       selectedDelivery,
       fulfilmentTypeOptions,
-      onChangeAddress,
       onChangeFulfilment,
-      servicePoints,
     } = this.props;
 
     const id = user.id;
@@ -78,11 +128,6 @@ class UserForm extends React.Component {
     const proxySection = proxyId
       ? userHighlightBox(<FormattedMessage id="ui-requests.requester.proxy" />, proxyName, proxyId, proxyBarcode)
       : '';
-    const servicePointOptions = [{ label: formatMessage({ id: 'ui-requests.actions.selectPickupSp' }), value: '' }];
-
-    if (servicePoints) {
-      servicePointOptions.push(...servicePoints.map(sp => ({ value: sp.id, label: sp.name })));
-    }
 
     return (
       <div>
@@ -102,24 +147,9 @@ class UserForm extends React.Component {
             />
           </Col>
           <Col xs={4}>
-            { selectedDelivery && deliveryLocations &&
-              <Field
-                name="deliveryAddressTypeId"
-                label={<FormattedMessage id="ui-requests.requester.deliveryAddress" />}
-                component={Select}
-                fullWidth
-                dataOptions={[{ label: formatMessage({ id: 'ui-requests.actions.selectAddressType' }), value: '' }, ...deliveryLocations]}
-                onChange={onChangeAddress}
-              />
-            }
-            { !selectedDelivery &&
-              <Field
-                name="pickupServicePointId"
-                label={<FormattedMessage id="ui-requests.requester.pickupServicePoint" />}
-                component={Select}
-                fullWidth
-                dataOptions={servicePointOptions}
-              />
+            {
+              (!selectedDelivery && this.renderPickupServicePointSelect()) ||
+              (deliveryLocations && this.renderDeliveryAddressSelect())
             }
           </Col>
         </Row>
@@ -147,4 +177,4 @@ class UserForm extends React.Component {
   }
 }
 
-export default injectIntl(UserForm);
+export default UserForm;

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -1,7 +1,11 @@
 import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import {
+  injectIntl,
+  intlShape,
+  FormattedMessage,
+} from 'react-intl';
 import { Field } from 'redux-form';
 import { Col, KeyValue, Row, Select } from '@folio/stripes/components';
 import { ProxyManager } from '@folio/stripes/smart-components';
@@ -71,7 +75,9 @@ class UserForm extends React.Component {
       proxyId = proxy.id || requestMeta.proxyUserId;
     }
 
-    const proxySection = proxyId ? userHighlightBox(formatMessage({ id: 'ui-requests.requester.proxy' }), proxyName, proxyId, proxyBarcode) : '';
+    const proxySection = proxyId
+      ? userHighlightBox(<FormattedMessage id="ui-requests.requester.proxy" />, proxyName, proxyId, proxyBarcode)
+      : '';
     const servicePointOptions = [{ label: formatMessage({ id: 'ui-requests.actions.selectPickupSp' }), value: '' }];
 
     if (servicePoints) {
@@ -80,15 +86,15 @@ class UserForm extends React.Component {
 
     return (
       <div>
-        {userHighlightBox(formatMessage({ id: 'ui-requests.requester.requester' }), name, id, barcode)}
+        {userHighlightBox(<FormattedMessage id="ui-requests.requester.requester" />, name, id, barcode)}
         <Row>
           <Col xs={4}>
-            <KeyValue label={formatMessage({ id: 'ui-requests.requester.patronGroup' })} value={patronGroup || '-'} />
+            <KeyValue label={<FormattedMessage id="ui-requests.requester.patronGroup" />} value={patronGroup || '-'} />
           </Col>
           <Col xs={4}>
             <Field
               name="fulfilmentPreference"
-              label={formatMessage({ id: 'ui-requests.requester.fulfilmentPref' })}
+              label={<FormattedMessage id="ui-requests.requester.fulfilmentPref" />}
               component={Select}
               fullWidth
               dataOptions={fulfilmentTypeOptions}
@@ -99,7 +105,7 @@ class UserForm extends React.Component {
             { selectedDelivery && deliveryLocations &&
               <Field
                 name="deliveryAddressTypeId"
-                label={formatMessage({ id: 'ui-requests.requester.deliveryAddress' })}
+                label={<FormattedMessage id="ui-requests.requester.deliveryAddress" />}
                 component={Select}
                 fullWidth
                 dataOptions={[{ label: formatMessage({ id: 'ui-requests.actions.selectAddressType' }), value: '' }, ...deliveryLocations]}
@@ -109,7 +115,7 @@ class UserForm extends React.Component {
             { !selectedDelivery &&
               <Field
                 name="pickupServicePointId"
-                label={formatMessage({ id: 'ui-requests.requester.pickupServicePoint' })}
+                label={<FormattedMessage id="ui-requests.requester.pickupServicePoint" />}
                 component={Select}
                 fullWidth
                 dataOptions={servicePointOptions}

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -60,14 +60,7 @@ class UserForm extends React.Component {
         <FormattedMessage id="ui-requests.actions.selectAddressType">
           {(optionLabel) => <option value="">{optionLabel}</option>}
         </FormattedMessage>
-        {deliveryLocations.map(location => {
-          const {
-            value,
-            label,
-          } = location;
-
-          return <option value={value}>{label}</option>;
-        })}
+        {deliveryLocations.map(({ value, label }) => <option value={value}>{label}</option>)}
       </Field>
     );
   }
@@ -87,14 +80,7 @@ class UserForm extends React.Component {
         <FormattedMessage id="ui-requests.actions.selectPickupSp">
           {optionLabel => <option value="">{optionLabel}</option>}
         </FormattedMessage>
-        {servicePoints.map(servicePoint => {
-          const {
-            id,
-            name,
-          } = servicePoint;
-
-          return <option value={id}>{name}</option>;
-        })}
+        {servicePoints.map(({ id, name }) => <option value={id}>{name}</option>)}
       </Field>
     );
   }
@@ -127,7 +113,7 @@ class UserForm extends React.Component {
 
     const proxySection = proxyId
       ? userHighlightBox(<FormattedMessage id="ui-requests.requester.proxy" />, proxyName, proxyId, proxyBarcode)
-      : '';
+      : null;
 
     return (
       <div>

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -2,7 +2,12 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
-import { injectIntl, intlShape } from 'react-intl';
+import {
+  injectIntl,
+  intlShape,
+  FormattedMessage,
+  FormattedDate
+} from 'react-intl';
 
 import { TitleManager } from '@folio/stripes/core';
 import { Link } from 'react-router-dom';
@@ -255,7 +260,7 @@ class ViewRequest extends React.Component {
           &nbsp;
         </span>
         <Link to={`/requests?filters=requestStatus.open%20-%20not%20yet%20filled%2CrequestStatus.open%20-%20awaiting%20pickup&query=${request.item.barcode}&sort=Request%20Date`}>
-          {formatMessage({ id: 'ui-requests.actions.viewRequestsInQueue' })}
+          <FormattedMessage id="ui-requests.actions.viewRequestsInQueue" />
         </Link>
       </div> : '-';
 
@@ -286,14 +291,15 @@ class ViewRequest extends React.Component {
       }
     }
 
-    const holdShelfExpireDate = (_.get(request, ['requestMeta', 'status'], '') === 'Open - Awaiting pickup') ?
-      stripes.formatDate(_.get(request, ['requestMeta', 'holdShelfExpirationDate'], '')) : '-';
+    const holdShelfExpireDate = (_.get(request, ['requestMeta', 'status'], '') === 'Open - Awaiting pickup')
+      ? <FormattedDate value={_.get(request, ['requestMeta', 'holdShelfExpirationDate'], '')} />
+      : '-';
 
     if (!request) {
       return (
         <Pane
           defaultWidth={this.props.paneWidth}
-          paneTitle={formatMessage({ id: 'ui-requests.requestMeta.detailLabel' })}
+          paneTitle={<FormattedMessage id="ui-requests.requestMeta.detailLabel" />}
           lastMenu={detailMenu}
           dismissible
           onClose={this.props.onClose}
@@ -308,7 +314,7 @@ class ViewRequest extends React.Component {
     return (
       <Pane
         defaultWidth={this.props.paneWidth}
-        paneTitle={formatMessage({ id: 'ui-requests.requestMeta.detailLabel' })}
+        paneTitle={<FormattedMessage id="ui-requests.requestMeta.detailLabel" />}
         lastMenu={detailMenu}
         actionMenuItems={!isRequestClosed ? [{
           id: 'clickable-edit-request',
@@ -320,7 +326,7 @@ class ViewRequest extends React.Component {
         }, {
           id: 'clickable-cancel-request',
           title: formatMessage({ id: 'ui-requests.cancel.cancelRequest' }),
-          label: formatMessage({ id: 'ui-requests.cancel.cancelRequest' }),
+          label: <FormattedMessage id="ui-requests.cancel.cancelRequest" />,
           onClick: () => this.setState({ isCancellingRequest: true }),
           icon: 'cancel',
         }] : undefined}
@@ -331,7 +337,7 @@ class ViewRequest extends React.Component {
         <AccordionSet accordionStatus={this.state.accordions} onToggle={this.onToggleSection}>
           <Accordion
             id="request-info"
-            label={formatMessage({ id: 'ui-requests.requestMeta.information' })}
+            label={<FormattedMessage id="ui-requests.requestMeta.information" />}
           >
             <Row>
               <Col xs={12}>
@@ -340,27 +346,51 @@ class ViewRequest extends React.Component {
             </Row>
             <Row>
               <Col xs={3}>
-                <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.type' })} value={_.get(request, ['requestMeta', 'requestType'], '-')} />
+                <KeyValue
+                  label={<FormattedMessage id="ui-requests.requestMeta.type" />}
+                  value={_.get(request, ['requestMeta', 'requestType'], '-')}
+                />
               </Col>
               <Col xs={3}>
-                <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.status' })} value={_.get(request, ['requestMeta', 'status'], '-')} />
+                <KeyValue
+                  label={<FormattedMessage id="ui-requests.requestMeta.status" />}
+                  value={_.get(request, ['requestMeta', 'status'], '-')}
+                />
               </Col>
               <Col xs={3}>
-                <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.expirationDate' })} value={stripes.formatDate(_.get(request, ['requestMeta', 'requestExpirationDate'])) || '-'} />
+                <KeyValue
+                  label={<FormattedMessage id="ui-requests.requestMeta.expirationDate" />}
+                  value={
+                    <FormattedDate value={_.get(request, ['requestMeta', 'requestExpirationDate'])}>
+                      {message => message || '-'}
+                    </FormattedDate>
+                  }
+                />
               </Col>
               <Col xs={3}>
-                <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.holdShelfExpirationDate' })} value={holdShelfExpireDate} />
+                <KeyValue
+                  label={<FormattedMessage id="ui-requests.requestMeta.holdShelfExpirationDate" />}
+                  value={holdShelfExpireDate}
+                />
               </Col>
             </Row>
             <Row>
               <Col xs={5}>
-                <KeyValue label={formatMessage({ id: 'ui-requests.requestMeta.queuePosition' })} value={positionLink} />
+                <KeyValue
+                  label={<FormattedMessage id="ui-requests.requestMeta.queuePosition" />}
+                  value={positionLink}
+                />
               </Col>
             </Row>
           </Accordion>
           <Accordion
             id="item-info"
-            label={formatMessage({ id: 'ui-requests.item.information' })}
+            label={
+              <FormattedMessage
+                id="ui-requests.item.information"
+                values={{ required: '' }}
+              />
+            }
           >
             <ItemDetail
               item={request.item}
@@ -372,7 +402,11 @@ class ViewRequest extends React.Component {
           </Accordion>
           <Accordion
             id="requester-info"
-            label={formatMessage({ id: 'ui-requests.requester.information' })}
+            label={
+              <FormattedMessage id="ui-requests.requester.information">
+                {message => message}
+              </FormattedMessage>
+            }
           >
             <UserDetail
               user={request.requester}
@@ -387,7 +421,10 @@ class ViewRequest extends React.Component {
           </Accordion>
         </AccordionSet>
 
-        <Layer isOpen={query.layer ? query.layer === 'edit' : false} label={formatMessage({ id: 'ui-requests.actions.editRequestLink' })}>
+        <Layer
+          isOpen={query.layer ? query.layer === 'edit' : false}
+          label={<FormattedMessage id="ui-requests.actions.editRequestLink" />}
+        >
           <RequestForm
             stripes={stripes}
             initialValues={request.requestMeta}

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -6,7 +6,7 @@ import {
   injectIntl,
   intlShape,
   FormattedMessage,
-  FormattedDate
+  FormattedDate,
 } from 'react-intl';
 
 import { TitleManager } from '@folio/stripes/core';
@@ -229,7 +229,15 @@ class ViewRequest extends React.Component {
   }
 
   render() {
-    const { patronGroups, optionLists, location, stripes, intl: { formatMessage } } = this.props;
+    const {
+      patronGroups,
+      optionLists,
+      location,
+      stripes,
+      intl: { formatMessage },
+      editLink,
+      onEdit,
+    } = this.props;
     const query = location.search ? queryString.parse(location.search) : {};
 
     // Most of the values needed to populate the view come from the "enhanced" request
@@ -267,14 +275,18 @@ class ViewRequest extends React.Component {
     const detailMenu = (
       <PaneMenu>
         {!isRequestClosed &&
-          <IconButton
-            icon="edit"
-            id="clickable-edit-request"
-            style={{ visibility: !request ? 'hidden' : 'visible' }}
-            href={this.props.editLink}
-            onClick={this.props.onEdit}
-            title={formatMessage({ id: 'ui-requests.actions.editRequest' })}
-          />
+        <FormattedMessage id="ui-requests.actions.editRequest">
+          {title => (
+            <IconButton
+              icon="edit"
+              id="clickable-edit-request"
+              style={{ visibility: !request ? 'hidden' : 'visible' }}
+              href={editLink}
+              onClick={onEdit}
+              title={title}
+            />
+          )}
+        </FormattedMessage>
         }
       </PaneMenu>
     );


### PR DESCRIPTION
According to [UIREQ-135](https://issues.folio.org/browse/UIREQ-135), all strings should be internationalized using the react-intl pattern constructs outlined [here](https://github.com/folio-org/stripes/blob/master/doc/i18n.md)