### PR TITLE
UIREQ-558: Retrieve requests to items in chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add a toast notification for CSV search results export. Refs UIREQ-555.
 * Increase the limit to display correct number of requests in the `Move request` modal. Fixes UIREQ-566.
 * Allow for duplicating a closed request. Fixes UIREQ-553.
+* Retrieve requests to items in chunks. Fixes UIREQ-558.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/MoveRequestDialog.js
+++ b/src/MoveRequestDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { countBy, get, orderBy, chunk, flatten } from 'lodash';
+import { countBy, get, orderBy, chunk } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -10,7 +10,6 @@ import {
 } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 import { Loading } from './components';
-import { eachPromise } from './utils';
 
 import css from './MoveRequestDialog.css';
 
@@ -120,7 +119,7 @@ class MoveRequestDialog extends React.Component {
     const holdings = await this.fetchHoldings();
     let items = await this.fetchItems(holdings);
     const requests = await this.fetchRequests(items);
-    const requestMap = countBy(flatten(requests), 'itemId');
+    const requestMap = countBy(requests, 'itemId');
     const { request } = this.props;
 
     items = items
@@ -165,6 +164,7 @@ class MoveRequestDialog extends React.Component {
       query = `(${query}) and (status="Open")`;
 
       requests.reset();
+      // eslint-disable-next-line no-await-in-loop
       const result = await requests.GET({ params: { query, limit: 1000 } });
 
       data.push(...result);

--- a/src/MoveRequestDialog.js
+++ b/src/MoveRequestDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { countBy, get, orderBy, chunk } from 'lodash';
+import { countBy, get, orderBy, chunk, flatten } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -10,6 +10,7 @@ import {
 } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 import { Loading } from './components';
+import { eachPromise } from './utils';
 
 import css from './MoveRequestDialog.css';
 
@@ -119,7 +120,7 @@ class MoveRequestDialog extends React.Component {
     const holdings = await this.fetchHoldings();
     let items = await this.fetchItems(holdings);
     const requests = await this.fetchRequests(items);
-    const requestMap = countBy(requests, 'itemId');
+    const requestMap = countBy(flatten(requests), 'itemId');
     const { request } = this.props;
 
     items = items

--- a/src/utils.js
+++ b/src/utils.js
@@ -263,9 +263,3 @@ export function formatNoteReferrerEntityData(data) {
     id,
   };
 }
-
-export function eachPromise(arr, fn) {
-  if (!Array.isArray(arr)) return Promise.reject(new Error('Array not found'));
-
-  return arr.reduce((acc, cur) => acc.then(response => fn(response, cur)), Promise.resolve([]));
-}

--- a/src/utils.js
+++ b/src/utils.js
@@ -263,3 +263,9 @@ export function formatNoteReferrerEntityData(data) {
     id,
   };
 }
+
+export function eachPromise(arr, fn) {
+  if (!Array.isArray(arr)) return Promise.reject(new Error('Array not found'));
+
+  return arr.reduce((acc, cur) => acc.then(response => fn(response, cur)), Promise.resolve([]));
+}


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-558

The problem for which this PR is addressed has the same origin as the problem described in [#974](https://github.com/folio-org/ui-users/pull/974). And the solution is the same.
The only difference is that chunks of 40 are used to retrieve open requests against items.