### PR TITLE
Fix cancelling request. Part of UIREQ-249

### DIFF
--- a/src/CancelRequestDialog.js
+++ b/src/CancelRequestDialog.js
@@ -131,7 +131,7 @@ class CancelRequestDialog extends React.Component {
       <ModalFooter>
         <Button
           buttonStyle="primary"
-          onClick={onClose}
+          onClick={this.onCancelRequestHandler}
           disabled={reason.requiresAdditionalInformation && !additionalInfo}
         >
           <FormattedMessage id="stripes-core.button.confirm" />


### PR DESCRIPTION
This was totally my fault. While working on UIREQ-232 I tried to cleanup react warnings and refactored ModalFooter but with the wrong `onClick` handler.

https://issues.folio.org/browse/UIREQ-249