### PR TITLE
integration tests must accommodate MCL aria changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update BigTest interactors to reflect MCL aria changes. Refs STRIPES-597.
 * Move AppIcon import to `@folio/stripes/core`. Refs STCOM-411.
+* Update integration tests to accommodate MCL aria changes. Fixes UIREQ-205.
 
 ## [1.7.0](https://github.com/folio-org/ui-requests/tree/v1.7.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.6.0...v1.7.0)

--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -24,7 +24,7 @@ module.exports.test = function uiTest(uiTestCtx) {
 
       it('should find "choose a filter" message', (done) => {
         nightmare
-          .wait('div[class^="emptyMessage"]')
+          .wait('div[class^="mclEmptyMessage"]')
           .then(done)
           .catch(done);
       });
@@ -40,7 +40,7 @@ module.exports.test = function uiTest(uiTestCtx) {
             .click(`#clickable-filter-requestType-${filter}`)
             .wait('#list-requests:not([data-total-count^="0"])')
             .click('#clickable-reset-all')
-            .wait('div[class^="emptyMessage"]')
+            .wait('div[class^="mclEmptyMessage"]')
             .then(done)
             .catch(done);
         });

--- a/test/ui-testing/new_request.js
+++ b/test/ui-testing/new_request.js
@@ -26,7 +26,7 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       it('should find an active user barcode', (done) => {
-        const listitem = '#list-users div[role="listitem"] > a:not([aria-label*="Barcode: undef"])';
+        const listitem = '#list-users div[role="row"] > a';
         const bcodeNode = `${listitem} > div:nth-child(3)`;
         nightmare
           .wait(1111)
@@ -57,8 +57,8 @@ module.exports.test = function uiTest(uiTestCtx) {
           .click('#section-patron #clickable-plugin-find-user')
           .wait('#clickable-filter-pg-faculty')
           .click('#clickable-filter-pg-faculty')
-          .wait('#list-users div[role="listitem"]:nth-of-type(3)')
-          .click('#list-users div[role="listitem"]:nth-of-type(3) a')
+          .wait('#list-users div[role="row"][aria-rowindex="2"]')
+          .click('#list-users div[role="row"][aria-rowindex="2"] a')
           .wait(2222)
           .wait('#input-item-barcode')
           .insert('#input-item-barcode', itembc)


### PR DESCRIPTION
Changes to the aria attributes in MCL must be reflected in the
integration tests as well.

Refs [UIREQ-205](https://issues.folio.org/browse/UIREQ-205), [STCOM-365](https://issues.folio.org/browse/STRIPES-365). 

See also folio-org/stripes-components/pull/849