### PR TITLE
use compatible versions of shared modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,40 @@
 * Allow requests for Restricted items. Refs UIREQ-581.
 * Previous patron block remembered on new request. Refs UIREQ-586.
 * Fix display of the content of error modal. Fix UIREQ-587.
+* Use `react-intl` `v5` compatible version of `react-intl-safe-html`.
+* Use `@folio/stripes` `v6` compatible version of `@folio/plugin-find-user`.
+
+## [4.0.6](https://github.com/folio-org/ui-requests/tree/v4.0.6) (2021-01-25)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.5...v4.0.6)
+
+* Barcode image not rendering on print slips. Refs UIREQ-570.
+
+## [4.0.5](https://github.com/folio-org/ui-requests/tree/v4.0.5) (2020-11-30)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.4...v4.0.5)
+
+* Increase the limit to display correct number of requests in the `Move request` modal. Fixes UIREQ-566.
+
+## [4.0.4](https://github.com/folio-org/ui-requests/tree/v4.0.4) (2020-11-20)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.3...v4.0.4)
+
+* Increment `@folio/stripes` to `^5.0.7`. Refs STFORM-16.
+* Add a toast notification for CSV search results export. Refs UIREQ-555.
+
+## [4.0.3](https://github.com/folio-org/ui-requests/tree/v4.0.3) (2020-11-16)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.2...v4.0.3)
+
+* Add a 'working' indicator for CSV search results export. Fixes UIREQ-555.
+
+## [4.0.2](https://github.com/folio-org/ui-requests/tree/v4.0.2) (2020-11-12)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.1...v4.0.2)
+
+* Fix sorting by request status. Fixes UIREQ-540.
+* Omit `holdShelfExpirationDate` field in duplicated request. Refs UIREQ-532.
+* Fix search by tags. Fixes UIREQ-542.
+* Avoid phantom block modal after clearing blocks. Refs UIREQ-545.
+* Fix default pickup service point when editing existing request. Fixes UIREQ-544.
+* Increase the limit to display all items in the `Move request` modal. Fixes UIREQ-541.
+* Fix the non-responsive design of the `Move request` modal. Fixes UIREQ-552.
 
 ## [4.0.1](https://github.com/folio-org/ui-requests/tree/v4.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.0...v4.0.1)

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "sinon": "^7.2.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.0.0",
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.14",
@@ -190,6 +190,6 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^4.0.0"
+    "@folio/plugin-find-user": "^5.0.0"
   }
 }


### PR DESCRIPTION
* Update `react-intl-safe-html` to `v3` for compatibility with
`react-intl` `v5`/`@folio/stripes` `v6`.
* Update `@folio/plugin-find-user` to `v3` for compatibility with
`@folio/stripes` `v6`.