### PR TITLE
Add requesterId to requests query. Part of UIU-1370.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add request queue page with reorder capabilities. Part of UIREQ-112.
 * Display cancellation reason on cancelled request. Part of UIREQ-364.
+* Add requesterId to requests query. Part of UIU-1370.
 
 ## [1.13.0](https://github.com/folio-org/ui-requests/tree/v1.13.0) (2019-09-23)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.12.0...v1.13.0)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -112,7 +112,7 @@ class RequestsRoute extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1',
-            '(requester.barcode="%{query.query}*" or item.title="%{query.query}*" or item.barcode="%{query.query}*" or itemId=="%{query.query}")',
+            '(requesterId=="%{query.query}" or requester.barcode="%{query.query}*" or item.title="%{query.query}*" or item.barcode="%{query.query}*" or itemId=="%{query.query}")',
             {
               'Title': 'item.title',
               'Item barcode': 'item.barcode',


### PR DESCRIPTION
This PR modifies requests query to support searching by requester's id. 
This is needed in order to fix a bug described in https://issues.folio.org/browse/UIU-1370
