### PR TITLE
UIREQ-600 also support circulation 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Choose correct service point when patron is changed in duplicate mode. Fixes UIREQ-595.
 * Increase limit for tags request to 10k. Refs UIREQ-596.
+* Also support `circulation` `10.0`. Refs UIREQ-600.
 
 ## [5.0.0](https://github.com/folio-org/ui-requests/tree/v5.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.6...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "queryResource": "query",
     "okapiInterfaces": {
       "cancellation-reason-storage": "1.1",
-      "circulation": "9.0",
+      "circulation": "9.0 10.0",
       "inventory": "10.0",
       "request-storage": "3.0",
       "pick-slips": "0.1",


### PR DESCRIPTION
The only breaking change in `circulation` `10.0` was the removal of the
`override-check-out-by-barcode` which is not used here, hence continuing
to support `9.0`.

Refs [UIREQ-600](https://issues.folio.org/browse/UIREQ-600)
