### PR TITLE
UIREQ-496 - Patron block modal for Requesting should display up to 3 blocks, with Automated Patron Blocks on top of Manual Patron Blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add `Patron comments` field to search results CSV export and expired holds report. Refs UIREQ-549, UIREQ-550.
 * Show `lastCheckedInDateTime` token for staff slips in locale format and date/time. Refs UIREQ-495.
 * Barcode image not rendering on print slips. Refs UIREQ-570.
+* Patron block modal for Requesting should display up to 3 blocks, with Automated Patron Blocks on top of Manual Patron Blocks. Refs UIREQ-496.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/PatronBlockModal.js
+++ b/src/PatronBlockModal.js
@@ -10,9 +10,10 @@ import {
 } from '@folio/stripes/components';
 
 const PatronBlockModal = ({ open, onClose, patronBlocks, automatedPatronBlocks, viewUserPath }) => {
-  const blocks = orderBy(patronBlocks, ['metadata.updatedDate'], ['desc']);
+  const orderedPatronBlocks = orderBy(patronBlocks, ['metadata.updatedDate'], ['desc']);
+  const blocks = [...automatedPatronBlocks, ...orderedPatronBlocks];
 
-  const blocksToRender = take([...automatedPatronBlocks, ...blocks], 3).map(block => {
+  const blocksToRender = take(blocks, 3).map(block => {
     return (
       <Row>
         <Col xs>
@@ -44,7 +45,7 @@ const PatronBlockModal = ({ open, onClose, patronBlocks, automatedPatronBlocks, 
       {blocksToRender}
       <br />
       <Row>
-        <Col xs={8}>{(patronBlocks.length > 3) && <FormattedMessage id="ui-requests.additionalReasons" />}</Col>
+        <Col xs={8}>{(blocks.length > 3) && <FormattedMessage id="ui-requests.additionalReasons" />}</Col>
         <Col xs={4}>
           <Row end="xs">
             <Col>


### PR DESCRIPTION
# Purpose
Fix displaying of warning message for merged patron blocks.

# Link
https://issues.folio.org/browse/UIREQ-496

# Screenshot
<img width="1792" alt="Screen Shot 2021-01-13 at 10 31 47 AM" src="https://user-images.githubusercontent.com/43472449/104426404-9050e300-558a-11eb-8cfa-2609d5bc4a3d.png">
