### PR TITLE
clear query-string when cancelling new request

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.0.0",
+    "@folio/stripes": "^2.6.0",
     "react": "*"
   },
   "optionalDependencies": {

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -404,6 +404,18 @@ class Requests extends React.Component {
     this.setState({ errorMessage });
   }
 
+  handleCloseNewRecord = (e) => {
+    if (e) {
+      e.preventDefault();
+    }
+
+    this.props.mutator.query.update({
+      layer: null,
+      itemBarcode: null,
+      userBarcode: null,
+    });
+  }
+
   onDuplicate = (request) => {
     const dupRequest = omit(request, [
       'id',
@@ -515,6 +527,7 @@ class Requests extends React.Component {
           newRecordInitialValues={InitialValues}
           massageNewRecord={this.massageNewRecord}
           onCreate={this.create}
+          onCloseNewRecord={this.handleCloseNewRecord}
           parentResources={resources}
           parentMutator={mutator}
           detailProps={{

--- a/test/bigtest/tests/edit-request-test.js
+++ b/test/bigtest/tests/edit-request-test.js
@@ -25,6 +25,8 @@ describe('Edit Request page', () => {
 
     it('closes the edit request form', function () {
       expect(this.location.search).not.to.include('layer=edit');
+      expect(this.location.search).not.to.include('userBarcode=');
+      expect(this.location.search).not.to.include('itemBarcode=');
     });
   });
 

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -60,6 +60,11 @@ describe('New Request page', () => {
 
           it('should redirect to view requests page after click', () => {
             expect(requests.$root).to.exist;
+            if (this.location && this.location.search) {
+              expect(this.location.search).not.to.include('layer=edit');
+              expect(this.location.search).not.to.include('userBarcode=');
+              expect(this.location.search).not.to.include('itemBarcode=');
+            }
           });
         });
       });


### PR DESCRIPTION
When cancelling a new request that was generated from ui-users or
ui-inventory, the `userBarcode` or `itemBarcode` parameters would persist in
the URL, causing that data to pre-populate in future requests. No more.

Refs [UIREQ-244](https://issues.folio.org/browse/UIREQ-244)