### PR TITLE
UIREQ-486: add permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
           "automated-patron-blocks.collection.get",
           "circulation.requests.item.post",
           "circulation-storage.requests.item.post",
+          "circulation.pick-slips.get",
           "inventory-storage.locations.item.get"
         ],
         "visible": true


### PR DESCRIPTION
# Description
Add missing permission for creating request through `duplicate`
# Issue
https://issues.folio.org/browse/UIREQ-486