### PR TITLE
Fix logic for moving item to paged request. Part of UIREQ-376

### DIFF
--- a/src/MoveRequestManager.js
+++ b/src/MoveRequestManager.js
@@ -69,7 +69,7 @@ class MoveRequestManager extends React.Component {
     } = this.state;
     const { request } = this.props;
     const pageRequestIsLater = selectedItemPageRequest != null &&
-      moment(selectedItemPageRequest.requestDate).isAfter(moment(request.requestDate));
+      moment(selectedItemPageRequest.requestDate).isBefore(moment(request.requestDate));
 
     return isPagedItem(selectedItem) && pageRequestIsLater;
   }
@@ -201,7 +201,7 @@ class MoveRequestManager extends React.Component {
             onCancel={this.cancelMoveRequest}
           />
         }
-        { chooseRequestType &&
+        {chooseRequestType &&
           <ChooseRequestTypeDialog
             open={chooseRequestType}
             data-test-choose-request-type-modal


### PR DESCRIPTION
This PR adjusts the logic for showing the "Can't move above page" popup. This is based on the findings from @bohdan-suprun in https://issues.folio.org/browse/UIREQ-376 and also the comments from @Baroquem under https://issues.folio.org/browse/UIREQ-320

@Baroquem please let me know if this looks good. 