### PR TITLE
Format holdShelfExpirationDate only when the date is set by the user.

### DIFF
--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -415,10 +415,9 @@ class RequestForm extends React.Component {
       unset(data, 'requestExpirationDate');
     }
 
-    if (holdShelfExpirationDate) {
-      const date = holdShelfExpirationDate.split('T')[0];
+    if (holdShelfExpirationDate && !holdShelfExpirationDate.match('T')) {
       const time = moment.tz(timeZone).format('HH:mm:ss');
-      data.holdShelfExpirationDate = moment.tz(`${date} ${time}`, timeZone).utc().format();
+      data.holdShelfExpirationDate = moment.tz(`${holdShelfExpirationDate} ${time}`, timeZone).utc().format();
     } else {
       unset(data, 'holdShelfExpirationDate');
     }

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -416,8 +416,9 @@ class RequestForm extends React.Component {
     }
 
     if (holdShelfExpirationDate) {
+      const date = holdShelfExpirationDate.split('T')[0];
       const time = moment.tz(timeZone).format('HH:mm:ss');
-      data.holdShelfExpirationDate = moment.tz(`${holdShelfExpirationDate} ${time}`, timeZone).utc().format();
+      data.holdShelfExpirationDate = moment.tz(`${date} ${time}`, timeZone).utc().format();
     } else {
       unset(data, 'holdShelfExpirationDate');
     }


### PR DESCRIPTION
It looks like `holdShelfExpirationDate` is pre populated with a full date and time in some cases. 
This PR skips the `holdShelfExpirationDate` formatting if the full date and time is already present.