### PR TITLE
UIREQ-553: Allow for duplicating a closed request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add a 'working' indicator for CSV search results export. Fixes UIREQ-555.
 * Add a toast notification for CSV search results export. Refs UIREQ-555.
 * Increase the limit to display correct number of requests in the `Move request` modal. Fixes UIREQ-566.
+* Allow for duplicating a closed request. Fixes UIREQ-553.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -395,7 +395,22 @@ class ViewRequest extends React.Component {
 
     const actionMenu = ({ onToggle }) => {
       if (isRequestClosed) {
-        return undefined;
+        return (
+          <IfPermission perm="ui-requests.create">
+            <Button
+              id="duplicate-request"
+              onClick={() => {
+                onToggle();
+                this.props.onDuplicate(request);
+              }}
+              buttonStyle="dropdownItem"
+            >
+              <Icon icon="duplicate">
+                <FormattedMessage id="ui-requests.actions.duplicateRequest" />
+              </Icon>
+            </Button>
+          </IfPermission>
+        );
       }
 
       return (

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -746,11 +746,6 @@ class RequestsRoute extends React.Component {
     } = this.props;
 
     const {
-      requestDate,
-      title,
-    } = this.columnLabels;
-
-    const {
       csvReportPending,
       dupRequest,
       errorMessage,

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -26,7 +26,7 @@ const itemStatuses = [
   'Aged to lost',
 ];
 
-describe.only('New Request page', () => {
+describe('New Request page', () => {
   setupApplication({
     modules: [{
       type: 'plugin',

--- a/test/bigtest/tests/view-request-test.js
+++ b/test/bigtest/tests/view-request-test.js
@@ -185,17 +185,17 @@ describe('View request page', () => {
       expect(viewRequest.requestInfoContains('Item Not Available')).to.be.true;
       expect(viewRequest.requestInfoContains('Item not found')).to.be.true;
     });
-  });
 
-  describe('duplicate closed request', function () {
-    beforeEach(async () => {
-      await viewRequest.headerDropdown.click();
-      await viewRequest.headerDropdownMenu.clickDuplicate();
-      await newRequest.isPresent;
-    });
+    describe('duplicate closed request', function () {
+      beforeEach(async () => {
+        await viewRequest.headerDropdown.click();
+        await viewRequest.headerDropdownMenu.clickDuplicate();
+        await newRequest.isPresent;
+      });
 
-    it('opens request form', function () {
-      expect(this.location.search).to.include('layer=create');
+      it('opens request form', function () {
+        expect(this.location.search).to.include('layer=create');
+      });
     });
   });
 });

--- a/test/bigtest/tests/view-request-test.js
+++ b/test/bigtest/tests/view-request-test.js
@@ -175,6 +175,7 @@ describe('View request page', () => {
         fulfilmentPreference: 'Delivery',
         cancellationReasonId: cancellationReason.id,
         cancellationAdditionalInformation: 'Item not found',
+        status: 'Closed - Cancelled',
       });
 
       this.visit('/requests/view/' + request.id);
@@ -183,6 +184,18 @@ describe('View request page', () => {
     it('shows cancellation reason', () => {
       expect(viewRequest.requestInfoContains('Item Not Available')).to.be.true;
       expect(viewRequest.requestInfoContains('Item not found')).to.be.true;
+    });
+  });
+
+  describe('duplicate closed request', function () {
+    beforeEach(async () => {
+      await viewRequest.headerDropdown.click();
+      await viewRequest.headerDropdownMenu.clickDuplicate();
+      await newRequest.isPresent;
+    });
+
+    it('opens request form', function () {
+      expect(this.location.search).to.include('layer=create');
     });
   });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-553

Allow for duplicating a closed request.

![closed_request](https://user-images.githubusercontent.com/63545/100116542-dd91bd80-2e41-11eb-93ce-2bc3924ec9cc.png)
