### PR TITLE
UIREQ-304:  Missing Instance title from the Moving Request popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.0.0] IN PROGRESS
 
 * Upgrade to `stripes` `4.0`, `react-intl` `4.5`. Refs STRIPES-672.
+* Fixed label in move hold modal to whow item title.  Fixes UIREQ-304.:
 
 ## [2.1.0] (IN PROGRESS)
 * Paneheader Actions updates. Refs UIREQ-415.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [3.0.0] IN PROGRESS
 
 * Upgrade to `stripes` `4.0`, `react-intl` `4.5`. Refs STRIPES-672.
-* Fixed label in move hold modal to whow item title.  Fixes UIREQ-304.:
+* Fixed label in move hold modal to show item title.  Fixes UIREQ-304.
 
 ## [2.1.0] (IN PROGRESS)
 * Paneheader Actions updates. Refs UIREQ-415.

--- a/src/MoveRequestDialog.js
+++ b/src/MoveRequestDialog.js
@@ -165,6 +165,7 @@ class MoveRequestDialog extends React.Component {
       onClose,
       open,
       moveInProgress,
+      request,
     } = this.props;
     const {
       items,
@@ -172,6 +173,7 @@ class MoveRequestDialog extends React.Component {
     } = this.state;
     const contentData = orderBy(items, 'requestQueue');
     const count = items.length;
+    const title = request.item.title;
 
     return (
       <Modal
@@ -183,7 +185,7 @@ class MoveRequestDialog extends React.Component {
         dismissible
       >
         <Pane
-          paneTitle={<FormattedMessage id="ui-requests.moveRequest.instanceItems" />}
+          paneTitle={<FormattedMessage id="ui-requests.moveRequest.instanceItems" values={{ title }} />}
           paneSub={<FormattedMessage id="ui-requests.resultCount" values={{ count }} />}
           defaultWidth="fill"
           noOverflow

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -123,7 +123,7 @@
   "cancel.additionalInfoPlaceholderRequired": "Enter more information about the cancellation (required)",
   "cancel.additionalInfoPlaceholderOptional": "Enter more information about the cancellation (optional)",
   "moveRequest.selectItem": "Select item",
-  "moveRequest.instanceItems": "Other items in instance",
+  "moveRequest.instanceItems": "Other items in {title}",
   "moveRequest.instanceItems.notFound": "No items found",
   "moveRequest.requestTypeChangeHeading": "Current requests type not allowed for selected item",
   "moveRequest.requestTypeChangeMessage": "Request will be converted to <strong>{requestType}</strong>.",


### PR DESCRIPTION
The label in question had a static placeholder in the translation file for the
item title.  I replaced this with a variable, and passed in the item title from the
modal render function.  Once this change propagates out to all the translation
files, they should start showing the item title in the modal.

Refs: https://issues.folio.org/browse/UIREQ-304