### PR TITLE
UIREQ-371 - No warning or error message when creating a request for user with no barcode

### DIFF
--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -55,7 +55,7 @@
   "errors.onlyCheckedOutForRecall": "Only checked out items can be recalled",
   "errors.onlyCheckedOutForHold": "Only checked out items can be held",
   "errors.selectItem": "Please select an item",
-  "errors.selectUser": "Please select a requester",
+  "errors.selectUser": "Please select a requester with the barcode",
 
   "actions.edit": "Edit",
   "actions.editRequestLink": "Edit Request Dialog",


### PR DESCRIPTION
# Purpose
Change validation message for select user field

# Link
https://issues.folio.org/browse/UIREQ-371

# Screenshot
<img width="1674" alt="Screen Shot 2020-04-08 at 12 52 42" src="https://user-images.githubusercontent.com/43472449/78770961-0f7c0f80-7998-11ea-9376-4dbe386779aa.png">
