### PR TITLE
PERF-62 use == for more efficient queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add staff notes accordion to request details page. Refs UIREQ-457.
 * Request staff notes: Assign/Unassign Notes. Refs UIREQ-458.
+* Use `==` for more efficient queries. Refs PERF-62.
 
 ## [3.0.1](https://github.com/folio-org/ui-requests/tree/v3.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v3.0.0...v3.0.1)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -145,7 +145,7 @@ class RequestsRoute extends React.Component {
     patronBlocks: {
       type: 'okapi',
       records: 'manualblocks',
-      path: 'manualblocks?query=userId=%{activeRecord.patronId}',
+      path: 'manualblocks?query=userId==%{activeRecord.patronId}',
       DELETE: {
         path: 'manualblocks/%{activeRecord.blockId}',
       },


### PR DESCRIPTION
Use `==` instead of `=` for more efficient queries.

Refs [PERF-62](https://issues.folio.org/browse/PERF-62)