### PR TITLE
UIREQ-587: Fix display of ErrorModal content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Fix canceled request display in `Hold shelf clearance report`. Fixes UIREQ-543.
 * Allow requests for Restricted items. Refs UIREQ-581.
 * Previous patron block remembered on new request. Refs UIREQ-586.
+* Fix display of the content of error modal. Fix UIREQ-587.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -69,6 +69,7 @@ import {
   getRequestTypeOptions,
   isDelivery,
   hasNonRequestableStatus,
+  parseErrorMessage,
 } from './utils';
 
 import css from './requests.css';
@@ -899,7 +900,7 @@ class RequestForm extends React.Component {
               <ErrorModal
                 onClose={this.onClose}
                 label={<FormattedMessage id="ui-requests.requestNotAllowed" />}
-                errorMessage={errorMessage}
+                errorMessage={parseErrorMessage(errorMessage)}
               />
             }
             <AccordionSet accordionStatus={accordions} onToggle={this.onToggleSection}>

--- a/src/components/ErrorModal.js
+++ b/src/components/ErrorModal.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import {
-  map,
-  split,
-} from 'lodash';
 
 import {
   Button,
@@ -18,7 +14,6 @@ const ErrorModal = (props) => {
     onClose,
     label,
   } = props;
-  const errors = split(errorMessage, ';');
 
   const footer = (
     <ModalFooter>
@@ -42,16 +37,7 @@ const ErrorModal = (props) => {
       onClose={onClose}
     >
       <div data-test-error-modal-content>
-        {
-          map(errors, (error, index) => (
-            <p
-              data-test-error-text
-              key={`error-${index}`}
-            >
-              {error}
-            </p>
-          ))
-        }
+        {errorMessage}
       </div>
     </Modal>
   );

--- a/src/utils.js
+++ b/src/utils.js
@@ -275,3 +275,16 @@ export function formatNoteReferrerEntityData(data) {
     id,
   };
 }
+
+export function parseErrorMessage(errorMessage) {
+  return errorMessage
+    .split(';')
+    .map((error, index) => (
+      <p
+        data-test-error-text
+        key={`error-${index}`}
+      >
+        {error}
+      </p>
+    ));
+}


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-587

### Purpose
Parsing `errorMessage` as a string inside `ErrorModal` will throw an error if `errorMessage` is a React element.

errorMessage: PropTypes.oneOfType([
    PropTypes.string,
    PropTypes.element,
]).isRequired,
  
This PR addresses this issue by moving the parsing out of `ErrorModal`.