### PR TITLE
UIREQ-496 - Patron block modal for Requesting should display up to 3 blocks, with Automated Patron Blocks on top of Manual Patron Blocks

### DIFF
--- a/src/PatronBlockModal.js
+++ b/src/PatronBlockModal.js
@@ -12,7 +12,7 @@ import {
 const PatronBlockModal = ({ open, onClose, patronBlocks, automatedPatronBlocks, viewUserPath }) => {
   const blocks = orderBy(patronBlocks, ['metadata.updatedDate'], ['desc']);
 
-  const bloclsToRender = take([...automatedPatronBlocks, ...blocks], 3).map(block => {
+  const blocksToRender = take([...automatedPatronBlocks, ...blocks], 3).map(block => {
     return (
       <Row>
         <Col xs>
@@ -41,7 +41,7 @@ const PatronBlockModal = ({ open, onClose, patronBlocks, automatedPatronBlocks, 
           :
         </Col>
       </Row>
-      {bloclsToRender}
+      {blocksToRender}
       <br />
       <Row>
         <Col xs={8}>{(patronBlocks.length > 3) && <FormattedMessage id="ui-requests.additionalReasons" />}</Col>

--- a/src/PatronBlockModal.js
+++ b/src/PatronBlockModal.js
@@ -1,4 +1,4 @@
-import { take, orderBy } from 'lodash';
+import { take, orderBy, isObject } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -10,21 +10,13 @@ import {
 } from '@folio/stripes/components';
 
 const PatronBlockModal = ({ open, onClose, patronBlocks, automatedPatronBlocks, viewUserPath }) => {
-  const blocks = take(orderBy(patronBlocks, ['metadata.updatedDate'], ['desc']), 1);
-  const renderBlocks = blocks.map(block => {
+  const blocks = orderBy(patronBlocks, ['metadata.updatedDate'], ['desc']);
+
+  const bloclsToRender = take([...automatedPatronBlocks, ...blocks], 3).map(block => {
     return (
       <Row>
         <Col xs>
-          <b>{block.desc || ''}</b>
-        </Col>
-      </Row>
-    );
-  });
-  const renderAutomatedPatronBlocks = automatedPatronBlocks.map(block => {
-    return (
-      <Row key={block}>
-        <Col xs>
-          <b>{block}</b>
+          <b>{ isObject(block) ? (block.desc || '') : block }</b>
         </Col>
       </Row>
     );
@@ -49,8 +41,7 @@ const PatronBlockModal = ({ open, onClose, patronBlocks, automatedPatronBlocks, 
           :
         </Col>
       </Row>
-      {renderAutomatedPatronBlocks}
-      {renderBlocks}
+      {bloclsToRender}
       <br />
       <Row>
         <Col xs={8}>{(patronBlocks.length > 3) && <FormattedMessage id="ui-requests.additionalReasons" />}</Col>


### PR DESCRIPTION
# Purpose
Display only 3 blocks at time.

# Link
https://issues.folio.org/browse/UIREQ-496

# Screenshot
<img width="1679" alt="Screen Shot 2020-12-18 at 14 03 33" src="https://user-images.githubusercontent.com/43472449/102612828-20416f80-413a-11eb-81ac-abb1cb152af3.png">
