### PR TITLE
Fix creating hold request via duplicate option. Part of UIREQ-275.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.10.0 (In Progress)
 
-* Fix creating hold request via duplicate. Part of UIREQ-275.
+* Fix creating hold request via duplicate option. Part of UIREQ-275.
 
 ## [1.9.0](https://github.com/folio-org/ui-requests/tree/v1.9.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.8.0...v1.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 1.10.0 (In Progress)
+
+* Fix creating hold request via duplicate. Part of UIREQ-275.
+
 ## [1.9.0](https://github.com/folio-org/ui-requests/tree/v1.9.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.8.0...v1.9.0)
 

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -424,6 +424,8 @@ class Requests extends React.Component {
       'requestCount',
       'position',
       'requester',
+      'item',
+      'pickupServicePoint',
     ]);
 
     this.setState({ dupRequest });


### PR DESCRIPTION
It looks like some additional props were included during duplication. This PR should fix it.

https://issues.folio.org/browse/UIREQ-275