### PR TITLE
UIREQ-385: Fix bug with wrong menus when duplicating request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Blocked patron can successfully place a Request. Refs UIREQ-394.
 * Fix reference to `userId` via block. Fixes UIREQ-396.
 * Create/Edit a request | Move Save/Cancel buttons to the footer. Refs UIREQ-370.
+* Fix bug with wrong delivery address in request form. Refs UIREQ-380.
+* Fix menus displaying when duplicating request. Refs UIREQ-385.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)
@@ -16,7 +18,6 @@
 * Remove 'Request can not be moved above page request' dialog. Part of UIREQ-379.
 * Provide reorder queue permission. Refs UIREQ-318.
 * Show reorder view after moving request from one item to another. Refs UIREQ-334.
-* Fix bug with wrong delivery address in request form. Refs UIREQ-380.
 
 ## [1.13.0](https://github.com/folio-org/ui-requests/tree/v1.13.0) (2019-09-23)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.12.0...v1.13.0)

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -29,7 +29,7 @@ class UserForm extends React.Component {
     proxy: PropTypes.object,
     stripes: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,
-    selectedDelivery: PropTypes.bool,
+    deliverySelected: PropTypes.bool,
     servicePoints: PropTypes.arrayOf(PropTypes.object),
     request: PropTypes.object,
   };
@@ -42,7 +42,7 @@ class UserForm extends React.Component {
     onChangeFulfilment: () => {},
     patronGroup: '',
     proxy: {},
-    selectedDelivery: false,
+    deliverySelected: false,
   };
 
   constructor(props) {
@@ -103,7 +103,7 @@ class UserForm extends React.Component {
       patronGroup,
       deliveryAddress,
       deliveryLocations,
-      selectedDelivery,
+      deliverySelected,
       fulfilmentPreference,
       fulfilmentTypeOptions,
       onChangeFulfilment,
@@ -160,13 +160,13 @@ class UserForm extends React.Component {
           </Col>
           <Col xs={4}>
             {
-              (!selectedDelivery && this.renderPickupServicePointSelect()) ||
+              (!deliverySelected && this.renderPickupServicePointSelect()) ||
               (deliveryLocations && this.renderDeliveryAddressSelect())
             }
           </Col>
         </Row>
 
-        { selectedDelivery &&
+        { deliverySelected &&
           <Row>
             <Col xs={4} xsOffset={8}>
               {deliveryAddress}


### PR DESCRIPTION
# Purpose
Show the Fulfillment preference menu with Hold shelf selected and the menu for selecting the service point for pickup when user logs in from user(not diku_admin) and trying to duplicate the request

# Link
https://issues.folio.org/browse/UIREQ-385

# Screenshots
## Before
![screenshot-1](https://user-images.githubusercontent.com/55701515/70531434-942b5e00-1b5d-11ea-828b-e27940f36bff.png)


## After
![bRkWMJdHQm](https://user-images.githubusercontent.com/55701515/70531249-3565e480-1b5d-11ea-8870-f04ff3ae67c3.gif)

