### PR TITLE
UIREQ-426: Fix the ability to change service point for open page re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Display effective call number string on the request queue page. Refs UIREQ-372.
 * Upgrade to `stripes` `v3.0.0`.
 * Correctly handle multiple sequential 'cancel' requests. Refs UIREQ-417.
+* Fix the ability to change service point for open page request. Fixes UIREQ-426.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -122,7 +122,7 @@ class RequestForm extends React.Component {
     super(props);
 
     const { request } = props;
-    const { requester, item, loan } = (request || {});
+    const { requester, requesterId, item, loan } = (request || {});
 
     this.state = {
       accordions: {
@@ -132,7 +132,7 @@ class RequestForm extends React.Component {
       },
       proxy: {},
       selectedItem: item,
-      selectedUser: requester,
+      selectedUser: { ...requester, id: requesterId },
       selectedLoan: loan,
       blocked: false,
       ...this.getDefaultRequestPreferences(),
@@ -322,13 +322,18 @@ class RequestForm extends React.Component {
   }
 
   getDefaultRequestPreferences() {
+    const {
+      request,
+      initialValues,
+    } = this.props;
+
     return {
       hasDelivery: false,
       requestPreferencesLoaded: false,
       defaultDeliveryAddressTypeId: '',
-      defaultServicePointId: '',
-      deliverySelected: isDelivery(this.props.initialValues),
-      selectedAddressTypeId: this.props.initialValues.deliveryAddressTypeId || '',
+      defaultServicePointId: request?.pickupServicePointId || '',
+      deliverySelected: isDelivery(initialValues),
+      selectedAddressTypeId: initialValues.deliveryAddressTypeId || '',
     };
   }
 


### PR DESCRIPTION
## Purpose
Fix the ability to change service point for open page request. [Story](https://issues.folio.org/browse/UIREQ-426).

**What was done**
- fixed bug with transfer the id from 'requester' to 'selectedUser';
- set previously selected value in the 'Pickup Service Point' selector.

### Demo
![Change_service_point](https://user-images.githubusercontent.com/49517355/76948495-d78d2980-690f-11ea-8051-882b8f59c439.gif)
