### PR TITLE
UIREQ-427: Add 'Load more' button at the end of the results list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add possibility for render all available tokens on pick slip. Fixes UICIRC-416.
 * Make disabling `Export hold shelf clearance report` for `CurrentServicePoint` not depending on filter results. Fixes UIREQ-395.
 * Fix link to `ui-users` from request details screen. Fixes UIREQ-424.
+* Add 'Load more' button at the end of the results list. Fixes UIREQ-427.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -83,12 +83,13 @@ class RequestsRoute extends React.Component {
       initialValue: { sort: 'Request date' },
     },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
+    resultOffset: { initialValue: 0 },
     records: {
       type: 'okapi',
       path: 'circulation/requests',
       records: 'requests',
-      recordsRequired: '%{resultCount}',
-      perRequest: 30,
+      resultOffset: '%{resultOffset}',
+      perRequest: 100,
       throwErrors: false,
       GET: {
         params: {
@@ -812,6 +813,8 @@ class RequestsRoute extends React.Component {
             newRecordPerms="ui-requests.create"
             renderFilters={this.renderFilters}
             onFilterChange={this.handleFilterChange}
+            pageAmount={100}
+            pagingType="click"
           />
         </div>
       </>


### PR DESCRIPTION
## Purpose
Add 'Load more' button at the end of the results list. [Story](https://issues.folio.org/browse/UIREQ-427).

### Screenshot
![Screen Shot 2020-03-06 at 19 25 44](https://user-images.githubusercontent.com/49517355/76107849-2ec2fe00-5fe2-11ea-8c91-4415f056c5f2.png)
