### PR TITLE
UIREQ-532: Omit HoldShelfExpirationDate field in duplicated request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0 (IN PROGRESS)
 
 * Add timepicker for hold shelf expiration date. Refs UIREQ-381.
+* Omit `holdShelfExpirationDate` field in duplicated request. Refs UIREQ-532.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/utils.js
+++ b/src/utils.js
@@ -110,6 +110,7 @@ export function duplicateRequest(request) {
     'item',
     'pickupServicePoint',
     'proxyUserId',
+    'holdShelfExpirationDate',
   ]);
 }
 


### PR DESCRIPTION
# Description
When new request is created as duplicate of existing request, then `HoldShelfExpirationDate` field should NOT be duplicated.
# Issue
https://issues.folio.org/browse/UIREQ-532