### PR TITLE
UIREQ-170: Remove deprecated actionMenuItems-prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Support circulation v5.0, requiring service-point information on loans. Refs UIREQ-161.
 * Use documented react-intl patterns instead of stripes.intl. UIREQ-135
 * Improve opening request record. Fixes UIREQ-134.
+* Removed deprecated actionMenuItems-prop. Fixes UIREQ-170.
 
 ## 1.4.1 (https://github.com/folio-org/ui-requests/tree/v1.4.1) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.4.0...v1.4.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -443,23 +443,24 @@ class RequestForm extends React.Component {
       </div> : '-';
 
     const actionMenu = ({ onToggle }) => {
-      if (isEditForm) {
-        return (
-          <Button
-            buttonStyle="dropdownItem"
-            id="clickable-cancel-request"
-            onClick={() => {
-              this.setState({ isCancellingRequest: true });
-              onToggle();
-            }}
-          >
-            <Icon icon="hollowX">
-              <FormattedMessage id="ui-requests.cancel.cancelRequest" />
-            </Icon>
-          </Button>
-        );
+      if (!isEditForm) {
+        return undefined;
       }
-      return undefined;
+
+      return (
+        <Button
+          buttonStyle="dropdownItem"
+          id="clickable-cancel-request"
+          onClick={() => {
+            this.setState({ isCancellingRequest: true });
+            onToggle();
+          }}
+        >
+          <Icon icon="hollowX">
+            <FormattedMessage id="ui-requests.cancel.cancelRequest" />
+          </Icon>
+        </Button>
+      );
     };
 
     return (

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -16,6 +16,7 @@ import {
   Button,
   Col,
   Datepicker,
+  Icon,
   KeyValue,
   Pane,
   PaneMenu,
@@ -441,6 +442,26 @@ class RequestForm extends React.Component {
         </Link>
       </div> : '-';
 
+    const actionMenu = ({ onToggle }) => {
+      if (isEditForm) {
+        return (
+          <Button
+            buttonStyle="dropdownItem"
+            id="clickable-cancel-request"
+            onClick={() => {
+              this.setState({ isCancellingRequest: true });
+              onToggle();
+            }}
+          >
+            <Icon icon="hollowX">
+              <FormattedMessage id="ui-requests.cancel.cancelRequest" />,
+            </Icon>
+          </Button>
+        );
+      }
+      return undefined;
+    };
+
     return (
       <form id="form-requests" style={{ height: '100%', overflow: 'auto' }}>
         <Paneset isRoot>
@@ -449,12 +470,7 @@ class RequestForm extends React.Component {
             height="100%"
             firstMenu={addRequestFirstMenu}
             lastMenu={isEditForm ? editRequestLastMenu : addRequestLastMenu}
-            actionMenuItems={isEditForm ? [{
-              id: 'clickable-cancel-request',
-              label: <FormattedMessage id="ui-requests.cancel.cancelRequest" />,
-              onClick: () => this.setState({ isCancellingRequest: true }),
-              icon: 'cancel',
-            }] : undefined}
+            actionMenu={actionMenu}
             paneTitle={
               isEditForm
                 ? <FormattedMessage id="ui-requests.actions.editRequest" />

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -454,7 +454,7 @@ class RequestForm extends React.Component {
             }}
           >
             <Icon icon="hollowX">
-              <FormattedMessage id="ui-requests.cancel.cancelRequest" />,
+              <FormattedMessage id="ui-requests.cancel.cancelRequest" />
             </Icon>
           </Button>
         );

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -9,6 +9,7 @@ import {
   intlShape,
 } from 'react-intl';
 import { makeQueryFunction, SearchAndSort } from '@folio/stripes/smart-components';
+import { Button } from '@folio/stripes/components';
 import { exportCsv } from '@folio/stripes/util';
 
 import ViewRequest from './ViewRequest';
@@ -292,21 +293,24 @@ class Requests extends React.Component {
       [title]: rq => (rq.item ? rq.item.title : ''),
     };
 
-    const actionMenuItems = [
-      {
-        label: <FormattedMessage id="stripes-components.exportToCsv" />,
-        onClick: (() => {
+    const actionMenu = ({ onToggle }) => (
+      <Button
+        buttonStyle="dropdownItem"
+        id="exportToCsvPaneHeaderBtn"
+        onClick={() => {
           if (!this.csvExportPending) {
             this.props.mutator.resultCount.replace(this.props.resources.records.other.totalRecords);
             this.csvExportPending = true;
           }
-        }),
-        id: 'exportToCsvPaneHeaderBtn',
-      },
-    ];
+          onToggle();
+        }}
+      >
+        <FormattedMessage id="stripes-components.exportToCsv" />
+      </Button>
+    );
 
     return (<SearchAndSort
-      actionMenuItems={actionMenuItems}
+      actionMenu={actionMenu}
       packageInfo={packageInfo}
       objectName="request"
       filterConfig={filterConfig}

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -5,7 +5,7 @@ import {
   includes,
   keyBy
 } from 'lodash';
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import {
@@ -16,6 +16,7 @@ import {
 import { TitleManager } from '@folio/stripes/core';
 import { Link } from 'react-router-dom';
 import {
+  Button,
   Accordion,
   AccordionSet,
   Col,
@@ -276,23 +277,48 @@ class ViewRequest extends React.Component {
       );
     }
 
+    const actionMenu = ({ onToggle }) => {
+      if (isRequestClosed) {
+        return undefined;
+      }
+
+      return (
+        <Fragment>
+          <Button
+            buttonStyle="dropdownItem"
+            id="clickable-edit-request"
+            href={this.props.editLink}
+            onClick={() => {
+              this.props.onEdit();
+              onToggle();
+            }}
+          >
+            <Icon icon="edit">
+              <FormattedMessage id="ui-requests.actions.edit" />
+            </Icon>
+          </Button>
+          <Button
+            buttonStyle="dropdownItem"
+            id="clickable-cancel-request"
+            onClick={() => {
+              this.setState({ isCancellingRequest: true });
+              onToggle();
+            }}
+          >
+            <Icon icon="hollowX">
+              <FormattedMessage id="ui-requests.cancel.cancelRequest" />
+            </Icon>
+          </Button>
+        </Fragment>
+      );
+    };
+
     return (
       <Pane
         defaultWidth={this.props.paneWidth}
         paneTitle={<FormattedMessage id="ui-requests.requestMeta.detailLabel" />}
         lastMenu={detailMenu}
-        actionMenuItems={!isRequestClosed ? [{
-          id: 'clickable-edit-request',
-          label: <FormattedMessage id="ui-requests.actions.edit" />,
-          href: this.props.editLink,
-          onClick: this.props.onEdit,
-          icon: 'edit',
-        }, {
-          id: 'clickable-cancel-request',
-          label: <FormattedMessage id="ui-requests.cancel.cancelRequest" />,
-          onClick: () => this.setState({ isCancellingRequest: true }),
-          icon: 'cancel',
-        }] : undefined}
+        actionMenu={actionMenu}
         dismissible
         onClose={this.props.onClose}
       >


### PR DESCRIPTION
Removed the deprecated `actionMenuItems`-prop. Replaced with the `actionMenu`-prop along with custom composed action menu's.

**Issue:** https://issues.folio.org/browse/UIREQ-170

**Note:** This PR needs to be merged into stripes-smart-components before merging this one.
https://github.com/folio-org/stripes-smart-components/pull/350