### PR TITLE
UIREQ-366 use correct label

### DIFF
--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -82,7 +82,7 @@
   "item.location.libraryName": "Library",
   "item.effectiveLocation": "Effective location",
   "item.location.code": "Shelving location code",
-  "item.callNumber": "Effective call number",
+  "item.callNumber": "Effective call number string",
   "item.enumeration": "Enumeration",
   "item.copyNumber": "Copy",
   "item.status": "Item status",


### PR DESCRIPTION
The label should be "Effective call number string", not "Call number".

[UIREQ-366](https://issues.folio.org/browse/UIREQ-366)