### PR TITLE
UIREQ-372: Display effective call number string on the request queue …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Make disabling `Export hold shelf clearance report` for `CurrentServicePoint` not depending on filter results. Fixes UIREQ-395.
 * Fix link to `ui-users` from request details screen. Fixes UIREQ-424.
 * Add 'Load more' button at the end of the results list. Fixes UIREQ-427.
+* Display effective call number string on the request queue page. Refs UIREQ-372.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.1.0",
-    "@folio/stripes": "^2.13.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.11.0",
     "@folio/stripes-core": "^3.12.0",
     "babel-eslint": "^10.0.3",
@@ -175,7 +175,7 @@
     "react-barcode": "^1.3.2"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.13.0",
+    "@folio/stripes": "^3.0.0",
     "react": "*",
     "react-router": "*",
     "react-router-dom": "*"

--- a/src/views/RequestQueueView.js
+++ b/src/views/RequestQueueView.js
@@ -21,6 +21,7 @@ import {
   Row,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
+import { effectiveCallNumber } from '@folio/stripes/util';
 
 import { iconTypes } from '../constants';
 import {
@@ -232,7 +233,6 @@ class RequestQueueView extends React.Component {
       data: {
         item,
         request,
-        holding,
       },
     } = this.props;
     const {
@@ -269,7 +269,7 @@ class RequestQueueView extends React.Component {
         >
           <div className={css.section}>
             <Row>
-              <Col xs={1}>
+              <Col xs={2}>
                 <KeyValue
                   label={<FormattedMessage id="ui-requests.item.barcode" />}
                   value={itemLink}
@@ -293,28 +293,13 @@ class RequestQueueView extends React.Component {
                   value={get(item, 'effectiveLocation.name', '-')}
                 />
               </Col>
-              <Col xs={2}>
+              <Col
+                data-test-item-call-number
+                xs={4}
+              >
                 <KeyValue
                   label={<FormattedMessage id="ui-requests.item.callNumber" />}
-                  value={item.callNumber || holding.callNumber || '-'}
-                />
-              </Col>
-              <Col xs={1}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.item.volume" />}
-                  value={get(item, 'volume', '-')}
-                />
-              </Col>
-              <Col xs={1}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.item.enumeration" />}
-                  value={get(item, 'enumeration', '-')}
-                />
-              </Col>
-              <Col xs={1}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.item.copyNumber" />}
-                  value={get(item.copyNumber) || holding.copyNumber || '-'}
+                  value={effectiveCallNumber(item)}
                 />
               </Col>
             </Row>

--- a/test/bigtest/interactors/KeyValue.js
+++ b/test/bigtest/interactors/KeyValue.js
@@ -1,0 +1,11 @@
+import {
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+@interactor class KeyValue {
+  label = scoped('div');
+  value = scoped('div:nth-child(2)');
+}
+
+export default KeyValue;

--- a/test/bigtest/interactors/request-queue.js
+++ b/test/bigtest/interactors/request-queue.js
@@ -2,12 +2,15 @@ import {
   interactor,
   isPresent,
   clickable,
+  scoped,
 } from '@bigtest/interactor';
 
 import SortableListInteractor from './sortable-list';
 import ConfirmReorderModal from './confirm-reorder-modal';
+import KeyValue from './KeyValue';
 
 @interactor class RequestQueue {
+  itemCallNumber = scoped('[data-test-item-call-number] div', KeyValue);
   sortableList = new SortableListInteractor();
   sortableListPresent = isPresent('[class^="mclScrollable---"]');
   confirmReorderModalIsPresent = isPresent('#confirm-reorder');

--- a/test/bigtest/network/factories/request.js
+++ b/test/bigtest/network/factories/request.js
@@ -65,5 +65,25 @@ export default Factory.extend({
         deliveryAddressTypeId: user.personal.addresses[0].addressTypeId
       });
     }
+  }),
+
+  withCallNumber: trait({
+    afterCreate(request, server) {
+      const item = server.create('item', {
+        callNumberComponents: {
+          prefix: 'prefix',
+          callNumber: 'callNumber',
+          suffix: 'suffix',
+        },
+        volume: 'volume',
+        enumeration: 'enumeration',
+        chronology: 'chronology',
+      });
+
+      request.update({
+        item: item.attrs,
+        itemId: item.id,
+      });
+    }
   })
 });

--- a/test/bigtest/network/scenarios/requestQueueScenario.js
+++ b/test/bigtest/network/scenarios/requestQueueScenario.js
@@ -1,3 +1,3 @@
 export default function (server) {
-  server.createList('request', 3, { requestType: 'Page' }, 'withPagedItems');
+  server.createList('request', 3, { requestType: 'Page' }, 'withPagedItems', 'withCallNumber');
 }

--- a/test/bigtest/tests/request-queue-test.js
+++ b/test/bigtest/tests/request-queue-test.js
@@ -11,6 +11,7 @@ import urls from '../../../src/routes/urls';
 
 describe('RequestQueue', () => {
   let requests;
+  const effectiveCallNumberString = 'prefix callNumber suffix volume enumeration chronology';
 
   const requestQueue = new RequestQueue();
 
@@ -24,6 +25,10 @@ describe('RequestQueue', () => {
 
     await requestQueue.whenSortableListPresent();
     await requestQueue.sortableList.whenLogIsPresent();
+  });
+
+  it('should display value in `Effective call number string` field', () => {
+    expect(requestQueue.itemCallNumber.value.text).to.equal(effectiveCallNumberString);
   });
 
   describe('Move request down in the queue', () => {


### PR DESCRIPTION
## Purpose
Display effective call number string on the dedicated request queue page. [Story](https://issues.folio.org/browse/UIREQ-372).

### Screenshots
**Item data**
![Item_data](https://user-images.githubusercontent.com/49517355/75986853-7d479e00-5ef7-11ea-83cd-3c353f92242c.png)

**Call number string**
![Call_number_string](https://user-images.githubusercontent.com/49517355/75986981-ba139500-5ef7-11ea-8686-a9383648cc5b.png)
