### PR TITLE
UIREQ-377: Fix indicator of edit page

### DIFF
--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -474,7 +474,7 @@ class RequestForm extends React.Component {
   isEditForm() {
     const { request } = this.props;
 
-    return !!get(request, 'item.barcode');
+    return !!get(request, 'id');
   }
 
   isSubmittingButtonDisabled() {


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-377

##Purpose
The edit page of a request displays like a create page when the request is created on item without barcode.

##Screenshots
Before
https://issues.folio.org/secure/attachment/22940/screenshot-2.png
After
![2019-12-05 18 37 33](https://user-images.githubusercontent.com/43621626/70254819-607fbb00-178e-11ea-9f5f-92213bba1650.gif)
