### PR TITLE
UIREQ-390: Prevent requests for Withdrawn items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix export to CSV. Fixes UIREQ-453.
 * Restore the ability to view 'Block details' from "Patron blocked from requesting" modal. Fixes UIREQ-451.
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
+* Prevent requests on for items with the status Withdrawn. Refs UIREQ-390.
 
 ## [2.0.1](https://github.com/folio-org/ui-requests/tree/v2.0.1) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v2.0.0...v2.0.1)

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,7 @@ export const requestStatuses = {
 export const itemStatuses = {
   PAGED: 'Paged',
   DECLARED_LOST: 'Declared lost',
+  WITHDRAWN: 'Withdrawn',
 };
 
 export const requestTypesMap = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -129,6 +129,10 @@ export function isDeclaredLostItem(item) {
   return get(item, 'status.name') === itemStatuses.DECLARED_LOST;
 }
 
+export function isWithdrawnItem(item) {
+  return get(item, 'status.name') === itemStatuses.WITHDRAWN;
+}
+
 export function isDelivery(request) {
   return get(request, 'fulfilmentPreference') === fulfilmentTypeMap.DELIVERY;
 }

--- a/test/bigtest/interactors/new-request.js
+++ b/test/bigtest/interactors/new-request.js
@@ -7,12 +7,13 @@ import {
   fillable,
   triggerable,
   selectable,
+  scoped,
 } from '@bigtest/interactor';
 
 import { getSelectValues } from './helpers';
 import HeaderDropdown from './header-dropdown';
 import InputField from './input-field';
-
+import KeyValue from './KeyValue';
 
 @interactor class NewRequest {
   pressEnter = triggerable('keydown', {
@@ -58,6 +59,8 @@ import InputField from './input-field';
 
   itemErrorIsPresent = isPresent('#section-item-info [class*=feedbackError---]');
   requesterErrorIsPresent = isPresent('#section-requester-info [class*=feedbackError---]');
+
+  requestType = scoped('[data-test-request-type] div', KeyValue);
 
   whenReady() {
     return this.when(() => this.itemBarcodeIsPresent);

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -16,6 +16,13 @@ import NewRequest from '../interactors/new-request';
 import RequestsInteractor from '../interactors/requests-interactor';
 import ViewRequest from '../interactors/view-request';
 
+import translations from '../../../translations/ui-requests/en';
+
+const itemStatuses = [
+  'Declared lost',
+  'Withdrawn',
+];
+
 describe('New Request page', () => {
   setupApplication({
     modules: [{
@@ -383,47 +390,54 @@ describe('New Request page', () => {
       });
     });
 
-    describe('New request for declared lost item', function () {
-      beforeEach(async function () {
-        const item = this.server.create('item', {
-          status: { name: 'Declared lost' },
-        });
-
-        await newRequest.itemField.fillAndBlur(item.barcode);
-        await errorModalInteractor.whenModalIsPresent();
-      });
-
-      it('shows declare lost error dialog', () => {
-        expect(errorModalInteractor.modalIsPresent).to.equal(true);
-      });
-
-      describe('Close declare lost error dialog', () => {
+    itemStatuses.forEach(status => {
+      describe(`New request for ${status} item`, function () {
         beforeEach(async function () {
-          await errorModalInteractor.whenModalIsPresent();
-          await errorModalInteractor.clickCloseBtn();
-        });
+          const item = this.server.create('item', {
+            status: { name: status },
+          });
 
-        it('closes lost error dialog', () => {
-          expect(errorModalInteractor.modalIsPresent).to.equal(false);
-        });
-      });
-
-      describe('Show declare lost error dialog on submit', () => {
-        beforeEach(async function () {
-          const user = this.server.create('user');
-
-          await errorModalInteractor.whenModalIsPresent();
-          await errorModalInteractor.clickCloseBtn();
-          await newRequest.userField.fillAndBlur(user.barcode);
-          await newRequest.clickNewRequest();
+          await newRequest.itemField.fillAndBlur(item.barcode);
           await errorModalInteractor.whenModalIsPresent();
         });
 
-        it('shows declare lost error dialog', () => {
+        it(`should show ${status} error dialog`, () => {
           expect(errorModalInteractor.modalIsPresent).to.equal(true);
+        });
+
+        describe(`closing ${status} error dialog`, () => {
+          beforeEach(async function () {
+            await errorModalInteractor.whenModalIsPresent();
+            await errorModalInteractor.clickCloseBtn();
+          });
+
+          it(`should close ${status} error dialog`, () => {
+            expect(errorModalInteractor.modalIsPresent).to.equal(false);
+          });
+
+          it('should display a message in request type field', () => {
+            expect(newRequest.requestType.value.text).to.equal(translations.noRequestTypesAvailable);
+          });
+        });
+
+        describe(`submitting New request for ${status} item form`, () => {
+          beforeEach(async function () {
+            const user = this.server.create('user');
+
+            await errorModalInteractor.whenModalIsPresent();
+            await errorModalInteractor.clickCloseBtn();
+            await newRequest.userField.fillAndBlur(user.barcode);
+            await newRequest.clickNewRequest();
+            await errorModalInteractor.whenModalIsPresent();
+          });
+
+          it(`should show ${status} error dialog`, () => {
+            expect(errorModalInteractor.modalIsPresent).to.equal(true);
+          });
         });
       });
     });
+
 
     describe('New request with prefilled user barcode and item barcode', function () {
       beforeEach(async function () {

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -178,6 +178,6 @@
   "filters.requestStatus.notYetFilled": "Open - Not yet filled",
 
   "noRequestTypesAvailable": "No request types available for selected item",
-  "declaredLost.title": "Item cannot be requested",
-  "declaredLost.message": "{title} ({materialType}) (Barcode: {barcode}) has the item status <strong>Declared lost</strong> and cannot be requested."
+  "errorModal.title": "Item cannot be requested",
+  "errorModal.message": "{title} ({materialType}) (Barcode: {barcode}) has the item status <strong>{itemStatus}</strong> and cannot be requested."
 }


### PR DESCRIPTION
## Purpose
Prevent requests for items with the status `Withdrawn`. Story [UIREQ-390](https://issues.folio.org/browse/UIREQ-390).

### Approach
Since the prevention of requests for items with the status `Declared lost` and `Withdrawn` is performed in a similar way, the code was refactored to use one functionality in both cases.

### Screenshot
![Screen Shot 2020-05-07 at 15 30 36](https://user-images.githubusercontent.com/49517355/81304101-4a4f9100-9085-11ea-9975-22eb9b7caa4e.png)
