### PR TITLE
make unit tests responsible for setting state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update BigTest interactors to reflect MCL aria changes. Refs STRIPES-597.
 * Move AppIcon import to `@folio/stripes/core`. Refs STCOM-411.
 * Update integration tests to accommodate MCL aria changes. Fixes UIREQ-205.
+* Update unit tests to change application from its default state. Fixes UIREQ-210.
 
 ## [1.7.0](https://github.com/folio-org/ui-requests/tree/v1.7.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.6.0...v1.7.0)

--- a/test/bigtest/interactors/requests.js
+++ b/test/bigtest/interactors/requests.js
@@ -1,7 +1,8 @@
 import {
   interactor,
   scoped,
-  collection
+  collection,
+  clickable
 } from '@bigtest/interactor';
 
 export default @interactor class RequestsInteractor {
@@ -9,4 +10,7 @@ export default @interactor class RequestsInteractor {
 
   instances = collection('[role=row] a');
   instance = scoped('[data-test-instance-details]');
+  clickHoldsCheckbox = clickable('#clickable-filter-requestType-Holds');
+  clickPagesCheckbox = clickable('#clickable-filter-requestType-Pages');
+  clickRecallsCheckbox = clickable('#clickable-filter-requestType-Recalls');
 }

--- a/test/bigtest/tests/requests-show-all-test.js
+++ b/test/bigtest/tests/requests-show-all-test.js
@@ -11,7 +11,11 @@ describe('Requests', () => {
 
   beforeEach(async function () {
     this.server.create('request');
-    this.visit('/requests?filters=requestType.Holds%2CrequestType.Pages%2CrequestType.Recalls&sort=Request%20Date');
+    this.visit('/requests');
+
+    await requests.clickHoldsCheckbox();
+    await requests.clickPagesCheckbox();
+    await requests.clickRecallsCheckbox();
   });
 
   it('shows the list of requests items', () => {


### PR DESCRIPTION
It seems to be the case that the application served up by mirage comes in
some sort of virgin state regardless of what URL we pass to
`this.visit()`. Deployed, a URL like `/requests?filter=foo` would cause
the "foo" checkbox to be ticked. Not so when running tests where passing a
fancy URL like

    /requests?filters=requestType.Holds%2CrequestType.Pages%2CrequestType.Recalls&sort=Request%20Date

appears to return the same page as passing

    /requests

What this means is that we need to use interactors to affect the state
that normally we would expect to inherit through the URL.

Fixes [UIREQ-210](https://issues.folio.org/browse/UIREQ-210)