### PR TITLE
UIREQ-484: Use item id instead of barcode for links on request details screen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Request staff notes: View assigned notes. Refs UIREQ-467.
 * Include tag-related permissions in `ui-users.edit` permission. Refs UITAG-29.
 * Request staff notes: Edit note details. Refs UIREQ-460.
+* Use item id instead of barcode for links on request details screen. Fixes UIREQ-484.
 
 ## [3.0.1](https://github.com/folio-org/ui-requests/tree/v3.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v3.0.0...v3.0.1)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -18,7 +18,7 @@ const ItemDetail = ({ item, loan, requestCount }) => {
   const contributor = get(item, ['contributorNames', '0', 'name'], '-');
 
   const positionLink = (
-    <Link to={`/requests?filters=${openRequestStatusFilters}&query=${item.barcode || item.id}&sort=Request Date`}>
+    <Link to={`/requests?filters=${openRequestStatusFilters}&query=${item.id}&sort=Request Date`}>
       {requestCount}
     </Link>
   );

--- a/src/PositionLink.js
+++ b/src/PositionLink.js
@@ -9,8 +9,7 @@ import { openRequestStatusFilters } from './utils';
 export default function PositionLink({ request }) {
   const queuePosition = get(request, 'position');
   const barcode = get(request, 'item.barcode');
-
-  const openRequestsPath = `/requests?filters=${openRequestStatusFilters}&query=${request.item.barcode}&sort=Request Date`;
+  const openRequestsPath = `/requests?filters=${openRequestStatusFilters}&query=${request.itemId}&sort=Request Date`;
 
   return (request && barcode ?
     <div>


### PR DESCRIPTION
The support for item ids was already there so this turned out to be a quick fix.

https://issues.folio.org/browse/UIREQ-484