### PR TITLE
UIREQ-604 avoid proptypes errors at all costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Change request type when changing to an item with different status. Fixes URIEQ-597.
 * Manual patron block modal is not shown. Refs UIREQ-601.
 * Provide search by ISBN. Refs UIREQ-354.
+* Avoid console errors related to bad proptypes. Refs UIREQ-604.
 
 ## [5.0.0](https://github.com/folio-org/ui-requests/tree/v5.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.6...v5.0.0)

--- a/src/components/PrintButton/PrintButton.js
+++ b/src/components/PrintButton/PrintButton.js
@@ -28,7 +28,7 @@ class PrintButton extends React.Component {
   };
 
   renderTriggerButton = () => {
-    const fieldsToSkip = ['contentRef', 'onBeforePrint', 'onAfterPrint'];
+    const fieldsToSkip = ['contentRef', 'onBeforePrint', 'onAfterPrint', 'onBeforeGetContent'];
     const props = omit(this.props, fieldsToSkip);
 
     return (

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -252,7 +252,7 @@ class RequestsRoute extends React.Component {
         GET: PropTypes.func,
       }),
       pickSlips: PropTypes.shape({
-        GET: PropTypes.func.isRequired,
+        GET: PropTypes.func,
       }).isRequired,
       currentServicePoint: PropTypes.shape({
         update: PropTypes.func.isRequired,


### PR DESCRIPTION
PropTypes have drifted out of sync causing numerous spurious console
warnings.

It is not obvious to me how to correct this one from where [`RequestsRoute` calls SearchAndSort](https://github.com/folio-org/ui-requests/blob/bc47dfcd347bff3aa395b7f2d340a09e722b2b06/src/routes/RequestsRoute.js#L894):
```
Warning: Failed prop type: Invalid prop `editRecordComponent` of type `object` supplied to `SearchAndSort`, expected `function`.
```
There's no console warning in [ui-inventory](https://github.com/folio-org/ui-inventory/blob/ed445992b4ca3595a5440c3a85c468113f7d611e/src/components/InstancesList/InstancesList.js#L654). What's special about ui-requests? 🤔 

Refs [UIREQ-604](https://issues.folio.org/browse/UIREQ-604)