### PR TITLE
UIREQ-528 consume date/time i18n components via stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Change request type when changing to an item with different status. Fixes URIEQ-597.
 * Manual patron block modal is not shown. Refs UIREQ-601.
 * Provide search by ISBN. Refs UIREQ-354.
+* Consume some i18n components via stripes proxies to avoid Safari bugs. Refs UIREQ-528.
 
 ## [5.0.0](https://github.com/folio-org/ui-requests/tree/v5.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.6...v5.0.0)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -2,7 +2,7 @@ import get from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FormattedMessage } from '@folio/streact-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Col, KeyValue, Row, FormattedDate } from '@folio/stripes/components';
 import { effectiveCallNumber } from '@folio/stripes/util';

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -2,9 +2,9 @@ import get from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from '@folio/streact-intl';
 
-import { Col, KeyValue, Row } from '@folio/stripes/components';
+import { Col, KeyValue, Row, FormattedDate } from '@folio/stripes/components';
 import { effectiveCallNumber } from '@folio/stripes/util';
 import {
   ClipCopy,

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -6,7 +6,6 @@ import {
 } from 'redux-form';
 import {
   FormattedMessage,
-  FormattedDate,
   injectIntl,
 } from 'react-intl';
 
@@ -33,17 +32,18 @@ import {
   Button,
   Col,
   Datepicker,
-  PaneHeaderIconButton,
+  FormattedDate,
+  Icon,
   KeyValue,
   Pane,
+  PaneFooter,
+  PaneHeaderIconButton,
   PaneMenu,
   Paneset,
   Row,
   Select,
   TextArea,
   TextField,
-  PaneFooter,
-  Icon,
   Timepicker,
 } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';

--- a/src/components/ReferredRecord/ReferredRecord.js
+++ b/src/components/ReferredRecord/ReferredRecord.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  FormattedMessage,
-  FormattedDate,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 
-import { KeyValue } from '@folio/stripes/components';
+import {
+  FormattedDate,
+  KeyValue,
+} from '@folio/stripes/components';
 
 import { createUserHighlightBoxLink } from '../../utils';
 

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { stringify } from 'query-string';
 import moment from 'moment-timezone';
 import {
-  FormattedTime,
   FormattedMessage,
   injectIntl,
 } from 'react-intl';
@@ -21,6 +20,7 @@ import {
 import {
   Button,
   filters2cql,
+  FormattedTime,
   MenuSection,
 } from '@folio/stripes/components';
 import {

--- a/src/views/RequestQueueView.js
+++ b/src/views/RequestQueueView.js
@@ -2,17 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { get } from 'lodash';
-import {
-  FormattedMessage,
-  FormattedDate,
-  FormattedTime,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import {
   Col,
   Callout,
   ConfirmationModal,
+  FormattedDate,
+  FormattedTime,
   KeyValue,
   Pane,
   PaneHeaderIconButton,


### PR DESCRIPTION
`<FormattedDate>` and `<FormattedTime>` do not handle some timestamp
formats correctly in some versions of Safari. Pass-through components
that refort such values as necessary are available in
`stripes-components` and are used here to allow request-related data to
be correctly display on iOS tablets and phones.

Refs [UIREQ-528](https://issues.folio.org/browse/UIREQ-528)