### PR TITLE
UIREQ-595: Choose correct service point when patron is changed in duplicate mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## [5.1.0] IN PROGRESS
+
+* Choose correct service point when patron is changed in duplicate mode. Fixes UIREQ-595.
+
 ## [5.0.0](https://github.com/folio-org/ui-requests/tree/v5.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.6...v5.0.0)
 

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -485,8 +485,14 @@ class RequestForm extends React.Component {
       defaultServicePointId,
       deliverySelected,
       selectedAddressTypeId,
+      selectedUser,
     } = this.state;
-    const { change } = this.props;
+    const {
+      change,
+      initialValues: {
+        requesterId,
+      },
+    } = this.props;
 
     if (deliverySelected) {
       const deliveryAddressTypeId = selectedAddressTypeId || defaultDeliveryAddressTypeId;
@@ -494,10 +500,11 @@ class RequestForm extends React.Component {
       change('deliveryAddressTypeId', deliveryAddressTypeId);
       change('pickupServicePointId', '');
     } else {
-      // Do not update pickupServicePointId with defaultServicePointId if
-      // in duplicate mode. The pickupServicePointId from duplicated request
-      // record will be used instead.
-      if (this.props?.query?.mode !== createModes.DUPLICATE) {
+      // Only change pickupServicePointId to defaultServicePointId
+      // if selected user has changed (by choosing a different user manually)
+      // or if the request form is not in a DUPLICATE mode.
+      // In DUPLICATE mode the pickupServicePointId from a duplicated request record will be used instead.
+      if (requesterId !== selectedUser?.id || this.props?.query?.mode !== createModes.DUPLICATE) {
         change('pickupServicePointId', defaultServicePointId);
       }
       change('deliveryAddressTypeId', '');


### PR DESCRIPTION
Choose correct service point when patron is changed in duplicate mode.

https://issues.folio.org/browse/UIREQ-595

![pickup_service_point](https://user-images.githubusercontent.com/63545/114088760-5a6a8480-9883-11eb-86b5-331637ba488e.gif)
