### PR TITLE
UIREQ-581: Allow requests for Restricted items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Display l10n'ed values for type, status in results pane. Refs UIREQ-580.
 * Override patron blocks of requesting when user has credentials. Refs UIREQ-576.
 * Fix canceled request display in `Hold shelf clearance report`. Fixes UIREQ-543.
+* Allow requests for Restricted items. Refs UIREQ-581.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -179,6 +179,42 @@ describe('New Request page', () => {
       });
     });
 
+    describe('creating new request for item with status "Restricted"', () => {
+      beforeEach(async function () {
+        this.server.create('item', {
+          barcode: '9676761472500',
+          title: 'Best Book Ever',
+          materialType: {
+            name: 'book'
+          },
+          status: { name: 'Restricted' },
+        });
+
+        const user = this.server.create('user', { barcode: '9676761472501' });
+        this.server.create('request-preference', {
+          userId: user.id,
+          fulfillment: 'Hold Shelf',
+          defaultServicePointId: 'servicepointId1',
+        });
+
+        await newRequest
+          .fillItemBarcode('9676761472500')
+          .clickItemEnterBtn();
+
+        await newRequest
+          .fillUserBarcode('9676761472501')
+          .clickUserEnterBtn();
+
+        await newRequest.chooseServicePoint('Circ Desk 1');
+        await newRequest.clickNewRequest();
+        await viewRequest.isPresent;
+      });
+
+      it('should create a new request and open view request pane', () => {
+        expect(viewRequest.requestSectionPresent).to.be.true;
+        expect(viewRequest.requesterSectionPresent).to.be.true;
+      });
+    });
 
     describe('creating new request type with delivery', () => {
       beforeEach(async function () {


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-581

### Purpose
The main work was done at BE ([#823](https://github.com/folio-org/mod-circulation/pull/823)).
On FE it was necessary to check the correctness of its display and implement a test case.