### PR TITLE
UIREQ-394 - Blocked patron can successfully place a Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.15.0] IN PROGRESS
 
 * Disable confirm button when cancel is in progress. Fixes UIREQ-321
+* Blocked patron can successfully place a Request. Refs UIREQ-394.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -502,7 +502,13 @@ class RequestForm extends React.Component {
   }
 
   onSave = (data) => {
-    const { intl: { timeZone } } = this.props;
+    const {
+      intl: {
+        timeZone,
+      },
+      parentResources,
+    } = this.props;
+
     const {
       requestExpirationDate,
       holdShelfExpirationDate,
@@ -510,6 +516,12 @@ class RequestForm extends React.Component {
       deliveryAddressTypeId,
       pickupServicePointId,
     } = data;
+
+    const [block] = this.getPatronBlocks(parentResources);
+    if (block.userId === this.state.selectedUser.id) {
+      this.setState({ blocked: true });
+      return;
+    }
 
     if (!requestExpirationDate) unset(data, 'requestExpirationDate');
     if (holdShelfExpirationDate && !holdShelfExpirationDate.match('T')) {


### PR DESCRIPTION
# Purpose
Deny to save a request if selected patron is blocked.

# Link
https://issues.folio.org/browse/UIREQ-394

# Screenshot
<img width="1680" alt="Screen Shot 2019-12-09 at 11 00 03" src="https://user-images.githubusercontent.com/43472449/70421729-1428c980-1a73-11ea-82a3-f4e99a4e6ab9.png">
