### PR TITLE
UIREQ-380: Fix bug with wrong deliver address in request form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Remove 'Request can not be moved above page request' dialog. Part of UIREQ-379.
 * Provide reorder queue permission. Refs UIREQ-318.
 * Show reorder view after moving request from one item to another. Refs UIREQ-334.
+* Fix bug with wrong delivery address in request form. Refs UIREQ-380.
 
 ## [1.13.0](https://github.com/folio-org/ui-requests/tree/v1.13.0) (2019-09-23)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.12.0...v1.13.0)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -247,9 +247,25 @@ class RequestForm extends React.Component {
   }
 
   onChangeFulfilment(e) {
+    const {
+      defaultDeliveryAddressTypeId,
+      defaultServicePointId,
+    } = this.state;
+    const { change } = this.props;
+
+    const deliverySelected = e.target.value === fulfilmentTypeMap.DELIVERY;
+
     this.setState({
-      selectedDelivery: e.target.value === fulfilmentTypeMap.DELIVERY,
+      selectedDelivery: deliverySelected,
     });
+
+    if (deliverySelected) {
+      change('deliveryAddressTypeId', defaultDeliveryAddressTypeId);
+      change('pickupServicePointId', '');
+    } else {
+      change('pickupServicePointId', defaultServicePointId);
+      change('deliveryAddressTypeId', '');
+    }
   }
 
   onChangeAddress(e) {
@@ -340,7 +356,6 @@ class RequestForm extends React.Component {
         selectedDelivery: true,
         selectedAddressTypeId: defaultDeliveryAddressTypeId,
       });
-
       this.props.change('deliveryAddressTypeId', defaultDeliveryAddressTypeId);
     }
     if (fulfillmentPreference === fulfilmentTypeMap.HOLD_SHELF) {


### PR DESCRIPTION
### Purpose

Fix bug with wrong delivery address selected when preference is equal 'hold shelf' and then changed

### Issue
https://issues.folio.org/browse/UIREQ-380

### Screenshot

![GYQfk4EXL9](https://user-images.githubusercontent.com/55701515/70160848-d408c600-16c3-11ea-8d8d-bde561c7d17b.gif)
