### PR TITLE
UIREQ-543: Fix canceled request display in Hold shelf clearance report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Increment `@folio/stripes-cli` to `v2`. Refs UIREQ-578.
 * Display l10n'ed values for type, status in results pane. Refs UIREQ-580.
 * Override patron blocks of requesting when user has credentials. Refs UIREQ-576.
+* Fix canceled request display in `Hold shelf clearance report`. Fixes UIREQ-543.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -87,6 +87,7 @@ class ViewRequest extends React.Component {
     onCloseEdit: PropTypes.func.isRequired,
     onEdit: PropTypes.func,
     onDuplicate: PropTypes.func,
+    buildRecordsForHoldsShelfReport: PropTypes.func.isRequired,
     optionLists: PropTypes.object,
     tagsToggle: PropTypes.func,
     paneWidth: PropTypes.string,
@@ -200,17 +201,25 @@ class ViewRequest extends React.Component {
   }
 
   cancelRequest(cancellationInfo) {
+    const {
+      resources,
+      mutator,
+      onCloseEdit,
+      buildRecordsForHoldsShelfReport,
+    } = this.props;
+
     // Get the initial request data, mix in the cancellation info, PUT,
     // and then close cancel/edit modes since cancelled requests can't be edited.
-    const request = get(this.props.resources, ['selectedRequest', 'records', 0], {});
+    const request = get(resources, ['selectedRequest', 'records', 0], {});
     const cancelledRequest = {
       ...request,
       ...cancellationInfo,
     };
 
-    this.props.mutator.selectedRequest.PUT(cancelledRequest).then(() => {
+    mutator.selectedRequest.PUT(cancelledRequest).then(() => {
       this.setState({ isCancellingRequest: false });
-      this.props.onCloseEdit();
+      onCloseEdit();
+      buildRecordsForHoldsShelfReport();
     });
   }
 

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -355,7 +355,6 @@ class RequestsRoute extends React.Component {
 
   componentDidMount() {
     this.setCurrentServicePointId();
-    this.buildRecordsForHoldsShelfReport();
   }
 
   componentDidUpdate(prevProps) {
@@ -928,6 +927,7 @@ class RequestsRoute extends React.Component {
               patronGroups,
               query: resources.query,
               onDuplicate: this.onDuplicate,
+              buildRecordsForHoldsShelfReport: this.buildRecordsForHoldsShelfReport,
             }}
             viewRecordPerms="ui-requests.view"
             newRecordPerms="ui-requests.create"

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -331,6 +331,7 @@ export default function config() {
     const body = JSON.parse(request.requestBody);
     const reqModel = requests.find(body.id);
     const defaultReq = this.build('request');
+    this.get('/circulation/requests-reports/hold-shelf-clearance/:id', { requests: [{ id: reqModel.id }], totalRecords: 1 });
     return reqModel.update({ ...defaultReq, ...body });
   });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-543

### Purpose
Add the ability to get the canceled request data immediately after the request cancellation event (without refreshing the page) to build an up-to-date `Hold shelf clearance report`.