### PR TITLE
UIREQ-433: Fix display of the request count on item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Upgrade to `stripes` `v3.0.0`.
 * Correctly handle multiple sequential 'cancel' requests. Refs UIREQ-417.
 * Fix the ability to change service point for open page request. Fixes UIREQ-426.
+* Fix display of the request count on item in the view and edit mode. Fixes UIREQ-433.
 
 ## [1.14.0](https://github.com/folio-org/ui-requests/tree/v1.14.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v1.13.0...v1.14.0)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -66,7 +66,10 @@ const ItemDetail = ({ item, loan, requestCount }) => {
             {loan && loan.dueDate ? <FormattedDate value={loan.dueDate} /> : '-'}
           </KeyValue>
         </Col>
-        <Col xs={4}>
+        <Col
+          data-test-requests-on-item
+          xs={4}
+        >
           <KeyValue label={<FormattedMessage id="ui-requests.item.requestsOnItem" />}>
             {positionLink}
           </KeyValue>

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -450,8 +450,9 @@ class RequestsRoute extends React.Component {
       const requester = get(users, 'users[0]', null);
       const requestCount = get(requests, 'totalRecords', 0);
       return {
-        ...requester,
-        ...requestCount,
+        ...r,
+        requester,
+        requestCount,
       };
     });
   }

--- a/test/bigtest/interactors/edit-request.js
+++ b/test/bigtest/interactors/edit-request.js
@@ -5,11 +5,13 @@ import {
   selectable,
   isPresent,
   is,
+  scoped,
 } from '@bigtest/interactor';
 
 import CancelRequestDialog from './cancel-request-dialog';
 import HeaderDropdownMenu from './header-dropdown-menu';
 import HeaderDropdown from './header-dropdown';
+import KeyValue from './KeyValue';
 
 @interactor class EditRequests {
   fillRequestExpirationDateField = fillable('#requestExpirationDate');
@@ -20,6 +22,7 @@ import HeaderDropdown from './header-dropdown';
   cancelRequestDialog = new CancelRequestDialog('[data-test-cancel-request-modal]');
   isLayerPresent = isPresent('[class*=LayerRoot][role=dialog]');
   fulfillmentPreferenceFieldDisabled = is('[data-test-fulfillment-preference-filed]', ':disabled');
+  requestsOnItem = scoped('[data-test-requests-on-item] div', KeyValue);
 }
 
 export default EditRequests;

--- a/test/bigtest/interactors/view-request.js
+++ b/test/bigtest/interactors/view-request.js
@@ -2,6 +2,7 @@ import {
   clickable,
   interactor,
   isPresent,
+  scoped,
 } from '@bigtest/interactor';
 
 import CancelRequestDialog from './cancel-request-dialog';
@@ -11,6 +12,7 @@ import HeaderDropdown from './header-dropdown';
 import HeaderDropdownMenu from './header-dropdown-menu';
 import ItemAccordion from './item-accordion';
 import MoveToSecondPositionDialog from './move-to-second-position-dialog';
+import KeyValue from './KeyValue';
 
 import { contains } from './helpers';
 
@@ -26,6 +28,7 @@ import { contains } from './helpers';
   requesterSectionPresent = isPresent('#requester-info');
   requesterInfoContains = contains('#requester-info');
   requestInfoContains = contains('#request-info');
+  requestsOnItem = scoped('[data-test-requests-on-item] div', KeyValue);
 
   itemAccordionClick = clickable('#accordion-toggle-button-item-info');
 }

--- a/test/bigtest/network/factories/request.js
+++ b/test/bigtest/network/factories/request.js
@@ -10,6 +10,7 @@ export default Factory.extend({
   requestDate: () => faker.date.past().toISOString().substring(0, 10),
   status: () => 'Open - Not yet filled',
   position: (i) => i + 1,
+  requestCount: (i) => i + 1,
   fulfilmentPreference: 'Hold Shelf',
   pickupServicePointId: 'servicepointId1',
   holdShelfExpirationDate: '2017-01-20',

--- a/test/bigtest/tests/edit-request-test.js
+++ b/test/bigtest/tests/edit-request-test.js
@@ -14,19 +14,24 @@ import { requestStatuses } from '../../../src/constants';
 describe('Edit Request page', () => {
   setupApplication();
 
+  const requestsOnItemValue = '2';
+
   const EditRequestInteractor = new EditRequest();
   const ViewRequestInteractor = new ViewRequest();
 
   beforeEach(async function () {
-    this.visit('/requests/view/requestId0?layer=edit');
+    const request = this.server.create('request', { requestCount: requestsOnItemValue });
+
+    this.visit(`/requests/view/${request.id}?layer=edit`);
   });
 
-  describe('Request edit layer', function () {
-    it('layer exists', function () {
-      expect(EditRequestInteractor.isLayerPresent).to.be.true;
-    });
+  it('layer exists', () => {
+    expect(EditRequestInteractor.isLayerPresent).to.be.true;
   });
 
+  it('should display a number of requests on item', () => {
+    expect(EditRequestInteractor.requestsOnItem.value.text).to.equal(requestsOnItemValue);
+  });
 
   describe('clicking cancel editing button', function () {
     beforeEach(async () => {

--- a/test/bigtest/tests/view-request-test.js
+++ b/test/bigtest/tests/view-request-test.js
@@ -13,12 +13,19 @@ import NewRequestInteractor from '../interactors/new-request';
 describe('View request page', () => {
   setupApplication();
 
+  const requestsOnItemValue = '3';
+
   const viewRequest = new ViewRequestInteractor();
   const newRequest = new NewRequestInteractor();
 
   describe('View default request', () => {
     beforeEach(async function () {
-      this.visit('/requests/view/requestId0');
+      const request = this.server.create('request', { requestCount: requestsOnItemValue });
+      this.visit(`/requests/view/${request.id}`);
+    });
+
+    it('should display a number of requests on item', () => {
+      expect(viewRequest.requestsOnItem.value.text).to.equal(requestsOnItemValue);
     });
 
     describe('cancel request', function () {


### PR DESCRIPTION
## Purpose
Fix display of the request count on the item in the view and edit mode. Story [UIREQ-433](https://issues.folio.org/browse/UIREQ-433).

- fixed a bug from PR #501 that accidentally removed the request attributes from the object returned by addRequestFields;
- added tests for 'Requests on item' field.

### Screenshots
**View mode**
![Screen Shot 2020-03-21 at 10 47 11](https://user-images.githubusercontent.com/49517355/77223488-bde51f80-6b65-11ea-9a8e-5cd4aba6e6be.png)

**Edit mode**
![Screen Shot 2020-03-21 at 10 43 58](https://user-images.githubusercontent.com/49517355/77223498-d6edd080-6b65-11ea-8982-4308734d5e43.png)

