### PR TITLE
UIREQ-455: Set correct service point default for proxy sponsors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [2.1.0] (IN PROGRESS)
 * Paneheader Actions updates. Refs UIREQ-415.
 * Add ability to create a request with the requester without barcode. Fixes UIREQ-444.
-* Fix bug causing spurious form saves after proxy selection. Fixes UIREQ-449, UIREQ-454, UIREQ-455.
+* Fix bug causing spurious form saves after proxy selection. Fixes UIREQ-449, UIREQ-454.
 * Prevent error on duplicating request with proxy requester. Fixes UIREQ-456.
+* Set correct service point default for proxy sponsors. Fixes UIREQ-455.
 * Change requester background color on `Request detail` page to increase color contrast. Refs UIREQ-438. 
 * Fix export to CSV. Fixes UIREQ-453.
 * Restore the ability to view 'Block details' from "Patron blocked from requesting" modal. Fixes UIREQ-451.

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -295,7 +295,8 @@ class RequestForm extends React.Component {
     }
   }
 
-  // Executed when user is selected from the proxy dialog
+  // Executed when a user is selected from the proxy dialog,
+  // regardless of whether the selection is "self" or an actual proxy
   onSelectProxy(proxy) {
     const { selectedUser } = this.state;
 
@@ -306,6 +307,7 @@ class RequestForm extends React.Component {
       this.setState({ selectedUser, proxy });
       this.props.change('requesterId', proxy.id);
       this.props.change('proxyUserId', selectedUser.id);
+      this.findRequestPreferences(proxy.id);
     }
   }
 
@@ -366,7 +368,6 @@ class RequestForm extends React.Component {
     try {
       const { requestPreferences } = await findResource('requestPreferences', userId, 'userId');
       const preferences = requestPreferences[0];
-
       const requestPreference = {
         ...this.getDefaultRequestPreferences(),
         ...pick(preferences, ['defaultDeliveryAddressTypeId', 'defaultServicePointId']),


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-455

This PR fixes an issue when creating new requests for proxy users: the pickup service point was not being populated for sponsors who had a specified service point preference.