### PR TITLE
UIREQ-393: Prevent requests for 5 new item statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix duplicating request when item is changed. Fixes UIREQ-572.
 * Replace withRef with forwardRef. Refs STRIPES-721.
 * Add `Patron comments` to staff slip options. Refs UICIRC-523.
+* Prevent all request types for items with intellectual item, in process (non-requestable), long missing, unavailable, and unknown statuses. Refs UIREQ-393.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -67,12 +67,8 @@ import {
   toUserAddress,
   getPatronGroup,
   getRequestTypeOptions,
-  isAgedToLostItem,
   isDelivery,
-  isDeclaredLostItem,
-  isWithdrawnItem,
-  isClaimedReturned,
-  isLostAndPaidItem,
+  hasNonRequestableStatus,
 } from './utils';
 
 import css from './requests.css';
@@ -556,7 +552,7 @@ class RequestForm extends React.Component {
         // the slow loan and request lookups
         this.setState({ selectedItem: item });
 
-        if (this.shouldShowRequestTypeError(item)) {
+        if (hasNonRequestableStatus(item)) {
           this.showErrorModal();
         }
 
@@ -687,14 +683,6 @@ class RequestForm extends React.Component {
     return pristine || submitting;
   }
 
-  shouldShowRequestTypeError = (item) => {
-    return isDeclaredLostItem(item) ||
-      isWithdrawnItem(item) ||
-      isClaimedReturned(item) ||
-      isLostAndPaidItem(item) ||
-      isAgedToLostItem(item);
-  }
-
   onSave = (data) => {
     const {
       intl: {
@@ -714,7 +702,7 @@ class RequestForm extends React.Component {
 
     const { selectedItem } = this.state;
 
-    if (this.shouldShowRequestTypeError(selectedItem)) {
+    if (hasNonRequestableStatus(selectedItem)) {
       return this.showErrorModal();
     }
 
@@ -843,7 +831,7 @@ class RequestForm extends React.Component {
     const multiRequestTypesVisible = !isEditForm && selectedItem && requestTypeOptions.length > 1;
     const singleRequestTypeVisible = !isEditForm && selectedItem && requestTypeOptions.length === 1;
     const patronGroup = getPatronGroup(selectedUser, patronGroups);
-    const requestTypeError = this.shouldShowRequestTypeError(selectedItem);
+    const requestTypeError = hasNonRequestableStatus(selectedItem);
     const itemStatus = selectedItem?.status?.name;
 
     return (

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,12 +31,17 @@ export const requestStatuses = {
 };
 
 export const itemStatuses = {
-  PAGED: 'Paged',
-  DECLARED_LOST: 'Declared lost',
-  WITHDRAWN: 'Withdrawn',
-  CLAIMED_RETURNED: 'Claimed returned',
-  LOST_AND_PAID: 'Lost and paid',
   AGED_TO_LOST: 'Aged to lost',
+  CLAIMED_RETURNED: 'Claimed returned',
+  DECLARED_LOST: 'Declared lost',
+  IN_PROCESS_NON_REQUESTABLE: 'In process (non-requestable)',
+  INTELLECTUAL_ITEM: 'Intellectual item',
+  LONG_MISSING: 'Long missing',
+  LOST_AND_PAID: 'Lost and paid',
+  PAGED: 'Paged',
+  UNAVAILABLE: 'Unavailable',
+  UNKNOWN: 'Unknown',
+  WITHDRAWN: 'Withdrawn',
 };
 
 export const requestTypesMap = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 import {
   escape,
   get,
+  includes,
   isEmpty,
   isObject,
   omit,
@@ -125,24 +126,19 @@ export function isPagedItem(item) {
   return item?.status?.name === itemStatuses.PAGED;
 }
 
-export function isDeclaredLostItem(item) {
-  return item?.status?.name === itemStatuses.DECLARED_LOST;
-}
-
-export function isWithdrawnItem(item) {
-  return item?.status?.name === itemStatuses.WITHDRAWN;
-}
-
-export function isClaimedReturned(item) {
-  return item?.status?.name === itemStatuses.CLAIMED_RETURNED;
-}
-
-export function isLostAndPaidItem(item) {
-  return item?.status?.name === itemStatuses.LOST_AND_PAID;
-}
-
-export function isAgedToLostItem(item) {
-  return item?.status?.name === itemStatuses.AGED_TO_LOST;
+export function hasNonRequestableStatus(item) {
+  return includes([
+    itemStatuses.AGED_TO_LOST,
+    itemStatuses.CLAIMED_RETURNED,
+    itemStatuses.DECLARED_LOST,
+    itemStatuses.INTELLECTUAL_ITEM,
+    itemStatuses.IN_PROCESS_NON_REQUESTABLE,
+    itemStatuses.LONG_MISSING,
+    itemStatuses.LOST_AND_PAID,
+    itemStatuses.UNAVAILABLE,
+    itemStatuses.UNKNOWN,
+    itemStatuses.WITHDRAWN,
+  ], item?.status?.name);
 }
 
 export function isDelivery(request) {

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -18,12 +18,17 @@ import ViewRequest from '../interactors/view-request';
 
 import translations from '../../../translations/ui-requests/en';
 
-const itemStatuses = [
-  'Declared lost',
-  'Withdrawn',
-  'Claimed returned',
-  'Lost and paid',
+const nonRequestableItemStatuses = [
   'Aged to lost',
+  'Claimed returned',
+  'Declared lost',
+  'In process (non-requestable)',
+  'Intellectual item',
+  'Long missing',
+  'Lost and paid',
+  'Unavailable',
+  'Unknown',
+  'Withdrawn',
 ];
 
 const patronComment = 'I really need this in the next three days';
@@ -405,7 +410,7 @@ describe('New Request page', () => {
       });
     });
 
-    itemStatuses.forEach(status => {
+    nonRequestableItemStatuses.forEach(status => {
       describe(`New request for ${status} item`, function () {
         beforeEach(async function () {
           const item = this.server.create('item', {


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-393

### Purpose
Prevent requests of any type from being made on items with `intellectual item`, `in process (non-requestable)`, `long missing`, `unavailable`, and `unknown` statuses.

### Screenshot
![Screen Shot 2021-02-02 at 16 00 22](https://user-images.githubusercontent.com/49517355/106610735-c7099000-656f-11eb-91a2-c961cf2cfaa3.png)