### PR TITLE
UIREQ-396: Fix reference to userId via block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Disable confirm button when cancel is in progress. Fixes UIREQ-321
 * Blocked patron can successfully place a Request. Refs UIREQ-394.
+* Fix reference to `userId` via block. Fixes UIREQ-396.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -518,7 +518,8 @@ class RequestForm extends React.Component {
     } = data;
 
     const [block] = this.getPatronBlocks(parentResources);
-    if (block.userId === this.state.selectedUser.id) {
+
+    if (get(block, 'userId') === this.state.selectedUser.id) {
       this.setState({ blocked: true });
       return;
     }


### PR DESCRIPTION
I'm not sure why block would be undefined in some cases. This PR is just a quick fix so the request can be created. We may need to revisit the `getPatronBlocks`. 
 
https://issues.folio.org/browse/UIREQ-396

