### PR TITLE
Populate shelving location on request view and edit form. Fixes UIREQ-311.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Do not show proxy popup during edit. Fixes UIREQ-291.
 * Move requests between items. Fixes UIREQ-269
 * Hide requester's proxy section when requesting as self. Fixes UIREQ-290.
+* Populate shelving location on request view and edit form. Fixes UIREQ-311.
 
 ## [1.10.1](https://github.com/folio-org/ui-requests/tree/v1.10.1) (2019-06-24)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.10.0...v1.10.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 1.12.0 (IN PROGRESS)
+
+* Populate shelving location on request view and edit form. Fixes UIREQ-311.
+
 ## [1.11.0](https://github.com/folio-org/ui-requests/tree/v1.11.0) (2019-07-24)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.10.1...v1.11.0)
 
@@ -8,7 +12,6 @@
 * Do not show proxy popup during edit. Fixes UIREQ-291.
 * Move requests between items. Fixes UIREQ-269
 * Hide requester's proxy section when requesting as self. Fixes UIREQ-290.
-* Populate shelving location on request view and edit form. Fixes UIREQ-311.
 
 ## [1.10.1](https://github.com/folio-org/ui-requests/tree/v1.10.1) (2019-06-24)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.10.0...v1.10.1)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -36,7 +36,7 @@ const ItemDetail = ({ item, loan, requestCount }) => {
         </Col>
         <Col xs={3}>
           <KeyValue label={<FormattedMessage id="ui-requests.item.location.name" />}>
-            {get(item, ['effectiveLocation', 'name']) || '-'}
+            {get(item, 'effectiveLocation.name') || get(item, 'location.name') || ''}
           </KeyValue>
         </Col>
       </Row>


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-311