### PR TITLE
UIREQ-570 - Barcode image does not render in print slips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fix fulfillment misspelling. Fixes UIREQ-567.
 * Add `Patron comments` field to search results CSV export and expired holds report. Refs UIREQ-549, UIREQ-550.
 * Show `lastCheckedInDateTime` token for staff slips in locale format and date/time. Refs UIREQ-495.
+* Barcode image not rendering on print slips. Refs UIREQ-570.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/utils.js
+++ b/src/utils.js
@@ -166,11 +166,20 @@ export const openRequestStatusFilters = [
   .map(status => `requestStatus.${status}`)
   .join(',');
 
+
+export const escapeValue = (val) => {
+  if (val.startsWith('<Barcode>') && val.endsWith('</Barcode>')) {
+    return val;
+  }
+  
+  return escape(val);
+};
+
 export function buildTemplate(template = '') {
   return dataSource => {
     return template.replace(/{{([^{}]*)}}/g, (token, tokenName) => {
       const tokenValue = dataSource[tokenName];
-      return typeof tokenValue === 'string' || typeof tokenValue === 'number' ? escape(tokenValue) : '';
+      return typeof tokenValue === 'string' || typeof tokenValue === 'number' ? escapeValue(tokenValue) : '';
     });
   };
 }

--- a/test/bigtest/tests/utils-test.js
+++ b/test/bigtest/tests/utils-test.js
@@ -9,6 +9,7 @@ import {
 
 import {
   convertToSlipData,
+  escapeValue,
   isPagedItem,
   createUserHighlightBoxLink,
   formatNoteReferrerEntityData,
@@ -193,6 +194,21 @@ describe('utils', () => {
 
     it('should return false when function gets uncorrect value', () => {
       expect(formatNoteReferrerEntityData(null)).to.be.false;
+    });
+  });
+
+  describe('escape value util', () => {
+    it('should return Barcode tag', () => {
+      const barcodeVal = '<Barcode>123456</Barcode>';
+
+      expect(escapeValue(barcodeVal)).to.equal(barcodeVal);
+    });
+
+    it('should return escaped values for non Barcode values', () => {
+      const passedValue = 'something<bad>very bad';
+      const expectedValue = 'something&lt;bad&gt;very bad';
+
+      expect(escapeValue(passedValue)).to.equal(expectedValue);
     });
   });
 });


### PR DESCRIPTION
# Purpose
Fix barcode displaying for print slips.

# Link
https://issues.folio.org/browse/UIREQ-570
