### PR TITLE
STCOM-374: Implement pane header dropdown on create request page

### DIFF
--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -40,6 +40,8 @@ import UserForm from './UserForm';
 import ItemDetail from './ItemDetail';
 import { toUserAddress } from './constants';
 
+import css from './requests.css';
+
 /**
  * on-blur validation checks that the requested item is checked out
  * and that the requesting user exists.
@@ -491,7 +493,7 @@ class RequestForm extends React.Component {
         </Link>
       </div> : '-';
 
-    const actionMenu = ({ onToggle }) => {
+    const renderActionMenu = ({ onToggle }) => {
       if (!isEditForm) {
         return (
           <Button
@@ -529,11 +531,8 @@ class RequestForm extends React.Component {
     return (
       <form
         id="form-requests"
+        className={css.requestForm}
         data-test-form-page
-        style={{
-          height: '100%',
-          overflow: 'auto'
-        }}
       >
         <Paneset isRoot>
           <Pane
@@ -541,7 +540,7 @@ class RequestForm extends React.Component {
             height="100%"
             firstMenu={addRequestFirstMenu}
             lastMenu={isEditForm ? editRequestLastMenu : addRequestLastMenu}
-            actionMenu={actionMenu}
+            actionMenu={renderActionMenu}
             paneTitle={
               isEditForm
                 ? <FormattedMessage id="ui-requests.actions.editRequest" />

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -493,7 +493,20 @@ class RequestForm extends React.Component {
 
     const actionMenu = ({ onToggle }) => {
       if (!isEditForm) {
-        return undefined;
+        return (
+          <Button
+            buttonStyle="dropdownItem"
+            id="clickable-cancel-new-request"
+            onClick={() => {
+              onCancel();
+              onToggle();
+            }}
+          >
+            <Icon icon="times-circle">
+              <FormattedMessage id="ui-requests.actions.cancelNewRequest" />
+            </Icon>
+          </Button>
+        );
       }
 
       return (

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -495,6 +495,7 @@ class RequestForm extends React.Component {
       if (!isEditForm) {
         return (
           <Button
+            data-test-cancel-new-request-action
             buttonStyle="dropdownItem"
             id="clickable-cancel-new-request"
             onClick={() => {
@@ -526,7 +527,14 @@ class RequestForm extends React.Component {
     };
 
     return (
-      <form id="form-requests" style={{ height: '100%', overflow: 'auto' }}>
+      <form
+        id="form-requests"
+        data-test-form-page
+        style={{
+          height: '100%',
+          overflow: 'auto'
+        }}
+      >
         <Paneset isRoot>
           <Pane
             defaultWidth="100%"

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -532,7 +532,7 @@ class RequestForm extends React.Component {
       <form
         id="form-requests"
         className={css.requestForm}
-        data-test-form-page
+        data-test-requests-form
       >
         <Paneset isRoot>
           <Pane

--- a/src/requests.css
+++ b/src/requests.css
@@ -8,3 +8,8 @@
     border-radius: 6px;
   }
 }
+
+.requestForm {
+  height: 100%;
+  overflow: auto;
+}

--- a/test/bigtest/interactors/new-request.js
+++ b/test/bigtest/interactors/new-request.js
@@ -25,4 +25,4 @@ import {
   headerDropdownMenu = new HeaderDropdownMenu();
 }
 
-export default new NewRequestsInteractor('[data-test-form-page]');
+export default new NewRequestsInteractor('[data-test-requests-form]');

--- a/test/bigtest/interactors/new-request.js
+++ b/test/bigtest/interactors/new-request.js
@@ -1,0 +1,28 @@
+import {
+  interactor,
+  clickable,
+  isPresent,
+  text,
+} from '@bigtest/interactor';
+
+@interactor class HeaderDropdown {
+  click = clickable('button');
+}
+
+@interactor class HeaderDropdownMenu {
+  clickCancel = clickable('[data-test-cancel-new-request-action]');
+}
+
+@interactor class NewRequestsInteractor {
+  isLoaded = isPresent('[class*=paneTitleLabel---]');
+
+  whenLoaded() {
+    return this.when(() => this.isLoaded);
+  }
+
+  title = text('[class*=paneTitleLabel---]');
+  headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
+  headerDropdownMenu = new HeaderDropdownMenu();
+}
+
+export default new NewRequestsInteractor('[data-test-form-page]');

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -1,0 +1,43 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import NewRequestInteractor from '../interactors/new-request';
+import RequestsInteractor from '../interactors/requests';
+
+describe('New Request page', () => {
+  setupApplication();
+
+  const requests = new RequestsInteractor();
+
+  beforeEach(function () {
+    this.visit('/requests?layer=create');
+  });
+
+  describe('visiting the create request page', () => {
+    it('displays the title in the pane header', () => {
+      expect(NewRequestInteractor.title).to.equal('New request');
+    });
+
+    describe('pane header menu', () => {
+      beforeEach(async () => {
+        await NewRequestInteractor.headerDropdown.click();
+      });
+
+      describe('clicking on cancel', () => {
+        beforeEach(async () => {
+          await NewRequestInteractor.headerDropdownMenu.clickCancel();
+        });
+
+        it('should redirect to view requests page after click', () => {
+          expect(requests.$root).to.exist;
+        });
+      });
+    });
+  });
+});

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -48,6 +48,7 @@
   "actions.edit": "Edit",
   "actions.editRequestLink": "Edit Request Dialog",
   "actions.closeNewRequest": "Close New Request",
+  "actions.cancelNewRequest": "Cancel",
   "actions.createNewRequest": "Create New Request",
   "actions.newRequest": "New request",
   "actions.updateRequest": "Update request",


### PR DESCRIPTION
## Purpose
According to [STCOM-374](https://issues.folio.org/browse/STCOM-374), it should be possible to cancel creating a new request using pane header dropdown.

## Approach
* add nesessary action to  `actionMenu` attribute of `Pane` component
* add related tests

## Screenshots
![2018-12-28 13 16 13](https://user-images.githubusercontent.com/43514877/50513840-e84f4680-0aa2-11e9-81d8-67d07059a222.gif)
