### PR TITLE
extract strings for translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix request expiration date not displaying on details view. Part of UIREQ-192.
 * Fix saving empty hold shelf expiration date. Part of UIREQ-206.
 * Update circulation v7.0 and request-storage v3.0 OKAPI interfaces Part of UIREQ-214.
+* Extract static strings for translation. Fixes UIREQ-219.
 
 ## [1.7.0](https://github.com/folio-org/ui-requests/tree/v1.7.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.6.0...v1.7.0)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -759,7 +759,7 @@ class RequestForm extends React.Component {
                               onClick={this.onItemClick}
                               disabled={submitting}
                             >
-                              Enter
+                              <FormattedMessage id="ui-requests.enter" />
                             </Button>
                           </Col>
                         </Row>
@@ -828,7 +828,7 @@ class RequestForm extends React.Component {
                               onClick={this.onUserClick}
                               disabled={submitting}
                             >
-                              Enter
+                              <FormattedMessage id="ui-requests.enter" />
                             </Button>
                           </Col>
                         </Row>

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -15,6 +15,7 @@
   "blockedLabel": "Reason for block:",
   "blockModal": "Patron blocked from requesting",
   "detailsButton": "Block details",
+  "enter": "Enter",
 
   "requests.title": "Title",
   "requests.type": "Type",


### PR DESCRIPTION
The request form contained untranslated, hard-coded strings.

Fixes [UIREQ-219](https://issues.folio.org/browse/UIREQ-219)