### PR TITLE
increment plugin-find-instance to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 3.0.1 (IN PROGRESS)
+
+* Increment `@folio/plugin-find-user` to `v3.0` for `@folio/stripes` `v4` compatibility.
+
 ## [3.0.0](https://github.com/folio-org/ui-requests/tree/v3.0.0) (2020-06-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v2.0.1...v3.0.0)
 

--- a/package.json
+++ b/package.json
@@ -183,6 +183,6 @@
     "react-router-dom": "^4.0.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^2.0.0"
+    "@folio/plugin-find-user": "^3.0.0"
   }
 }


### PR DESCRIPTION
Increment `@folio/plugin-find-user` version to `^3` for
compatibility with `@folio/stripes` `4.0`.