### PR TITLE
UIREQ-458: Request staff notes: Assign/Unassign Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.1.0](IN PROGRESS)
 
 * Add staff notes accordion to request details page. Refs UIREQ-457.
+* Request staff notes: Assign/Unassign Notes. Refs UIREQ-458.
 
 ## [3.0.1](https://github.com/folio-org/ui-requests/tree/v3.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v3.0.0...v3.0.1)

--- a/test/bigtest/interactors/view-request.js
+++ b/test/bigtest/interactors/view-request.js
@@ -6,7 +6,10 @@ import {
 } from '@bigtest/interactor';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { NotesAccordion } from '@folio/stripes-smart-components/lib/Notes/NotesSmartAccordion/tests/interactors';
+import {
+  NotesAccordion,
+  NotesModal,
+} from '@folio/stripes-smart-components/lib/Notes/NotesSmartAccordion/tests/interactors';
 
 import CancelRequestDialog from './cancel-request-dialog';
 import MoveRequestDialog from './move-request-dialog';
@@ -33,6 +36,7 @@ import { contains } from './helpers';
   requestInfoContains = contains('#request-info');
   requestsOnItem = scoped('[data-test-requests-on-item] div', KeyValue);
   staffNotesAccordion = new NotesAccordion('#staff-notes');
+  notesModal = new NotesModal();
 
   itemAccordionClick = clickable('#accordion-toggle-button-item-info');
 }

--- a/test/bigtest/tests/view-request-test.js
+++ b/test/bigtest/tests/view-request-test.js
@@ -100,6 +100,16 @@ describe('View request page', () => {
         expect(this.location.pathname).to.equal('/requests/notes/new');
       });
     });
+
+    describe('when click assign / unassign button', () => {
+      beforeEach(async () => {
+        await viewRequest.staffNotesAccordion.clickAssignButton();
+      });
+
+      it('should open popup "Assign / Unassign note"', () => {
+        expect(viewRequest.notesModal.isDisplayed).to.be.true;
+      });
+    });
   });
 
   describe.skip('View delivery request', () => {

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -114,8 +114,9 @@
   "requester.patronGroup.group": "Requester patron group",
   "tags.tagList": "Tags",
 
-  "notes.StaffNotes": "Staff notes",
+  "notes.staffNotes": "Staff notes",
   "notes.newStaffNote": "New staff note",
+  "notes.entityType.request": "Request",
 
   "cancel.cancelRequest": "Cancel request",
   "cancel.modalLabel": "Confirm request cancellation",


### PR DESCRIPTION
## Description

All needed functionality already provided in [PR](https://github.com/folio-org/ui-requests/pull/590) 
Also here just add test for 'assign / unassign' button

## Issue

[UIREQ-458](https://issues.folio.org/browse/UIREQ-458)

## Screenshot
![image](https://user-images.githubusercontent.com/55701515/85545687-d82b0f80-b624-11ea-804c-0b830f6ee7c6.png)
