### PR TITLE
UIREQ-395: Change conditions for disabling link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Only fetch open loans when loading an item. Fixes UIREQ-353.
 * Make `Export hold shelf clearance report` for `CurrentServicePoint` disabled if there is nothing on it for the currently selected service point. Fixes UIREQ-395.
 * Add possibility for render all available tokens on pick slip. Fixes UICIRC-416.
+* Make disabling `Export hold shelf clearance report` for `CurrentServicePoint` not depending from filter results. Fixes UIREQ-395.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Only fetch open loans when loading an item. Fixes UIREQ-353.
 * Make `Export hold shelf clearance report` for `CurrentServicePoint` disabled if there is nothing on it for the currently selected service point. Fixes UIREQ-395.
 * Add possibility for render all available tokens on pick slip. Fixes UICIRC-416.
-* Make disabling `Export hold shelf clearance report` for `CurrentServicePoint` not depending from filter results. Fixes UIREQ-395.
+* Make disabling `Export hold shelf clearance report` for `CurrentServicePoint` not depending on filter results. Fixes UIREQ-395.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -610,7 +610,7 @@ class RequestsRoute extends React.Component {
       .join(',');
 
     mutator.query.update({ filters });
-    this.buildRecordsForHoldsShelfReport();
+    //this.buildRecordsForHoldsShelfReport();
   };
 
   getActiveFilters = () => {
@@ -673,7 +673,6 @@ class RequestsRoute extends React.Component {
       dupRequest,
       errorMessage,
       errorModalData,
-      servicePointId,
       requests,
     } = this.state;
 
@@ -722,7 +721,7 @@ class RequestsRoute extends React.Component {
         <Button
           buttonStyle="dropdownItem"
           id="exportExpiredHoldsToCsvPaneHeaderBtn"
-          disabled={servicePointId && (isEmpty(requests) || !requestCount)}
+          disabled={isEmpty(requests)}
           onClick={() => {
             onToggle();
             this.exportExpiredHoldsToCSV();

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -610,7 +610,6 @@ class RequestsRoute extends React.Component {
       .join(',');
 
     mutator.query.update({ filters });
-    //this.buildRecordsForHoldsShelfReport();
   };
 
   getActiveFilters = () => {
@@ -674,6 +673,7 @@ class RequestsRoute extends React.Component {
       errorMessage,
       errorModalData,
       requests,
+      servicePointId,
     } = this.state;
 
     const { name: servicePointName } = this.getCurrentServicePointInfo();
@@ -721,7 +721,7 @@ class RequestsRoute extends React.Component {
         <Button
           buttonStyle="dropdownItem"
           id="exportExpiredHoldsToCsvPaneHeaderBtn"
-          disabled={isEmpty(requests)}
+          disabled={servicePointId && isEmpty(requests)}
           onClick={() => {
             onToggle();
             this.exportExpiredHoldsToCSV();


### PR DESCRIPTION
# Description:

Change condition to make `Hold Shelf clearance report` active when there are items matching the logged in users service point and inactive (greyed out) when there are no items matching the logged in users service point, **not depending** from search/filtered results.

# Issue:

https://issues.folio.org/browse/UIREQ-395

# Screenshot:
![image](https://user-images.githubusercontent.com/55694637/75028600-398d7700-54a9-11ea-843e-9fb3b91fe211.png)
![image](https://user-images.githubusercontent.com/55694637/75028639-49a55680-54a9-11ea-9dbc-676f8ee79f12.png)
