### PR TITLE
UIREQ-404 removed duplicate requester details

### DIFF
--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -948,25 +948,6 @@ class RequestForm extends React.Component {
                           </Col>
                         </Row>
                       }
-                      {selectedUser && (requestPreferencesLoaded || this.isEditForm()) &&
-                        <UserForm
-                          user={request ? request.requester : selectedUser}
-                          stripes={this.props.stripes}
-                          request={request}
-                          patronGroup={get(patronGroup, 'desc')}
-                          deliverySelected={deliverySelected}
-                          fulfilmentPreference={fulfilmentPreference}
-                          deliveryAddress={addressDetail}
-                          deliveryLocations={deliveryLocations}
-                          fulfilmentTypeOptions={this.getFulfilmentTypeOptions()}
-                          onChangeAddress={this.onChangeAddress}
-                          onChangeFulfilment={this.onChangeFulfilment}
-                          proxy={this.getProxy()}
-                          servicePoints={servicePoints}
-                          onSelectProxy={this.onSelectProxy}
-                          onCloseProxy={() => { this.setState({ selectedUser: null, proxy: null }); }}
-                        />
-                      }
                     </Col>
                   </Row>
                 </Accordion>


### PR DESCRIPTION
The request details pane was inadvertently duplicated during a botched
merge. Cate found the symptoms in the UI, @hjiebsco found the error in
the code, and I'm just doing the clean up.

Fixes [UIREQ-404](https://issues.folio.org/browse/UIREQ-404)