### PR TITLE
UIREQ-510 html-encode strings for react-to-print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add loading indicator when service point is switched. Fixes UIREQ-508.
 * Use patron group name ('group') instead of description in displays. Fixes UIREQ-499.
 * Improve performance issues with preview for print pick slips. Fixes UIREQ-507.
+* Escape values passed to `react-to-print`. Fixes UIREQ-510.
 
 ## [3.0.1](https://github.com/folio-org/ui-requests/tree/v3.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v3.0.0...v3.0.1)

--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
-    "entities": "^2.0.0",
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.14",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
+    "entities": "^2.0.0",
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.14",

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,8 @@ import {
 import queryString from 'query-string';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { encodeHTML } from 'entities';
+
 import {
   Col,
   Headline,
@@ -166,7 +168,7 @@ export function buildTemplate(template = '') {
   return dataSource => {
     return template.replace(/{{([^{}]*)}}/g, (token, tokenName) => {
       const tokenValue = dataSource[tokenName];
-      return typeof tokenValue === 'string' || typeof tokenValue === 'number' ? tokenValue : '';
+      return typeof tokenValue === 'string' || typeof tokenValue === 'number' ? encodeHTML(tokenValue) : '';
     });
   };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import {
+  escape,
   get,
   isEmpty,
   isObject,
@@ -10,7 +11,6 @@ import {
 import queryString from 'query-string';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { encodeHTML } from 'entities';
 
 import {
   Col,
@@ -168,7 +168,7 @@ export function buildTemplate(template = '') {
   return dataSource => {
     return template.replace(/{{([^{}]*)}}/g, (token, tokenName) => {
       const tokenValue = dataSource[tokenName];
-      return typeof tokenValue === 'string' || typeof tokenValue === 'number' ? encodeHTML(tokenValue) : '';
+      return typeof tokenValue === 'string' || typeof tokenValue === 'number' ? escape(tokenValue) : '';
     });
   };
 }


### PR DESCRIPTION
Values passed to `react-to-print` need to be escaped because of the way
it generates its document under the hood. Without escaping, if we passed
a value like `something<bad>very bad`, this would cause React to blow up
when slips were generated with an error like
```
ERROR:Failed to execute 'createElement' on 'Document':The tag name
provided ('bad') is not a valid name.
```

Refs [UIREQ-510](https://issues.folio.org/browse/UIREQ-510)