### PR TITLE
UIREQ-627 omit cancellation details in duplicated requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Localize `Barcode`. Refs UIREQ-220.
 * Fix proxy bug in request duplication. Fixes UIREQ-626.
+* Omit request-cancellation details in duplicated requests. Refs UIREQ-627.
 
 ## [5.1.0](https://github.com/folio-org/ui-requests/tree/v5.1.0) (2021-06-17)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.0.0...v5.1.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -58,12 +58,20 @@ export const requestStatusesTranslations = {
 
 export const itemStatuses = {
   AGED_TO_LOST: 'Aged to lost',
+  AVAILABLE: 'Available',
+  AWAITING_DELIVERY: 'Awaiting delivery',
+  AWAITING_PICKUP: 'Awaiting pickup',
+  CHECKED_OUT: 'Checked out',
   CLAIMED_RETURNED: 'Claimed returned',
   DECLARED_LOST: 'Declared lost',
+  IN_PROCESS: 'In process',
   IN_PROCESS_NON_REQUESTABLE: 'In process (non-requestable)',
+  IN_TRANSIT: 'In transit',
   INTELLECTUAL_ITEM: 'Intellectual item',
   LONG_MISSING: 'Long missing',
   LOST_AND_PAID: 'Lost and paid',
+  MISSING: 'Missing',
+  ON_ORDER: 'On order',
   PAGED: 'Paged',
   UNAVAILABLE: 'Unavailable',
   UNKNOWN: 'Unknown',
@@ -193,4 +201,3 @@ export const errorCodes = {
   SYNC: 'sync',
   UNKNOWN: 'unknown',
 };
-

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,16 +103,20 @@ export function duplicateRequest(request) {
   clonedRequest.requestType = requestTypes.find(rt => rt === requestType) || requestTypes[0];
 
   return omit(clonedRequest, [
+    'cancellationAdditionalInformation',
+    'cancellationReasonId',
+    'cancelledByUserId',
+    'cancelledDate',
+    'holdShelfExpirationDate',
     'id',
     'metadata',
-    'status',
-    'requestCount',
     'position',
-    'requester',
-    'requesterId',
-    'holdShelfExpirationDate',
     'proxy',
     'proxyUserId',
+    'requestCount',
+    'requester',
+    'requesterId',
+    'status',
   ]);
 }
 

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -11,7 +11,7 @@ import {
   // buildUrl,
   // convertToSlipData,
   createUserHighlightBoxLink,
-  // duplicateRequest,
+  duplicateRequest,
   escapeValue,
   // formatNoteReferrerEntityData,
   // getFullName,
@@ -26,6 +26,16 @@ import {
   // toUserAddress,
   // userHighlightBox,
 } from './utils';
+
+import {
+  // requestTypesByItemStatus,
+  // requestTypeOptionMap,
+  itemStatuses,
+  // fulfilmentTypeMap,
+  // requestStatuses,
+  requestTypesMap,
+  // requestTypes,
+} from './constants';
 
 describe('escapeValue', () => {
   it('escapes values', () => {
@@ -76,6 +86,86 @@ describe('createUserHighlightBoxLink', () => {
     expect(text).toMatch('');
   });
 });
+
+
+
+describe('duplicateRequest', () => {
+  it('omits non-cloneable attributes', () => {
+    const r = {
+      monkey: 'bagel',
+      requestType: 'r',
+      cancellationAdditionalInformation: '',
+      cancellationReasonId: '',
+      cancelledByUserId: '',
+      cancelledDate: '',
+      holdShelfExpirationDate: '',
+      id: '',
+      metadata: '',
+      position: '',
+      proxy: '',
+      proxyUserId: '',
+      requestCount: '',
+      requester: '',
+      requesterId: '',
+      status: '',
+    };
+    const duped = duplicateRequest(r);
+
+    const omit = [
+      'cancellationAdditionalInformation',
+      'cancellationReasonId',
+      'cancelledByUserId',
+      'cancelledDate',
+      'holdShelfExpirationDate',
+      'id',
+      'metadata',
+      'position',
+      'proxy',
+      'proxyUserId',
+      'requestCount',
+      'requester',
+      'requesterId',
+      'status',
+    ];
+
+    omit.forEach(i => {
+      expect(duped).not.toHaveProperty(i);
+    });
+  });
+
+  describe('adjusts request type if necessary', () => {
+    it('leaves request type if it is valid for item type', () => {
+      const r = {
+        monkey: 'bagel',
+        requestType: requestTypesMap.RECALL,
+        item: { status: itemStatuses.CHECKED_OUT }
+      };
+      const duped = duplicateRequest(r);
+      expect(duped.requestType).toBe(requestTypesMap.RECALL);
+    });
+
+    it('changes request type if it is invalid for item-status', () => {
+      const r = {
+        monkey: 'bagel',
+        requestType: requestTypesMap.RECALL,
+        item: { status: itemStatuses.AVAILABLE }
+      };
+      const duped = duplicateRequest(r);
+      expect(duped.requestType).toBe(requestTypesMap.PAGE);
+    });
+
+    it('omits request type if it is invalid for item-status', () => {
+      const r = {
+        monkey: 'bagel',
+        requestType: requestTypesMap.RECALL,
+        item: { status: itemStatuses.AGED_TO_LOST }
+      };
+      const duped = duplicateRequest(r);
+      expect(duped.requestType).toBeUndefined();
+    });
+  });
+});
+
 
 
 


### PR DESCRIPTION
When cloning an existing request, if the original has been cancelled, do
not include the cancellation-related fields in the clone.

Refs [UIREQ-627](https://issues.folio.org/browse/UIREQ-627)