### PR TITLE
UIREQ-607: Add translation key "mod-circulation.requesterHasItemOnLoan"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Avoid console errors related to bad proptypes. Refs UIREQ-604.
 * Consume some i18n components via stripes proxies to avoid Safari bugs. Refs UIREQ-528.
 * Validate items by barcode with an efficient exact-match query. Fixes UIREQ-602.
+* Add translation key "mod-circulation.requesterHasItemOnLoan". Refs UIREQ-607.
 
 ## [5.0.0](https://github.com/folio-org/ui-requests/tree/v5.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.6...v5.0.0)

--- a/translations/ui-requests/de.json
+++ b/translations/ui-requests/de.json
@@ -17,6 +17,7 @@
     "errors.onlyCheckedOutForHold": "Nur ausgeliehene Exemplare können vorgemerkt werden",
     "errors.selectItem": "Bitte ein Exemplar auswählen",
     "errors.selectUser": "Bitte Informationen zum Bestellenden ausfüllen, um fortzufahren",
+    "mod-circulation.requesterHasItemOnLoan": "Benutzer/-in hat das Exemplar bereits ausgeliehen.",
     "actions.closeNewRequest": "Neue Bestandsanfrage schließen",
     "actions.createNewRequest": "Neue Bestandsanfrage erstellen",
     "actions.newRequest": "Neue Bestandsanfrage",

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -63,6 +63,8 @@
   "errors.selectItemRequired": "Please select an item and hit enter",
   "errors.selectUser": "Please fill out requestor information to continue",
 
+  "mod-circulation.requesterHasItemOnLoan": "This requester currently has this item on loan.",
+
   "actions.label": "Actions",
   "actions.edit": "Edit",
   "actions.editRequestLink": "Edit Request Dialog",


### PR DESCRIPTION
mod-circulation may send the translation key

"ui-requests.mod-circulation.requesterHasItemOnLoan".

This PR only adds the translation key.

Processing the translation key is out of scope.
Generating the translation key is out of scope.

For details see

* https://issues.folio.org/browse/UIREQ-603 "Internationalize back-end failure messages"
* https://issues.folio.org/browse/CIRC-1146 "Internationalize back-end failure messages"
    = https://github.com/folio-org/mod-circulation/pull/879/files