### PR TITLE
read query string for user and item barcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Use documented react-intl patterns instead of stripes.intl. UIREQ-135
 * Improve opening request record. Fixes UIREQ-134.
 * Removed deprecated actionMenuItems-prop. Fixes UIREQ-170.
+* Read user and item barcodes from the query string for new requests. Fixes UIREQ-146.
 
 ## 1.4.1 (https://github.com/folio-org/ui-requests/tree/v1.4.1) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.4.0...v1.4.1)

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -133,6 +133,7 @@ class Requests extends React.Component {
         hasLoaded: PropTypes.bool.isRequired,
         records: PropTypes.arrayOf(PropTypes.object),
       }),
+      query: PropTypes.object,
       records: PropTypes.shape({
         hasLoaded: PropTypes.bool.isRequired,
         other: PropTypes.shape({
@@ -380,6 +381,7 @@ class Requests extends React.Component {
           servicePoints
         },
         patronGroups,
+        query: this.props.resources.query,
         uniquenessValidator: this.props.mutator,
       }}
       viewRecordPerms="module.requests.enabled"


### PR DESCRIPTION
Pass the query resource down to `<RequestForm>` so it can access the
query string to lookup the user and item records based on the presence
of `userBarcode` and `itemBarcode`.

Additionally, avoid `setTimeout`. This was in there previously because
redux-form's `props.change` method is async and we needed to let that
propagate first. Thing is, we _have_ the user barcode already, so we
don't actually need to wait for that propagation; we can just pass the
value directly. And now we do.

Fixes [UIREQ-146](https://issues.folio.org/browse/UIREQ-146)