### PR TITLE
UIREQ-535 update plugins for stripes v5 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 4.0.1 IN PROGRESS
+
+* Update plugins to `stripes v5`-compatible versions. Refs UIREQ-535.
+
 ## [4.0.0](https://github.com/folio-org/ui-requests/tree/v4.0.0) (2020-10-14)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v3.0.1...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -190,6 +190,6 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^3.0.0"
+    "@folio/plugin-find-user": "^4.0.0"
   }
 }


### PR DESCRIPTION
Apps and plugins must depend on the same versions of peer dependencies.

Refs [UIREQ-535](https://issues.folio.org/browse/UIREQ-535)