### PR TITLE
UIREQ-263: Add Location Code Column to Request CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 1.10.2 (In Progress)
+
+* Add Location Code Column to Request CSV. Refs UIREQ-263.
+
 ## [1.10.1](https://github.com/folio-org/ui-requests/tree/v1.10.1) (2019-06-24)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.10.0...v1.10.1)
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,6 +52,7 @@ export const reportHeaders = [
   'item.copyNumbers',
   'item.contributorNames',
   'item.location.name',
+  'item.location.code',
   'item.callNumber',
   'item.enumeration',
   'item.status',

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -76,6 +76,7 @@
   "item.copyNumbers": "Copy number",
   "item.contributorNames": "Contributor",
   "item.location.name": "Shelving location",
+  "item.location.code": "Shelving location code",
   "item.callNumber": "Call number",
   "item.enumeration": "Enumeration",
   "item.copyNumber": "Copy",


### PR DESCRIPTION
### Purpose

Add Location Code Column to Request CSV according to [story](https://issues.folio.org/browse/UIREQ-263).

**Response**

![Response](https://user-images.githubusercontent.com/49517355/60197907-1262a500-9849-11e9-89ed-1154e5fcc661.png)

**.csv file**

![csv_file](https://user-images.githubusercontent.com/49517355/60197931-23abb180-9849-11e9-8e96-6421373f1e97.png)
