### PR TITLE
UIREQ-456: Omit proxyUserId from duplicated properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [2.1.0] (IN PROGRESS)
 * Paneheader Actions updates. Refs UIREQ-415.
 * Add ability to create a request with the requester without barcode. Fixes UIREQ-444.
-* Fix bug causing spurious form saves after proxy selection. Fixes UIREQ-449, UIREQ-454.
+* Fix bug causing spurious form saves after proxy selection. Fixes UIREQ-449, UIREQ-454, UIREQ-455.
+* Prevent error on duplicating request with proxy requester. Fixes UIREQ-456.
 * Change requester background color on `Request detail` page to increase color contrast. Refs UIREQ-438. 
 * Fix export to CSV. Fixes UIREQ-453.
 * Restore the ability to view 'Block details' from "Patron blocked from requesting" modal. Fixes UIREQ-451.

--- a/src/utils.js
+++ b/src/utils.js
@@ -107,6 +107,7 @@ export function duplicateRequest(request) {
     'requester',
     'item',
     'pickupServicePoint',
+    'proxyUserId'
   ]);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -107,7 +107,7 @@ export function duplicateRequest(request) {
     'requester',
     'item',
     'pickupServicePoint',
-    'proxyUserId'
+    'proxyUserId',
   ]);
 }
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-456

Copying the proxyUserId when duplicating a request that has a proxy user causes an error when trying to save the new request.