### PR TITLE
Fixed double '@folio/stripes/components' reference

### DIFF
--- a/src/Requests.js
+++ b/src/Requests.js
@@ -8,9 +8,8 @@ import {
   injectIntl,
   intlShape,
 } from 'react-intl';
-import { AppIcon } from '@folio/stripes/components';
+import { AppIcon, Button } from '@folio/stripes/components';
 import { makeQueryFunction, SearchAndSort } from '@folio/stripes/smart-components';
-import { Button } from '@folio/stripes/components';
 import { exportCsv } from '@folio/stripes/util';
 
 import ViewRequest from './ViewRequest';


### PR DESCRIPTION
@folio/stripes/components were referenced two times in Requests.js. This commit fixes that.