### PR TITLE
UIREQ-530: Add `Patron comments` field to request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Increase the limit to display correct number of requests in the `Move request` modal. Fixes UIREQ-566.
 * Allow for duplicating a closed request. Fixes UIREQ-553.
 * Retrieve requests to items in chunks. Fixes UIREQ-558.
+* Add `Patron comments` field to request. Refs UIREQ-530.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -40,6 +40,7 @@ import {
   Paneset,
   Row,
   Select,
+  TextArea,
   TextField,
   PaneFooter,
   Icon,
@@ -954,11 +955,11 @@ class RequestForm extends React.Component {
                     <this.props.metadataDisplay metadata={request.metadata} />
                   </Col> }
                 <Row>
-                  <Col xs={8}>
+                  <Col xs={12}>
                     <Row>
                       <Col
                         data-test-request-type
-                        xs={4}
+                        xs={3}
                       >
                         {!isEditForm && !selectedItem &&
                           <span data-test-request-type-message>
@@ -1007,14 +1008,14 @@ class RequestForm extends React.Component {
                             value={<FormattedMessage id="ui-requests.noRequestTypesAvailable" />}
                           /> }
                       </Col>
-                      <Col xs={3}>
+                      <Col xs={2}>
                         {isEditForm &&
                           <KeyValue
                             label={<FormattedMessage id="ui-requests.status" />}
                             value={request.status}
                           /> }
                       </Col>
-                      <Col xs={3}>
+                      <Col xs={2}>
                         <Field
                           name="requestExpirationDate"
                           label={<FormattedMessage id="ui-requests.requestExpirationDate" />}
@@ -1024,6 +1025,30 @@ class RequestForm extends React.Component {
                           id="requestExpirationDate"
                         />
                       </Col>
+                      <Col
+                        data-test-request-patron-comments
+                        xsOffset={1}
+                        xs={4}
+                      >
+                        {isEditForm
+                          ? (
+                            <KeyValue
+                              label={<FormattedMessage id="ui-requests.patronComments" />}
+                              value={request.patronComments}
+                            />
+                          )
+                          : (
+                            <Field
+                              name="patronComments"
+                              label={<FormattedMessage id="ui-requests.patronComments" />}
+                              id="patronComments"
+                              component={TextArea}
+                            />
+                          )
+                        }
+                      </Col>
+                    </Row>
+                    <Row>
                       {isEditForm && request.status === requestStatuses.AWAITING_PICKUP &&
                         <>
                           <Col xs={3}>

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -586,6 +586,16 @@ class ViewRequest extends React.Component {
                     value={request.cancellationAdditionalInformation}
                   />
                 </Col> }
+              <Col
+                data-test-request-patron-comments
+                xsOffset={3}
+                xs={6}
+              >
+                <KeyValue
+                  label={<FormattedMessage id="ui-requests.patronComments" />}
+                  value={request.patronComments}
+                />
+              </Col>
             </Row>
           </Accordion>
           <Accordion

--- a/test/bigtest/interactors/edit-request.js
+++ b/test/bigtest/interactors/edit-request.js
@@ -19,6 +19,8 @@ import KeyValue from './KeyValue';
   cancelRequestDialog = new CancelRequestDialog('[data-test-cancel-request-modal]');
   isLayerPresent = isPresent('[class*=LayerRoot][role=dialog]');
   fulfillmentPreferenceFieldDisabled = is('[data-test-fulfillment-preference-filed]', ':disabled');
+  patronComments = scoped('[data-test-request-patron-comments] div', KeyValue);
+  isPatronCommentsEditable = isPresent('[data-test-request-patron-comments] textarea');
   requestsOnItem = scoped('[data-test-requests-on-item] div', KeyValue);
   fillUserBarcode = fillable('[name="requester.barcode"]');
   clickUserEnterBtn = clickable('#clickable-select-requester');

--- a/test/bigtest/interactors/new-request.js
+++ b/test/bigtest/interactors/new-request.js
@@ -10,6 +10,8 @@ import {
   scoped,
 } from '@bigtest/interactor';
 
+import TextAreaInteractor from '@folio/stripes-components/lib/TextArea/tests/interactor'; // eslint-disable-line
+
 import { getSelectValues } from './helpers';
 import HeaderDropdown from './header-dropdown';
 import InputField from './input-field';
@@ -61,6 +63,7 @@ import KeyValue from './KeyValue';
   requesterErrorIsPresent = isPresent('#section-requester-info [class*=feedbackError---]');
 
   requestType = scoped('[data-test-request-type] div', KeyValue);
+  patronComments = new TextAreaInteractor('[class*=textArea---]');
 
   whenReady() {
     return this.when(() => this.itemBarcodeIsPresent);

--- a/test/bigtest/interactors/view-request.js
+++ b/test/bigtest/interactors/view-request.js
@@ -6,10 +6,10 @@ import {
 } from '@bigtest/interactor';
 import { isEmpty } from 'lodash';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   NotesAccordion,
   NotesModal,
+  // eslint-disable-next-line import/no-extraneous-dependencies
 } from '@folio/stripes-smart-components/lib/Notes/NotesSmartAccordion/tests/interactors';
 
 import CancelRequestDialog from './cancel-request-dialog';
@@ -35,6 +35,7 @@ import { contains } from './helpers';
   requesterSectionPresent = isPresent('#requester-info');
   requesterInfoContains = contains('#requester-info');
   requestInfoContains = contains('#request-info');
+  patronComments = scoped('[data-test-request-patron-comments] div', KeyValue);
   requestsOnItem = scoped('[data-test-requests-on-item] div', KeyValue);
   staffNotesAccordion = new NotesAccordion('#staff-notes');
   notesModal = new NotesModal();

--- a/test/bigtest/tests/edit-request-test.js
+++ b/test/bigtest/tests/edit-request-test.js
@@ -11,6 +11,8 @@ import EditRequest from '../interactors/edit-request';
 import ViewRequest from '../interactors/view-request';
 import { requestStatuses } from '../../../src/constants';
 
+import translations from '../../../translations/ui-requests/en';
+
 describe('Edit Request page', () => {
   setupApplication();
 
@@ -31,6 +33,14 @@ describe('Edit Request page', () => {
 
   it('should display a number of requests on item', () => {
     expect(EditRequestInteractor.requestsOnItem.value.text).to.equal(requestsOnItemValue);
+  });
+
+  it('should display a patron comments field', () => {
+    expect(EditRequestInteractor.patronComments.label.text).to.equal(translations.patronComments);
+  });
+
+  it('patron comments field should not be editable', () => {
+    expect(EditRequestInteractor.isPatronCommentsEditable).to.be.false;
   });
 
   describe('clicking cancel editing button', function () {

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -26,6 +26,8 @@ const itemStatuses = [
   'Aged to lost',
 ];
 
+const patronComment = 'I really need this in the next three days';
+
 describe('New Request page', () => {
   setupApplication({
     modules: [{
@@ -127,6 +129,7 @@ describe('New Request page', () => {
           .fillUserBarcode('9676761472501')
           .clickUserEnterBtn();
 
+        await newRequest.patronComments.fillAndBlur(patronComment);
         await newRequest.chooseFulfillmentPreference('Hold Shelf');
         await newRequest.chooseServicePoint('Circ Desk 2');
         await newRequest.clickNewRequest();
@@ -136,6 +139,10 @@ describe('New Request page', () => {
       it('should create a new request and open view request pane', () => {
         expect(viewRequest.requestSectionPresent).to.be.true;
         expect(viewRequest.requesterSectionPresent).to.be.true;
+      });
+
+      it('should display the patron comments', () => {
+        expect(viewRequest.patronComments.value.text).to.equal(patronComment);
       });
     });
 

--- a/test/bigtest/tests/view-request-test.js
+++ b/test/bigtest/tests/view-request-test.js
@@ -10,6 +10,8 @@ import setupApplication from '../helpers/setup-application';
 import ViewRequestInteractor from '../interactors/view-request';
 import NewRequestInteractor from '../interactors/new-request';
 
+import translations from '../../../translations/ui-requests/en';
+
 describe('View request page', () => {
   setupApplication();
 
@@ -28,6 +30,10 @@ describe('View request page', () => {
 
     it('should display a number of requests on item', () => {
       expect(viewRequest.requestsOnItem.value.text).to.equal(requestsOnItemValue);
+    });
+
+    it('should display a patron comments field', () => {
+      expect(viewRequest.patronComments.label.text).to.equal(translations.patronComments);
     });
 
     describe('cancel request', function () {

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -18,6 +18,7 @@
   "holdShelfExpirationDate": "Hold shelf expiration date",
   "holdShelfExpirationTime": "Hold shelf expiration time",
   "position": "Position in queue",
+  "patronComments": "Patron comments",
   "close": "Close",
   "blockedLabel": "Reason for block",
   "blockModal": "Patron blocked from requesting",


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-530

### Purpose
Add the `Patron comments` field to the `View`, `New`, and `Edit` request pages. Additionally, on the `Edit` page this field should be uneditable.