### PR TITLE
Cleanup item lookup values when layer is closed. Fixes UIREQ-285 and UIREQ-287.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Refactor async validation. Part of UIREQ-280.
+* Cleanup item lookup values when layer is closed. Fixes UIREQ-285 and UIREQ-287.
 
 ## [1.10.0](https://github.com/folio-org/ui-requests/tree/v1.10.0) (2019-06-12)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.9.0...v1.10.0)

--- a/src/Requests.js
+++ b/src/Requests.js
@@ -409,7 +409,7 @@ class Requests extends React.Component {
 
   create = (data) => {
     return this.props.mutator.records.POST(data)
-      .then(() => this.props.mutator.query.update({ layer: null }))
+      .then(() => this.closeLayer())
       .catch(resp => this.processError(resp));
   };
 
@@ -437,13 +437,17 @@ class Requests extends React.Component {
       e.preventDefault();
     }
 
+    this.closeLayer();
+  };
+
+  closeLayer() {
     this.props.mutator.query.update({
       layer: null,
       itemBarcode: null,
       userBarcode: null,
       itemId: null,
     });
-  };
+  }
 
   onDuplicate = (request) => {
     const dupRequest = duplicateRequest(request);


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-287
https://issues.folio.org/browse/UIREQ-285