### PR TITLE
UIREQ-602 use exact-match query for item validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Also support `circulation` `10.0`. Refs UIREQ-600.
 * Change request type when changing to an item with different status. Fixes URIEQ-597.
 * Manual patron block modal is not shown. Refs UIREQ-601.
+* Validate items by barcode with an efficient exact-match query. Fixes UIREQ-602.
 
 ## [5.0.0](https://github.com/folio-org/ui-requests/tree/v5.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.6...v5.0.0)

--- a/src/asyncValidate.js
+++ b/src/asyncValidate.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 function asyncValidateItem(values, props) {
   const uv = props.parentMutator.itemUniquenessValidator;
-  const query = `(barcode="${values.item.barcode}")`;
+  const query = `(barcode=="${values.item.barcode}")`;
 
   uv.reset();
   return uv.GET({ params: { query } }).then((items) => {


### PR DESCRIPTION
During async-validation of requests, use an exact-match query for the
item barcode. This is faster and more efficient.

Refs [UIREQ-602](https://issues.folio.org/browse/UIREQ-602)