### PR TITLE
UIREQ-304 force update of en_* locales

### DIFF
--- a/translations/ui-requests/en_GB.json
+++ b/translations/ui-requests/en_GB.json
@@ -128,7 +128,7 @@
     "loanType": "Loan type",
     "actions.moveRequest": "Move request",
     "moveRequest.selectItem": "Select item",
-    "moveRequest.instanceItems": "Other items in instance",
+    "moveRequest.instanceItems": "Other items in {title}",
     "moveRequest.instanceItems.notFound": "No items found",
     "moveRequest.requestTypeChangeHeading": "Current requests type not allowed for selected item",
     "moveRequest.requestTypeChangeMessage": "Request will be converted to <strong>{requestType}</strong>.",

--- a/translations/ui-requests/en_SE.json
+++ b/translations/ui-requests/en_SE.json
@@ -128,7 +128,7 @@
     "loanType": "Loan type",
     "actions.moveRequest": "Move request",
     "moveRequest.selectItem": "Select item",
-    "moveRequest.instanceItems": "Other items in instance",
+    "moveRequest.instanceItems": "Other items in {title}",
     "moveRequest.instanceItems.notFound": "No items found",
     "moveRequest.requestTypeChangeHeading": "Current requests type not allowed for selected item",
     "moveRequest.requestTypeChangeMessage": "Request will be converted to <strong>{requestType}</strong>.",

--- a/translations/ui-requests/en_US.json
+++ b/translations/ui-requests/en_US.json
@@ -128,7 +128,7 @@
     "loanType": "Loan type",
     "actions.moveRequest": "Move request",
     "moveRequest.selectItem": "Select item",
-    "moveRequest.instanceItems": "Other items in instance",
+    "moveRequest.instanceItems": "Other items in {title}",
     "moveRequest.instanceItems.notFound": "No items found",
     "moveRequest.requestTypeChangeHeading": "Current requests type not allowed for selected item",
     "moveRequest.requestTypeChangeMessage": "Request will be converted to <strong>{requestType}</strong>.",


### PR DESCRIPTION
FOLIO-2630 is preventing changes from propagating to `en_*` locales;
this does that manually for the changes requested in UIREQ-304 (#583).

Refs [UIREQ-304](https://issues.folio.org/browse/UIREQ-304), [FOLIO-2630](https://issues.folio.org/browse/FOLIO-2630)