### PR TITLE
UIREQ-323 - Hold shelf expiration date not displaying after request expires (Closed - Pickup expired)

### DIFF
--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -347,10 +347,10 @@ class ViewRequest extends React.Component {
       }
     }
 
-    const holdShelfExpireDate = (get(request, 'holdShelfExpirationDate', '') &&
-      [requestStatuses.AWAITING_PICKUP, requestStatuses.PICKUP_EXPIRED].includes(get(request, ['status'], '')))
-      ? <FormattedTime value={request.holdShelfExpirationDate} day="numeric" month="numeric" year="numeric" />
-      : '-';
+    const holdShelfExpireDate = get(request, 'holdShelfExpirationDate', '') &&
+      [requestStatuses.AWAITING_PICKUP, requestStatuses.PICKUP_EXPIRED].includes(get(request, ['status'], ''))
+      ? <FormattedTime value={request.holdShelfExpirationDate} day="numeric" month="numeric" year="numeric" />
+      : '-';
 
     const expirationDate = (get(request, 'requestExpirationDate', ''))
       ? <FormattedDate value={request.requestExpirationDate} />

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -347,10 +347,10 @@ class ViewRequest extends React.Component {
       }
     }
 
-    const holdShelfExpireDate = (get(request, 'holdShelfExpirationDate', '') &&
-      get(request, ['status'], '') === requestStatuses.AWAITING_PICKUP)
-      ? <FormattedTime value={request.holdShelfExpirationDate} day="numeric" month="numeric" year="numeric" />
-      : '-';
+    const holdShelfExpireDate = (get(request, 'holdShelfExpirationDate', '') &&
+      [requestStatuses.AWAITING_PICKUP, requestStatuses.PICKUP_EXPIRED].includes(get(request, ['status'], '')))
+      ? <FormattedTime value={request.holdShelfExpirationDate} day="numeric" month="numeric" year="numeric" />
+      : '-';
 
     const expirationDate = (get(request, 'requestExpirationDate', ''))
       ? <FormattedDate value={request.requestExpirationDate} />

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ export const requestStatuses = {
   RECALL: 'Recall',
   HOLD: 'Hold',
   NOT_YET_FILLED: 'Open - Not yet filled',
-  PICKUP_EXPIRED: 'Closed - Pickup expired',
+  PICKUP_EXPIRED: 'Closed - Pickup expired',
 };
 
 export const itemStatuses = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,7 @@ export const requestStatuses = {
   RECALL: 'Recall',
   HOLD: 'Hold',
   NOT_YET_FILLED: 'Open - Not yet filled',
+  PICKUP_EXPIRED: 'Closed - Pickup expired',
 };
 
 export const itemStatuses = {


### PR DESCRIPTION
# Purpose
To allow display hold shelf expiration date for closed requests

# Link
https://issues.folio.org/browse/UIREQ-323

# Screenshot
<img width="1680" alt="Screen Shot 2019-10-22 at 5 15 24 PM" src="https://user-images.githubusercontent.com/43472449/67295427-c3273b00-f4ef-11e9-9456-d270ad394a3b.png">
