### PR TITLE
await request details pane

### DIFF
--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -26,7 +26,7 @@ const itemStatuses = [
   'Aged to lost',
 ];
 
-describe('New Request page', () => {
+describe.only('New Request page', () => {
   setupApplication({
     modules: [{
       type: 'plugin',
@@ -127,8 +127,10 @@ describe('New Request page', () => {
           .fillUserBarcode('9676761472501')
           .clickUserEnterBtn();
 
+        await newRequest.chooseFulfillmentPreference('Hold Shelf');
         await newRequest.chooseServicePoint('Circ Desk 2');
         await newRequest.clickNewRequest();
+        await viewRequest.isPresent;
       });
 
       it('should create a new request and open view request pane', () => {
@@ -152,9 +154,11 @@ describe('New Request page', () => {
           .fillItemBarcode('9676761472500')
           .clickItemEnterBtn();
         await newRequest.clickAddUser();
+        await newRequest.chooseFulfillmentPreference('Hold Shelf');
         await newRequest.whenServicePointIsPresent();
         await newRequest.chooseServicePoint('Circ Desk 2');
         await newRequest.clickNewRequest();
+        await viewRequest.isPresent;
       });
 
       it('should create a new request and open view request pane', () => {
@@ -196,6 +200,7 @@ describe('New Request page', () => {
         await newRequest.chooseFulfillmentPreference('Delivery');
         await newRequest.chooseDeliveryAddress('Claim');
         await newRequest.clickNewRequest();
+        await viewRequest.isPresent;
       });
 
       it('should create a new request and open view request pane', () => {


### PR DESCRIPTION
Failing tests in #668 appear to be timing related, failing to await the
display of the request-details pane (or running out of time before it
displays). Wish I knew why this started showing up all of a sudden, but
here we are.