### PR TITLE
UIREQ-369: disallow editing fulfillment preference on requests with Awaiting delivery/pickup status

### DIFF
--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -8,6 +8,12 @@ import { Field } from 'redux-form';
 import { Col, KeyValue, Row, Select } from '@folio/stripes/components';
 import { ProxyManager } from '@folio/stripes/smart-components';
 import { getFullName, userHighlightBox } from './utils';
+import { requestStatuses } from './constants';
+
+const {
+  AWAITING_DELIVERY,
+  AWAITING_PICKUP,
+} = requestStatuses;
 
 class UserForm extends React.Component {
   static propTypes = {
@@ -104,11 +110,11 @@ class UserForm extends React.Component {
       request,
     } = this.props;
 
-
     const id = user.id;
     const name = getFullName(user);
     const barcode = user.barcode;
-    const editMode = get(request, 'id');
+    const editMode = !!request;
+    const shouldDisableFulfillmentPreferenceField = editMode && (request.status === AWAITING_PICKUP || request.status === AWAITING_DELIVERY);
 
     let proxyName;
     let proxyBarcode;
@@ -138,6 +144,8 @@ class UserForm extends React.Component {
               fullWidth
               value={fulfilmentPreference}
               onChange={onChangeFulfilment}
+              disabled={shouldDisableFulfillmentPreferenceField}
+              data-test-fulfillment-preference-filed
             >
               {fulfilmentTypeOptions.map(({ labelTranslationPath, value }) => (
                 <FormattedMessage key={value} id={labelTranslationPath}>

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -113,8 +113,8 @@ class UserForm extends React.Component {
     const id = user.id;
     const name = getFullName(user);
     const barcode = user.barcode;
-    const editMode = !!request;
-    const shouldDisableFulfillmentPreferenceField = editMode && (request.status === AWAITING_PICKUP || request.status === AWAITING_DELIVERY);
+    const isEditable = !!request;
+    const shouldDisableFulfillmentPreferenceField = isEditable && (request.status === AWAITING_PICKUP || request.status === AWAITING_DELIVERY);
 
     let proxyName;
     let proxyBarcode;
@@ -176,7 +176,7 @@ class UserForm extends React.Component {
 
         {proxySection}
 
-        { !editMode &&
+        { !isEditable &&
           <this.connectedProxyManager
             patron={user}
             proxy={proxy}

--- a/test/bigtest/interactors/edit-request.js
+++ b/test/bigtest/interactors/edit-request.js
@@ -4,6 +4,7 @@ import {
   fillable,
   selectable,
   isPresent,
+  is,
 } from '@bigtest/interactor';
 
 import CancelRequestDialog from './cancel-request-dialog';
@@ -25,6 +26,7 @@ import CancelRequestDialog from './cancel-request-dialog';
   clickUpdate = clickable('#clickable-update-request');
   cancelRequestDialog = new CancelRequestDialog('[data-test-cancel-request-modal]');
   isLayerPresent = isPresent('[class*=LayerRoot][role=dialog]');
+  fulfillmentPreferenceFieldDisabled = is('[data-test-fulfillment-preference-filed]', ':disabled');
 }
 
 export default new EditRequestsInteractor();

--- a/test/bigtest/tests/edit-request-test.js
+++ b/test/bigtest/tests/edit-request-test.js
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import setupApplication from '../helpers/setup-application';
 import EditRequestInteractor from '../interactors/edit-request';
 import ViewRequestInteractor from '../interactors/view-request';
+import { requestStatuses } from '../../../src/constants';
 
 describe('Edit Request page', () => {
   setupApplication();
@@ -61,6 +62,36 @@ describe('Edit Request page', () => {
     it('should update existing request and open a view request pane', () => {
       expect(ViewRequestInteractor.requestSectionPresent).to.be.true;
       expect(ViewRequestInteractor.requesterInfoContains('Circ Desk 2')).to.be.true;
+    });
+  });
+
+  describe('when the request has status "Open - Awaiting delivery"', () => {
+    beforeEach(function () {
+      this.server.create('request', {
+        status: requestStatuses.AWAITING_DELIVERY,
+        id: 'someId'
+      });
+
+      this.visit('/requests/view/someId?layer=edit');
+    });
+
+    it('should disable fulfillment preference field', () => {
+      expect(EditRequestInteractor.fulfillmentPreferenceFieldDisabled).to.be.true;
+    });
+  });
+
+  describe('when the request has status "Open - Awaiting pickup"', () => {
+    beforeEach(function () {
+      this.server.create('request', {
+        status: requestStatuses.AWAITING_PICKUP,
+        id: 'someId2'
+      });
+
+      this.visit('/requests/view/someId2?layer=edit');
+    });
+
+    it('should disable fulfillment preference field', () => {
+      expect(EditRequestInteractor.fulfillmentPreferenceFieldDisabled).to.be.true;
     });
   });
 });


### PR DESCRIPTION
### Purpose
Disallow editing of fulfillment preference when a request is in Open - Awaiting delivery/pickup status

[Related story](https://issues.folio.org/browse/UIREQ-369)