### PR TITLE
UIREQ-566: Increase limit to display correct number of requests in Mo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix the non-responsive design of the `Move request` modal. Fixes UIREQ-552.
 * Add a 'working' indicator for CSV search results export. Fixes UIREQ-555.
 * Add a toast notification for CSV search results export. Refs UIREQ-555.
+* Increase the limit to display correct number of requests in the `Move request` modal. Fixes UIREQ-566.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/MoveRequestDialog.js
+++ b/src/MoveRequestDialog.js
@@ -154,7 +154,7 @@ class MoveRequestDialog extends React.Component {
     query = `(${query}) and (status="Open")`;
     requests.reset();
 
-    return requests.GET({ params: { query } });
+    return requests.GET({ params: { query, limit: 1000 } });
   }
 
   async onRowClick(item) {


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-566

### Purpose
Since on `bugfest-honeysuckle` we already have instances containing over 100 items and all / most of those items may have a request (or requests) for them, it was decided to increase the limit to display the correct number of requests for each item in the `Move request` modal.