### PR TITLE
UIREQ-542: Fix search by tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 ## 5.0.0 (IN PROGRESS)
 
 * Add timepicker for hold shelf expiration date. Refs UIREQ-381.
-<<<<<<< HEAD
 * Omit `holdShelfExpirationDate` field in duplicated request. Refs UIREQ-532.
-=======
 * Fix sorting by request status. Fixes UIREQ-540.
->>>>>>> dc735788387be845b1b5396ec876fee96353831b
+* Fix search by tags. Fixes UIREQ-542.
+
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/components/RequestsFilters/RequestsFiltersConfig.js
+++ b/src/components/RequestsFilters/RequestsFiltersConfig.js
@@ -20,6 +20,7 @@ export default [
     name: 'tags',
     cql: 'tags.tagList',
     values: [],
+    operator: '=',
   },
   {
     name: requestFilterTypes.PICKUP_SERVICE_POINT,


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-542

It looks like due to this change:

https://github.com/folio-org/stripes-components/pull/1368

the searching by tags stopped working because `tags.tagList` only works with `=`.

