### PR TITLE
UIREQ-552: Fix the non-responsive design of Move request modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix search by tags. Fixes UIREQ-542.
 * Fix default pickup service point when editing existing request. Fixes UIREQ-544.
 * Increase the limit to display all items in the `Move request` modal. Fixes UIREQ-541.
+* Fix the non-responsive design of the `Move request` modal. Fixes UIREQ-552.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/MoveRequestDialog.css
+++ b/src/MoveRequestDialog.css
@@ -1,5 +1,4 @@
 .content {
   padding: 0px;
   margin: 0px;
-  height: calc(100vh-45px);
 }

--- a/src/MoveRequestDialog.js
+++ b/src/MoveRequestDialog.js
@@ -47,6 +47,8 @@ const formatter = {
   loanType: item => (item.temporaryLoanType ? get(item, 'temporaryLoanType.name', '') : get(item, 'permanentLoanType.name', '')),
 };
 
+const MAX_HEIGHT = 500;
+
 class MoveRequestDialog extends React.Component {
   static manifest = {
     holdings: {
@@ -195,13 +197,13 @@ class MoveRequestDialog extends React.Component {
             <MultiColumnList
               id="instance-items-list"
               interactive
-              autosize
               ariaLabel={<FormattedMessage id="ui-requests.moveRequest.instanceItems" />}
               contentData={contentData}
               visibleColumns={COLUMN_NAMES}
               columnMapping={COLUMN_MAP}
               columnWidths={COLUMN_WIDTHS}
               formatter={formatter}
+              maxHeight={MAX_HEIGHT}
               isEmptyMessage={<FormattedMessage id="ui-requests.moveRequest.instanceItems.notFound" />}
               onRowClick={(_, item) => this.onRowClick(item)}
             /> }


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-552

### Purpose
This PR fixes a bug that came up after #661 when the modal window styles were changed to implement scrolling.