### PR TITLE
Fix async validation during edit. Part of UIREQ-283

### DIFF
--- a/src/Requests.js
+++ b/src/Requests.js
@@ -637,7 +637,6 @@ class Requests extends React.Component {
               },
               patronGroups,
               query: resources.query,
-              uniquenessValidator: mutator,
               onDuplicate: this.onDuplicate,
             }}
             viewRecordPerms="module.requests.enabled"

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -75,6 +75,7 @@ class ViewRequest extends React.Component {
     tagsToggle: PropTypes.func,
     paneWidth: PropTypes.string,
     patronGroups: PropTypes.arrayOf(PropTypes.object),
+    parentMutator: PropTypes.object,
     resources: PropTypes.shape({
       selectedRequest: PropTypes.shape({
         hasLoaded: PropTypes.bool.isRequired,
@@ -223,6 +224,7 @@ class ViewRequest extends React.Component {
       onCloseEdit,
       findResource,
       patronGroups,
+      parentMutator,
     } = this.props;
 
     const query = location.search ? queryString.parse(location.search) : {};
@@ -246,6 +248,7 @@ class ViewRequest extends React.Component {
                 optionLists={optionLists}
                 patronGroups={patronGroups}
                 query={this.props.query}
+                parentMutator={parentMutator}
                 findResource={findResource}
               />
             </Layer>

--- a/src/asyncValidate.js
+++ b/src/asyncValidate.js
@@ -13,10 +13,11 @@ function getItemErrors(item) {
 
 function asyncValidateItem(values, props) {
   return new Promise((resolve, reject) => {
-    const uv = props.uniquenessValidator.itemUniquenessValidator;
+    const uv = props.parentMutator.itemUniquenessValidator;
     const query = `(barcode="${values.item.barcode}")`;
+
     uv.reset();
-    uv.GET({ params: { query } }).then((items) => {
+    return uv.GET({ params: { query } }).then((items) => {
       const errors = getItemErrors(items[0]);
       if (errors) {
         reject(errors);
@@ -29,10 +30,10 @@ function asyncValidateItem(values, props) {
 
 function asyncValidateUser(values, props) {
   return new Promise((resolve, reject) => {
-    const uv = props.uniquenessValidator.userUniquenessValidator;
+    const uv = props.parentMutator.userUniquenessValidator;
     const query = `(barcode="${values.requester.barcode}")`;
     uv.reset();
-    uv.GET({ params: { query } }).then((users) => {
+    return uv.GET({ params: { query } }).then((users) => {
       if (users.length < 1) {
         const error = { requester: { barcode: <FormattedMessage id="ui-requests.errors.userBarcodeDoesNotExist" /> } };
         reject(error);


### PR DESCRIPTION
It looks like async validation was failing in edit mode because we didn't pass the mutator for `RequestForm` during edit. This PR should fix it. 

https://issues.folio.org/browse/UIREQ-283 