### PR TITLE
UIREQ-495: Show `lastCheckedInDateTime` token for staff slips in locale format and date/time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add `Patron comments` field to request. Refs UIREQ-530.
 * Fix fulfillment misspelling. Fixes UIREQ-567.
 * Add `Patron comments` field to search results CSV export. Refs UIREQ-549.
+* Show `lastCheckedInDateTime` token for staff slips in locale format and date/time. Refs UIREQ-495.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,7 @@ export function buildTemplate(template = '') {
   };
 }
 
-function buildLocaleDateAndTime(dateTime, timezone, locale) {
+export function buildLocaleDateAndTime(dateTime, timezone, locale) {
   return moment(dateTime)
     .tz(timezone)
     .locale(locale)

--- a/src/utils.js
+++ b/src/utils.js
@@ -179,7 +179,7 @@ function buildLocaleDateAndTime(dateTime, timezone, locale) {
   return moment(dateTime)
     .tz(timezone)
     .locale(locale)
-    .format('YYYY/MM/DD h:mm A');
+    .format('L LT');
 }
 
 export const convertToSlipData = (source, intl, timeZone, locale, slipName = 'Pick slip') => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -223,7 +223,7 @@ export const convertToSlipData = (source, intl, timeZone, locale, slipName = 'Pi
       'item.numberOfPieces': item.numberOfPieces,
       'item.descriptionOfPieces': item.descriptionOfPieces,
       'item.lastCheckedInDateTime': item.lastCheckedInDateTime
-        ? item.lastCheckedInDateTime && buildLocaleDateAndTime(item.lastCheckedInDateTime, timeZone, locale)
+        ? buildLocaleDateAndTime(item.lastCheckedInDateTime, timeZone, locale)
         : item.lastCheckedInDateTime,
       'item.fromServicePoint': item.fromServicePoint,
       'item.toServicePoint': item.toServicePoint,

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,7 @@ import {
 import queryString from 'query-string';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import moment from 'moment-timezone';
 
 import {
   Col,
@@ -29,7 +30,6 @@ import {
 } from './constants';
 
 import css from './requests.css';
-
 
 // eslint-disable-next-line import/prefer-default-export
 export function getFullName(user) {
@@ -175,6 +175,13 @@ export function buildTemplate(template = '') {
   };
 }
 
+function buildLocaleDateAndTime(dateTime, timezone, locale) {
+  return moment(dateTime)
+    .tz(timezone)
+    .locale(locale)
+    .format('YYYY/MM/DD h:mm A');
+}
+
 export const convertToSlipData = (source, intl, timeZone, locale, slipName = 'Pick slip') => {
   return source.map(pickSlip => {
     const {
@@ -215,7 +222,9 @@ export const convertToSlipData = (source, intl, timeZone, locale, slipName = 'Pi
       'item.loanType': item.loanType,
       'item.numberOfPieces': item.numberOfPieces,
       'item.descriptionOfPieces': item.descriptionOfPieces,
-      'item.lastCheckedInDateTime': item.lastCheckedInDateTime,
+      'item.lastCheckedInDateTime': item.lastCheckedInDateTime
+        ? item.lastCheckedInDateTime && buildLocaleDateAndTime(item.lastCheckedInDateTime, timeZone, locale)
+        : item.lastCheckedInDateTime,
       'item.fromServicePoint': item.fromServicePoint,
       'item.toServicePoint': item.toServicePoint,
       'item.effectiveLocationInstitution': item.effectiveLocationInstitution,

--- a/test/bigtest/tests/utils-test.js
+++ b/test/bigtest/tests/utils-test.js
@@ -12,6 +12,7 @@ import {
   isPagedItem,
   createUserHighlightBoxLink,
   formatNoteReferrerEntityData,
+  buildLocaleDateAndTime,
 } from '../../../src/utils';
 
 describe('utils', () => {
@@ -51,8 +52,8 @@ describe('utils', () => {
       formatMessage: () => ('formatMessage'),
       formatDate: () => ('formatDate'),
     };
-    const timeZone = '';
-    const locale = '';
+    const timeZone = 'America/New_York';
+    const locale = 'en-US';
     const item = {
       title: 'The Long Way to a Small, Angry Planet',
       barcode: '036000291452',
@@ -133,7 +134,7 @@ describe('utils', () => {
       'item.loanType': 'Can Circulate',
       'item.numberOfPieces': '3',
       'item.descriptionOfPieces': 'Description of three pieces',
-      'item.lastCheckedInDateTime': '2020-02-17T12:12:33.374Z',
+      'item.lastCheckedInDateTime': buildLocaleDateAndTime('2020-02-17T12:12:33.374Z', timeZone, locale),
       'item.effectiveLocationInstitution': 'Nottingham University',
       'item.effectiveLocationCampus': 'Jubilee Campus',
       'item.effectiveLocationLibrary': 'Djanogly Learning Resource Centre',


### PR DESCRIPTION
# Description
Show `lastCheckedInDateTime` token for staff slips in locale format and date/time instead of UTC (Zulu time)
# Issue
https://issues.folio.org/browse/UIREQ-495
# Screenshots
**Before**
![uireq-495-bef](https://user-images.githubusercontent.com/55694637/101778848-1ba70680-3afd-11eb-9ab6-87888da65c3a.png)
**After**
![uireq-495-after](https://user-images.githubusercontent.com/55694637/101778864-22357e00-3afd-11eb-9ea0-e4a05c029e53.png)
