### PR TITLE
UIREQ-415: Paneheader Actions updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## [2.0.2] (IN PROGRESS)
+
+* Paneheader Actions updates. Refs UIREQ-415.
+
 ## [2.0.1](https://github.com/folio-org/ui-requests/tree/v2.0.1) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v2.0.0...v2.0.1)
 

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -322,16 +322,6 @@ class ViewRequest extends React.Component {
             )}
           </FormattedMessage>
         }
-        {!isRequestClosed &&
-          <IfPermission perm="ui-requests.edit">
-            <PaneHeaderIconButton
-              icon="edit"
-              id="clickable-edit-request"
-              style={{ visibility: !request ? 'hidden' : 'visible' }}
-              href={editLink}
-              onClick={onEdit}
-            />
-          </IfPermission> }
       </PaneMenu>
     );
   }

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -716,10 +716,8 @@ class RequestsRoute extends React.Component {
           <Button
             buttonStyle="dropdownItem"
             id="clickable-newrequest"
-            onClick={() => {
-              onToggle();
-            }}
             to={`${this.props.location.pathname}?layer=create`}
+            onClick={onToggle}
           >
             <FormattedMessage id="stripes-smart-components.new" />
           </Button>
@@ -780,7 +778,6 @@ class RequestsRoute extends React.Component {
         }
         <div data-test-request-instances>
           <SearchAndSort
-            onCreate={this.create}
             hasNewButton={false}
             actionMenu={actionMenu}
             packageInfo={packageInfo}
@@ -808,6 +805,7 @@ class RequestsRoute extends React.Component {
             resultsFormatter={resultsFormatter}
             newRecordInitialValues={InitialValues}
             massageNewRecord={this.massageNewRecord}
+            onCreate={this.create}
             onCloseNewRecord={this.handleCloseNewRecord}
             parentResources={resources}
             parentMutator={mutator}

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -16,6 +16,7 @@ import { SubmissionError } from 'redux-form';
 import {
   AppIcon,
   stripesConnect,
+  IfPermission,
 } from '@folio/stripes/core';
 import { Button } from '@folio/stripes/components';
 import { makeQueryFunction, SearchAndSort } from '@folio/stripes/smart-components';
@@ -711,6 +712,18 @@ class RequestsRoute extends React.Component {
 
     const actionMenu = ({ onToggle }) => (
       <>
+        <IfPermission perm="ui-requests.create">
+          <Button
+            buttonStyle="dropdownItem"
+            id="clickable-newrequest"
+            onClick={() => {
+              onToggle();
+            }}
+            to={`${this.props.location.pathname}?layer=create`}
+          >
+            <FormattedMessage id="stripes-smart-components.new" />
+          </Button>
+        </IfPermission>
         <Button
           buttonStyle="dropdownItem"
           id="exportToCsvPaneHeaderBtn"
@@ -767,6 +780,8 @@ class RequestsRoute extends React.Component {
         }
         <div data-test-request-instances>
           <SearchAndSort
+            onCreate={this.create}
+            hasNewButton={false}
             actionMenu={actionMenu}
             packageInfo={packageInfo}
             objectName="request"
@@ -793,7 +808,6 @@ class RequestsRoute extends React.Component {
             resultsFormatter={resultsFormatter}
             newRecordInitialValues={InitialValues}
             massageNewRecord={this.massageNewRecord}
-            onCreate={this.create}
             onCloseNewRecord={this.handleCloseNewRecord}
             parentResources={resources}
             parentMutator={mutator}

--- a/test/bigtest/interactors/header-dropdown-menu.js
+++ b/test/bigtest/interactors/header-dropdown-menu.js
@@ -11,6 +11,7 @@ import {
   clickDelete = clickable('[data-test-delete-request]');
   clickDuplicate = clickable('#duplicate-request');
   clickEdit = clickable('#clickable-edit-request');
+  clickNew = clickable('#clickable-newrequest');
   clickExportToCSV = clickable('#exportToCsvPaneHeaderBtn');
   clickExportExpiredHoldsToCSV = clickable('#exportExpiredHoldsToCsvPaneHeaderBtn');
   isExportExpiredHoldsToCSVDisabled = property('#exportExpiredHoldsToCsvPaneHeaderBtn', 'disabled');

--- a/test/bigtest/tests/all-requests-test.js
+++ b/test/bigtest/tests/all-requests-test.js
@@ -48,4 +48,15 @@ describe('Requests', () => {
       expect(requests.instance.isVisible).to.equal(true);
     });
   });
+
+  describe('clicking on New button', () => {
+    beforeEach(async function () {
+      await requests.headerDropdown.click();
+      await requests.headerDropdownMenu.clickNew();
+    });
+
+    it('should redirect on create request page', function () {
+      expect(this.location.search).to.include('layer=create');
+    });
+  });
 });


### PR DESCRIPTION
# Description
Paneheader Actions updates

- Replace `New` button into `Actions` dropdown menu

- Remove `Edit` icon 

# Link
https://issues.folio.org/browse/UIREQ-415
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/78048958-206ac680-7383-11ea-85ad-023abd8774d2.png)

**After**
![image](https://user-images.githubusercontent.com/55694637/78049027-35475a00-7383-11ea-9820-b7a95e688430.png)
