### PR TITLE
Add ability to create a request without an item barcode. Part of UIREQ-253.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.9.0 (In Progress)
 
 * Allow requests for On order and In process items. Part of UIREQ-247.
+* Add ability to create a request without an item barcode. Part of UIREQ-253.
 
 ## [1.8.0](https://github.com/folio-org/ui-requests/tree/v1.8.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.7.0...v1.8.0)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -14,7 +14,7 @@ const ItemDetail = ({ item, loan, itemId, requestCount }) => {
   const status = get(item, 'status.name') || get(item, 'status');
   const contributor = get(item, ['contributorNames', '0', 'name'], '-');
   const positionLink = item.barcode ? <Link to={`/requests?filters=requestStatus.Open%20-%20Awaiting%20pickup%2CrequestStatus.Open%20-%20In%20transit%2CrequestStatus.Open%20-%20Not%20yet%20filled&query=${item.barcode}&sort=Request%20Date`}>{requestCount}</Link> : '-';
-  const itemLabel = item.barcode ? 'ui-requests.item.id' : 'ui-requests.item.barcode';
+  const itemLabel = item.barcode ? 'ui-requests.item.barcode' : 'ui-requests.item.id';
 
   return (
     <React.Fragment>

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -6,20 +6,21 @@ import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Col, KeyValue, Row } from '@folio/stripes/components';
 
 const ItemDetail = ({ item, loan, itemId, requestCount }) => {
-  if (!item.barcode) {
+  if (!item.id) {
     return <FormattedMessage id="ui-requests.actions.loading" />;
   }
 
-  const recordLink = item.barcode ? <Link to={`/inventory/view/${item.instanceId}/${item.holdingsRecordId}/${itemId}`}>{item.barcode}</Link> : '';
+  const recordLink = item ? <Link to={`/inventory/view/${item.instanceId}/${item.holdingsRecordId}/${itemId}`}>{item.barcode || item.id}</Link> : '-';
   const status = get(item, 'status.name') || get(item, 'status');
   const contributor = get(item, ['contributorNames', '0', 'name'], '-');
-  const positionLink = item ? <Link to={`/requests?filters=requestStatus.Open%20-%20Awaiting%20pickup%2CrequestStatus.Open%20-%20In%20transit%2CrequestStatus.Open%20-%20Not%20yet%20filled&query=${item.barcode}&sort=Request%20Date`}>{requestCount}</Link> : '-';
+  const positionLink = item.barcode ? <Link to={`/requests?filters=requestStatus.Open%20-%20Awaiting%20pickup%2CrequestStatus.Open%20-%20In%20transit%2CrequestStatus.Open%20-%20Not%20yet%20filled&query=${item.barcode}&sort=Request%20Date`}>{requestCount}</Link> : '-';
+  const itemLabel = item.barcode ? 'ui-requests.item.id' : 'ui-requests.item.barcode';
 
   return (
-    <div>
+    <React.Fragment>
       <Row>
         <Col xs={3}>
-          <KeyValue label={<FormattedMessage id="ui-requests.item.barcode" />}>
+          <KeyValue label={<FormattedMessage id={itemLabel} />}>
             {recordLink}
           </KeyValue>
         </Col>
@@ -73,7 +74,7 @@ const ItemDetail = ({ item, loan, itemId, requestCount }) => {
           </KeyValue>
         </Col>
       </Row>
-    </div>
+    </React.Fragment>
   );
 };
 

--- a/src/PositionLink.js
+++ b/src/PositionLink.js
@@ -6,7 +6,9 @@ import { FormattedMessage } from 'react-intl';
 
 export default function PositionLink({ request }) {
   const queuePosition = get(request, 'position');
-  return (request ?
+  const barcode = get(request, 'item.barcode');
+
+  return (request && barcode ?
     <div>
       <span>
         {queuePosition}

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -382,7 +382,6 @@ class RequestForm extends React.Component {
     });
   }
 
-  requireItem = value => (value ? undefined : <FormattedMessage id="ui-requests.errors.selectItem" />);
   requireUser = value => (value ? undefined : <FormattedMessage id="ui-requests.errors.selectUser" />);
 
   getProxy() {

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -154,7 +154,11 @@ class RequestForm extends React.Component {
     }
 
     if (this.props.query.itemBarcode) {
-      this.findItem(this.props.query.itemBarcode);
+      this.findItem('barcode', this.props.query.itemBarcode);
+    }
+
+    if (this.props.query.itemId) {
+      this.findItem('id', this.props.query.itemId);
     }
   }
 
@@ -193,7 +197,11 @@ class RequestForm extends React.Component {
     }
 
     if (prevQuery.itemBarcode !== query.itemBarcode) {
-      this.findItem(query.itemBarcode);
+      this.findItem('barcode', query.itemBarcode);
+    }
+
+    if (prevQuery.itemId !== query.itemId) {
+      this.findItem('id', query.itemId);
     }
 
     if (!isEqual(blocks, prevBlocks) && blocks.length > 0) {
@@ -297,9 +305,9 @@ class RequestForm extends React.Component {
     });
   }
 
-  findItem(barcode) {
+  findItem(key, value) {
     const { findResource } = this.props;
-    return findResource('item', barcode, 'barcode')
+    return findResource('item', value, key)
       .then((result) => {
         if (!result || result.totalRecords === 0) return null;
 
@@ -307,7 +315,7 @@ class RequestForm extends React.Component {
         const options = this.getRequestTypeOptions(item);
 
         this.props.change('itemId', item.id);
-        this.props.change('item.barcode', barcode);
+        this.props.change('item.barcode', item.barcode);
         if (options.length === 1) {
           this.props.change('requestType', options[0].value);
         }
@@ -337,7 +345,7 @@ class RequestForm extends React.Component {
 
     if (barcode) {
       this.setState({ selectedItem: null });
-      this.findItem(barcode);
+      this.findItem('barcode', barcode);
     }
   }
 
@@ -689,7 +697,7 @@ class RequestForm extends React.Component {
                                     ref={this.itemBarcodeRef}
                                     onInput={this.onItemClickDebounce}
                                     onKeyDown={e => this.onKeyDown(e, 'item')}
-                                    validate={this.requireItem}
+
                                   />
                                 )}
                               </FormattedMessage>

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -209,10 +209,9 @@ export default function config() {
     return requests.find(request.params.id);
   });
 
-  this.post('/circulation/requests', ({ requests }, request) => {
+  this.post('/circulation/requests', (_, request) => {
     const body = JSON.parse(request.requestBody);
-    const defaultReq = this.build('request');
-    return requests.create({ ...defaultReq, ...body });
+    return this.create('request', body);
   });
 
   this.put('/circulation/requests/:id', ({ requests }, request) => {
@@ -227,6 +226,7 @@ export default function config() {
     const cqlQuery = url.searchParams.get('query');
     const cqlParser = new CQLParser();
     cqlParser.parse(cqlQuery);
+
     return requests.where({
       itemId: cqlParser.tree.term
     });
@@ -265,10 +265,8 @@ export default function config() {
     if (request.queryParams.query) {
       const cqlParser = new CQLParser();
       cqlParser.parse(request.queryParams.query);
-      const item = items.where({
-        barcode: cqlParser.tree.term
-      });
-      return item;
+      const { field, term } = cqlParser.tree;
+      return items.where({ [field]: term });
     } else {
       return items.all();
     }

--- a/test/bigtest/network/factories/request.js
+++ b/test/bigtest/network/factories/request.js
@@ -14,7 +14,8 @@ export default Factory.extend({
   tags: { tagList: ['tag1'] },
   afterCreate(request, server) {
     const user = server.create('user');
-    const item = server.create('item');
+    const options = (request.itemId) ? { id: request.itemId } : null;
+    const item = server.create('item', options);
 
     request.update({
       item: item.attrs,

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -305,7 +305,7 @@ describe('New Request page', () => {
     });
   });
 
-  describe('New request with prefilled user and item', function () {
+  describe('New request with prefilled user barcode and item barcode', function () {
     beforeEach(async function () {
       this.server.create('item', {
         barcode: '9676761472503',
@@ -313,12 +313,33 @@ describe('New Request page', () => {
       this.server.create('user', {
         barcode: '9676761472504',
       });
-      this.visit('/requests/view/requestId0?layer=create&userBarcode=9676761472504&itemBarcode=9676761472503');
+      this.visit('/requests/view/?layer=create&userBarcode=9676761472504&itemBarcode=9676761472503');
     });
 
     it('should update prefill user and item', () => {
       expect(NewRequestInteractor.containsUserBarcode).to.equal('9676761472504');
       expect(NewRequestInteractor.containsItemBarcode).to.equal('9676761472503');
+    });
+  });
+
+  describe('New request with prefilled user barcode and item id', function () {
+    beforeEach(async function () {
+      this.server.create('item', {
+        id: '123',
+        barcode: '',
+      });
+      this.server.create('user', {
+        barcode: '9676761472504',
+      });
+      this.visit('/requests/view/?layer=create&userBarcode=9676761472504&itemId=123');
+
+      await NewRequestInteractor.chooseServicePoint('Circ Desk 2');
+      await NewRequestInteractor.clickNewRequest();
+    });
+
+    it('should update prefill user and item', () => {
+      expect(ViewRequestInteractor.requestSectionPresent).to.be.true;
+      expect(ViewRequestInteractor.requesterSectionPresent).to.be.true;
     });
   });
 });

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -70,6 +70,7 @@
 
   "item.information": "Item information",
   "item.barcode": "Item barcode",
+  "item.id": "Item id",
   "item.scanOrEnterBarcode": "Scan or enter item barcode",
   "item.title": "Title",
   "item.copyNumbers": "Copy number",


### PR DESCRIPTION
`On Order` items don't have barcodes but we still need to be able to create requests for them when coming from the inventory module. 

https://issues.folio.org/browse/UIREQ-253