### PR TITLE
UIREQ-354 provide search by isbn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Also support `circulation` `10.0`. Refs UIREQ-600.
 * Change request type when changing to an item with different status. Fixes URIEQ-597.
 * Manual patron block modal is not shown. Refs UIREQ-601.
+* Provide search by ISBN. Refs UIREQ-354.
 
 ## [5.0.0](https://github.com/folio-org/ui-requests/tree/v5.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.6...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "queryResource": "query",
     "okapiInterfaces": {
       "cancellation-reason-storage": "1.1",
-      "circulation": "9.0 10.0",
+      "circulation": "10.0",
       "inventory": "10.0",
       "request-storage": "3.0",
       "pick-slips": "0.1",

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -115,7 +115,7 @@ class RequestsRoute extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1',
-            '(requesterId=="%{query.query}" or requester.barcode="%{query.query}*" or item.title="%{query.query}*" or item.barcode="%{query.query}*" or itemId=="%{query.query}")',
+            '(requesterId=="%{query.query}" or requester.barcode="%{query.query}*" or item.title="%{query.query}*" or item.barcode="%{query.query}*" or itemId=="%{query.query}" or itemIsbn="%{query.query}")',
             {
               'title': 'item.title',
               'itemBarcode': 'item.barcode',


### PR DESCRIPTION
Include ISBN search. The `itemIsbn` index is actually a part of
mod-circulation-storage, though it is accessed here via the
business-logic module that sits on top of it, mod-circulation, thus
bumping the minimum `circulation` okapi-index to `10.0`, the lowest
version that is guaranteed to supply that index.

Refs [UIREQ-354](https://issues.folio.org/browse/UIREQ-354)