### PR TITLE
CHAL-91 show "Load more" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.12.2",
+    "@folio/stripes": "~2.12.2",
     "@folio/stripes-cli": "^1.6.0",
     "@folio/stripes-core": "~3.11.2",
     "babel-eslint": "^9.0.0",
@@ -172,7 +172,7 @@
     "react-barcode": "^1.3.2"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.12.2",
+    "@folio/stripes": "~2.12.2",
     "react": "*",
     "react-router": "*",
     "react-router-dom": "*"

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.0.0",
+    "@folio/stripes": "^2.12.2",
     "@folio/stripes-cli": "^1.6.0",
     "@folio/stripes-core": "^3.0.1",
     "babel-eslint": "^9.0.0",
@@ -172,7 +172,7 @@
     "react-barcode": "^1.3.2"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.9.0",
+    "@folio/stripes": "^2.12.2",
     "react": "*",
     "react-router": "*",
     "react-router-dom": "*"

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@folio/eslint-config-stripes": "^3.2.1",
     "@folio/stripes": "^2.12.2",
     "@folio/stripes-cli": "^1.6.0",
-    "@folio/stripes-core": "^3.0.1",
+    "@folio/stripes-core": "~3.11.2",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
@@ -179,5 +179,8 @@
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^1.1.0"
+  },
+  "resolutions": {
+    "@folio/stripes-core": "~3.11.2"
   }
 }

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -104,12 +104,13 @@ class RequestsRoute extends React.Component {
       initialValue: { sort: 'Request Date' },
     },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
+    resultOffset: { initialValue: 0 },
     records: {
       type: 'okapi',
       path: 'circulation/requests',
       records: 'requests',
-      recordsRequired: '%{resultCount}',
-      perRequest: 30,
+      resultOffset: '%{resultOffset}',
+      perRequest: 100,
       throwErrors: false,
       GET: {
         params: {
@@ -758,6 +759,8 @@ class RequestsRoute extends React.Component {
             }}
             viewRecordPerms="ui-requests.view"
             newRecordPerms="ui-requests.create"
+            pageAmount={100}
+            pagingType="click"
           />
         </div>
       </React.Fragment>


### PR DESCRIPTION
Replace infinite scroll with a "Load more" button in the results list.
Infinite scroll can behave poorly when results lists are long.

Refs [CHAL-91](https://issues.folio.org/browse/CHAL-91)