### PR TITLE
UIREQ-451: Restore the ability to view 'Block details' from "Patron b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Paneheader Actions updates. Refs UIREQ-415.
 * Add ability to create a request with the requester without barcode. Fixes UIREQ-444.
 * Fix export to CSV. Fixes UIREQ-453.
+* Restore the ability to view 'Block details' from "Patron blocked from requesting" modal. Fixes UIREQ-451.
 
 ## [2.0.1](https://github.com/folio-org/ui-requests/tree/v2.0.1) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v2.0.0...v2.0.1)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -118,6 +118,10 @@ class RequestsRoute extends React.Component {
     patronGroups: {
       type: 'okapi',
       path: 'groups',
+      params: {
+        query: 'cql.allRecords=1 sortby group',
+        limit: '200',
+      },
       records: 'usergroups',
     },
     servicePoints: {


### PR DESCRIPTION
## Purpose

Due to the default `limit` in the query parameters of `patronGroups`, when creating a request for an item in `RequestForm` only the first 10 `patronGroup` records were fetching. Thus, most requests had the `patronGroup` property as `undefined`.

The value of `limit` has been increased to `200` as in the `UserSearchContainer` component of `ui-users` module.


https://issues.folio.org/browse/UIREQ-451