### PR TITLE
Fix opening correct request item during duplication. Part of  UIREQ-274.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.10.0 (In Progress)
 
 * Fix creating hold request via duplicate option. Part of UIREQ-275.
+* Fix opening correct request item during duplication. Part of UIREQ-274.
 
 ## [1.9.0](https://github.com/folio-org/ui-requests/tree/v1.9.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.8.0...v1.9.0)

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -413,6 +413,7 @@ class Requests extends React.Component {
       layer: null,
       itemBarcode: null,
       userBarcode: null,
+      itemId: null,
     });
   }
 
@@ -432,6 +433,7 @@ class Requests extends React.Component {
     this.props.mutator.query.update({
       layer: 'create',
       itemBarcode: request.item.barcode,
+      itemId: request.itemId,
       userBarcode: request.requester.barcode,
     });
   }


### PR DESCRIPTION
It looks `itemId` was not cleaned up for items without the barcode. This PR should fix it.

https://issues.folio.org/browse/UIREQ-274 