### PR TITLE
UIREQ-608: Update circulation interface dependency to support v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Avoid console errors related to bad proptypes. Refs UIREQ-604.
 * Consume some i18n components via stripes proxies to avoid Safari bugs. Refs UIREQ-528.
 * Validate items by barcode with an efficient exact-match query. Fixes UIREQ-602.
+* Also support `circulation` `11.0`. Refs UIREQ-608.
 
 ## [5.0.0](https://github.com/folio-org/ui-requests/tree/v5.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v4.0.6...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "queryResource": "query",
     "okapiInterfaces": {
       "cancellation-reason-storage": "1.1",
-      "circulation": "10.0",
+      "circulation": "10.0 11.0",
       "inventory": "10.0",
       "request-storage": "3.0",
       "pick-slips": "0.1",


### PR DESCRIPTION
## Purpose
There is a breaking change in mod-circulation (https://github.com/folio-org/mod-circulation/pull/854), circulation interface version will be updated to 11.0.  Other modules should update their dependencies to support this change.

**Do not merge. We have several associated pull request and we need merge them at the same time.**

**API changes**
circulation/override-renewal-by-barcode - will be removed
circulation/renew-by-barcode - request and response will be changed
Current changes will be effect ui-users module

## Refs
https://issues.folio.org/browse/UIREQ-608