### PR TITLE
UITAG-29 provide tag-related permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Increment `@folio/stripes` to `v5` for `react-router` `v5.2`.
 * Fix the ability to sort by the `Request Date` column. Fixes UIREQ-481.
 * Request staff notes: View assigned notes. Refs UIREQ-467.
+* Include tag-related permissions in `ui-users.edit` permission. Refs UITAG-29.
 
 ## [3.0.1](https://github.com/folio-org/ui-requests/tree/v3.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v3.0.0...v3.0.1)

--- a/package.json
+++ b/package.json
@@ -129,7 +129,9 @@
           "circulation.requests.item.put",
           "circulation-storage.requests.collection.delete",
           "circulation-storage.requests.item.put",
-          "circulation-storage.requests.item.delete"
+          "circulation-storage.requests.item.delete",
+          "tags.collection.get",
+          "tags.item.post"
         ],
         "visible": true
       }


### PR DESCRIPTION
The tag-management component would display but throw errors because
there was no way to assign tag-related permissions in the UI. The
interaction between tag-CRUD permissions and entity-CRUD permissions can
be confusing and the `<Tags>` component does not, at present, handle
discrepancies between them.

Refs [UITAG-29](https://issues.folio.org/browse/UITAG-29)