### PR TITLE
UIREQ-541: Increase limit to display all items in Move request modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix sorting by request status. Fixes UIREQ-540.
 * Fix search by tags. Fixes UIREQ-542.
 * Fix default pickup service point when editing existing request. Fixes UIREQ-544.
+* Increase the limit to display all items in the `Move request` modal. Fixes UIREQ-541.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/MoveRequestDialog.css
+++ b/src/MoveRequestDialog.css
@@ -1,4 +1,5 @@
 .content {
   padding: 0px;
   margin: 0px;
+  height: calc(100vh-45px);
 }

--- a/src/MoveRequestDialog.js
+++ b/src/MoveRequestDialog.js
@@ -143,7 +143,7 @@ class MoveRequestDialog extends React.Component {
     const query = holdings.map(h => `holdingsRecordId==${h.id}`).join(' or ');
     items.reset();
 
-    return items.GET({ params: { query } });
+    return items.GET({ params: { query, limit: 1000 } });
   }
 
   fetchRequests(items) {
@@ -195,6 +195,7 @@ class MoveRequestDialog extends React.Component {
             <MultiColumnList
               id="instance-items-list"
               interactive
+              autosize
               ariaLabel={<FormattedMessage id="ui-requests.moveRequest.instanceItems" />}
               contentData={contentData}
               visibleColumns={COLUMN_NAMES}


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-541

### Purpose
Since the modal became scrollable after increasing the limit, it had to change the styles to be able to see all items in it.