### PR TITLE
UIREQ-366 correctly align columns

### DIFF
--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -56,17 +56,17 @@ const ItemDetail = ({ item, loan, requestCount }) => {
         </Col>
       </Row>
       <Row>
-        <Col xs={3}>
+        <Col xs={4}>
           <KeyValue label={<FormattedMessage id="ui-requests.item.status" />}>
             {status || '-'}
           </KeyValue>
         </Col>
-        <Col xs={3}>
+        <Col xs={4}>
           <KeyValue label={<FormattedMessage id="ui-requests.item.dueDate" />}>
             {loan && loan.dueDate ? <FormattedDate value={loan.dueDate} /> : '-'}
           </KeyValue>
         </Col>
-        <Col xs={3}>
+        <Col xs={4}>
           <KeyValue label={<FormattedMessage id="ui-requests.item.requestsOnItem" />}>
             {positionLink}
           </KeyValue>


### PR DESCRIPTION
Brainfart: in the request-details pane I only updated the width 
of the columns in rows 1 and 2; forgot about row 3. Whoops.

[UIREQ-366](https://issues.folio.org/browse/UIREQ-366)

### before: 
<img width="800" alt="Screen Shot 2020-01-27 at 2 38 29 PM (2)" src="https://user-images.githubusercontent.com/199241/73207552-e414b300-4112-11ea-9ca2-75f6fc6046bf.png">

### after:
<img width="800" alt="Screen Shot 2020-01-27 at 2 38 34 PM (2)" src="https://user-images.githubusercontent.com/199241/73207561-e70fa380-4112-11ea-8d01-9db02f50d0cd.png">
