### PR TITLE
remove tests based on flaky data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix creating hold request via duplicate option. Part of UIREQ-275.
 * Fix opening correct request item during duplication. Part of UIREQ-274.
+* Disable integration test based on flaky built-in data. Refs CIRCSTORE-129.
 
 ## [1.9.0](https://github.com/folio-org/ui-requests/tree/v1.9.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.8.0...v1.9.0)

--- a/test/ui-testing/filters.js
+++ b/test/ui-testing/filters.js
@@ -6,7 +6,6 @@ module.exports.test = function uiTest(uiTestCtx) {
     const nightmare = new Nightmare(config.nightmare);
 
     this.timeout(Number(config.test_timeout));
-    const requestTypes = ['holds', 'recalls'];
 
     describe('Login > Open module "Requests" > Get hit counts > Click filters > Logout', () => {
       before((done) => {
@@ -29,22 +28,33 @@ module.exports.test = function uiTest(uiTestCtx) {
           .catch(done);
       });
 
-      requestTypes.forEach((filter) => {
-        it(`should click ${filter} and change hit count`, (done) => {
-          nightmare
-            .wait('#input-request-search')
-            .type('#input-request-search', 0)
-            .wait('#clickable-reset-all')
-            .click('#clickable-reset-all')
-            .wait(`#clickable-filter-request-type-${filter}`)
-            .click(`#clickable-filter-request-type-${filter}`)
-            .wait('#list-requests:not([data-total-count^="0"])')
-            .click('#clickable-reset-all')
-            .wait('div[class^="mclEmptyMessage"]')
-            .then(done)
-            .catch(done);
-        });
-      });
+      //
+      // these tests are based on the premise that certain requests
+      // exist on the system, but they were removed as part of CIRCSTORE-129.
+      // we probably _should_ test the filters for different request types,
+      // but we'll have to do that in platform-level integration tests that
+      // function by actually creating such requests, rather than assuming
+      // they already exist.
+      //
+      //
+      // const requestTypes = ['holds', 'recalls'];
+      //
+      // requestTypes.forEach((filter) => {
+      //   it(`should click ${filter} and change hit count`, (done) => {
+      //     nightmare
+      //       .wait('#input-request-search')
+      //       .type('#input-request-search', 0)
+      //       .wait('#clickable-reset-all')
+      //       .click('#clickable-reset-all')
+      //       .wait(`#clickable-filter-request-type-${filter}`)
+      //       .click(`#clickable-filter-request-type-${filter}`)
+      //       .wait('#list-requests:not([data-total-count^="0"])')
+      //       .click('#clickable-reset-all')
+      //       .wait('div[class^="mclEmptyMessage"]')
+      //       .then(done)
+      //       .catch(done);
+      //   });
+      // });
     });
   });
 };


### PR DESCRIPTION
Some requests with questionable data were removed in CIRCSTORE-129. Now,
the tests based on those requests have been removed as well. Eventually,
we probably _should_ have tests for the filters for different request
types, but those integration tests should live at the platform level.

Refs [CIRCSTORE-129](https://issues.folio.org/browse/CIRCSTORE-129)