### PR TITLE
UIREQ-499: Use patron group name instead of description in displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Request staff notes: Edit note details. Refs UIREQ-460.
 * Use item id instead of barcode for links on request details screen. Fixes UIREQ-484.
 * Refactor to `miragejs` from `@bigtest/mirage`.
+* Use patron group name ('group') instead of description in displays. Fixes UIREQ-499.
 
 ## [3.0.1](https://github.com/folio-org/ui-requests/tree/v3.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v3.0.0...v3.0.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -1083,7 +1083,7 @@ class RequestForm extends React.Component {
                           user={request ? request.requester : selectedUser}
                           stripes={this.props.stripes}
                           request={request}
-                          patronGroup={get(patronGroup, 'desc')}
+                          patronGroup={patronGroup?.group}
                           deliverySelected={deliverySelected}
                           fulfilmentPreference={fulfilmentPreference}
                           deliveryAddress={addressDetail}

--- a/src/UserDetail.js
+++ b/src/UserDetail.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -43,7 +42,7 @@ class UserDetail extends React.Component {
     let proxyId;
     if (proxy) {
       proxyName = getFullName(proxy);
-      proxyBarcode = _.get(proxy, ['barcode'], '-');
+      proxyBarcode = proxy?.barcode || '-';
       proxyId = proxy.id || request.proxyUserId;
     }
 
@@ -58,13 +57,13 @@ class UserDetail extends React.Component {
           <Col xs={4}>
             <KeyValue
               label={<FormattedMessage id="ui-requests.requester.patronGroup.group" />}
-              value={patronGroup.desc || '-'}
+              value={patronGroup.group || '-'}
             />
           </Col>
           <Col xs={4}>
             <KeyValue
               label={<FormattedMessage id="ui-requests.requester.fulfilmentPref" />}
-              value={_.get(request, ['fulfilmentPreference'], '-')}
+              value={request?.fulfilmentPreference || '-'}
             />
           </Col>
           <Col xs={4}>

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -121,7 +120,7 @@ class UserForm extends React.Component {
     let proxyId;
     if (proxy) {
       proxyName = getFullName(proxy);
-      proxyBarcode = get(proxy, ['barcode'], '-');
+      proxyBarcode = proxy?.barcode || '-';
       proxyId = proxy.id;
     }
 

--- a/src/views/RequestQueueView.js
+++ b/src/views/RequestQueueView.js
@@ -80,8 +80,8 @@ const formatter = {
   pickup: r => get(r, 'pickupServicePoint.name') ||
     ((r.deliveryType) ? <FormattedMessage id="ui-requests.requestQueue.deliveryType" values={{ type: r.deliveryType }} /> : '-'),
   requester: r => getFullName(r.requester),
-  requesterBarcode: r => get(r, 'requester.barcode', '-'),
-  patronGroup: r => get(r, 'requester.patronGroup.desc', '-'),
+  requesterBarcode: r => r?.requester?.barcode || '-',
+  patronGroup: r => r?.requester?.patronGroup?.group || '-',
   requestDate: r => (<FormattedTime value={r.requestDate} day="numeric" month="numeric" year="numeric" />),
   requestExpirationDate: r => (r.requestExpirationDate ? <FormattedDate value={r.requestExpirationDate} /> : '-'),
   holdShelfExpireDate: r => (r.holdShelfExpirationDate ? <FormattedDate value={r.holdShelfExpirationDate} /> : '-'),


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-499

In several places in the app, a requester's patron group was being shown using the group description rather than the actual group name (the 'group' value, confusingly). Now we'll use the group name, making all those nondescript groups a little more visible.