### PR TITLE
STRIPES-693 Apply columnwidths API to MCL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Escape values passed to `react-to-print`. Fixes UIREQ-510.
 * Block requests for Aged to lost items. Refs UIREQ-429.
 * Create filter for Requests - Pickup service point. Refs UIREQ-516.
+* Use MultiColumnList columnwidths API to shrink column widths - Fixes UIREQ-521.
 
 ## [3.0.1](https://github.com/folio-org/ui-requests/tree/v3.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v3.0.0...v3.0.1)

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "mocha": "^5.2.0",
     "react": "^16.5.1",
     "react-dom": "^16.5.1",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
@@ -185,7 +185,7 @@
   "peerDependencies": {
     "@folio/stripes": "^5.0.0",
     "react": "*",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -825,8 +825,12 @@ class RequestsRoute extends React.Component {
               'proxy',
             ]}
             columnWidths={{
-              [requestDate]: '220px',
-              [title]: '40%'
+              requestDate: { max: 165 },
+              title: { max: 300 },
+              position: { max: 100 },
+              requestType: { max: 101 },
+              itemBarcode: { max: 115 },
+              type: { max: 100 }
             }}
             columnMapping={this.columnLabels}
             resultsFormatter={resultsFormatter}

--- a/src/views/RequestQueueView.js
+++ b/src/views/RequestQueueView.js
@@ -50,14 +50,14 @@ const COLUMN_NAMES = [
 ];
 
 const COLUMN_WIDTHS = {
-  position: '5%',
-  requestType: '5%',
-  status: '11%',
-  pickup: '9%',
-  requester: '15%',
-  requesterBarcode: '12%',
-  patronGroup: '13%',
-  requestDate: '11%',
+  position: { max: 74 },
+  requestType: { max: 101 },
+  status: { max: 198 },
+  pickup: { max: 133 },
+  requester: { max: 223 },
+  requesterBarcode: { max: 178 },
+  patronGroup: { max: 190 },
+  requestDate: { max: 180 },
   requestExpirationDate: '8%',
   holdShelfExpireDate: '13%',
 };


### PR DESCRIPTION
In the spirit of sparing *some horizontal space... This almost knocked off a whole column width from the example data...

## Before
![Requests-before](https://user-images.githubusercontent.com/20704067/92957728-a27d1200-f42e-11ea-8ebc-82c0b84a5112.png)

## After
![Requests-updated](https://user-images.githubusercontent.com/20704067/92957749-ac9f1080-f42e-11ea-8d13-28ed324c38c4.png)

