### PR TITLE
UIREQ-496 - Patron block modal for Requesting should display up to 3 blocks, with Automated Patron Blocks on top of Manual Patron Blocks

### DIFF
--- a/src/PatronBlockModal.js
+++ b/src/PatronBlockModal.js
@@ -10,7 +10,7 @@ import {
 } from '@folio/stripes/components';
 
 const PatronBlockModal = ({ open, onClose, patronBlocks, automatedPatronBlocks, viewUserPath }) => {
-  const blocks = take(orderBy(patronBlocks, ['metadata.updatedDate'], ['desc']), 3);
+  const blocks = take(orderBy(patronBlocks, ['metadata.updatedDate'], ['desc']), 1);
   const renderBlocks = blocks.map(block => {
     return (
       <Row>
@@ -49,8 +49,8 @@ const PatronBlockModal = ({ open, onClose, patronBlocks, automatedPatronBlocks, 
           :
         </Col>
       </Row>
-      {renderBlocks}
       {renderAutomatedPatronBlocks}
+      {renderBlocks}
       <br />
       <Row>
         <Col xs={8}>{(patronBlocks.length > 3) && <FormattedMessage id="ui-requests.additionalReasons" />}</Col>


### PR DESCRIPTION
# Purpose
- change blocks order
- show only one manual block on the modal

# Link
https://issues.folio.org/browse/UIREQ-496

# Screenshot
<img width="1680" alt="Screen Shot 2020-11-20 at 09 28 21" src="https://user-images.githubusercontent.com/43472449/99772328-3c3dfb00-2b13-11eb-8ff3-26c84cc82184.png">
