### PR TITLE
UIREQ-262:  Add library column to Request CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 1.10.2 (In Progress)
+
+* Add library column to Request CSV. Refs UIREQ-262.
+
 ## [1.10.1](https://github.com/folio-org/ui-requests/tree/v1.10.1) (2019-06-24)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.10.0...v1.10.1)
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -51,6 +51,7 @@ export const reportHeaders = [
   'item.title',
   'item.copyNumbers',
   'item.contributorNames',
+  'item.location.libraryName',
   'item.location.name',
   'item.callNumber',
   'item.enumeration',

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -75,6 +75,7 @@
   "item.title": "Title",
   "item.copyNumbers": "Copy number",
   "item.contributorNames": "Contributor",
+  "item.location.libraryName": "Library",
   "item.location.name": "Shelving location",
   "item.callNumber": "Call number",
   "item.enumeration": "Enumeration",


### PR DESCRIPTION
## Purpose

Add the library column to Request CSV in the scope of the [issue](https://issues.folio.org/browse/UIREQ-262)

## Screenshots

![library_column_in_request_csv](https://user-images.githubusercontent.com/50317804/60187344-146f3880-9836-11e9-875c-7bdb78746f8e.png)
