### PR TITLE
update BigTest interactor for MCL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 1.8.0 [IN PROGRESS]
+
+* Update BigTest interactors to reflect MCL aria changes. Refs STRIPES-597.
+
 ## [1.7.0](https://github.com/folio-org/ui-requests/tree/v1.7.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.6.0...v1.7.0)
 

--- a/test/bigtest/interactors/requests.js
+++ b/test/bigtest/interactors/requests.js
@@ -7,6 +7,6 @@ import {
 export default @interactor class RequestsInteractor {
   static defaultScope = '[data-test-request-instances]';
 
-  instances = collection('[role=listitem] a');
+  instances = collection('[role=row] a');
   instance = scoped('[data-test-instance-details]');
 }


### PR DESCRIPTION
MCL recently changed how it uses some ARIA properties and the downstream
tests need to reflect this.

Refs [STRIPES-597](https://issues.folio.org/browse/STRIPES-597), [STCOM-365](https://issues.folio.org/browse/STCOM-365)