### PR TITLE
UIREQ-628 provide request-preferences permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Localize `Barcode`. Refs UIREQ-220.
 * Fix proxy bug in request duplication. Fixes UIREQ-626.
+* Include `request-preferences` permission in edit and create psets. Refs UIREQ-628.
 
 ## [5.1.0](https://github.com/folio-org/ui-requests/tree/v5.1.0) (2021-06-17)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.0.0...v5.1.0)

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
           "automated-patron-blocks.collection.get",
           "circulation.requests.item.post",
           "circulation-storage.requests.item.post",
+          "circulation-storage.request-preferences.collection.get",
           "circulation.pick-slips.get",
           "inventory-storage.locations.item.get"
         ],
@@ -130,6 +131,7 @@
           "circulation-storage.requests.collection.delete",
           "circulation-storage.requests.item.put",
           "circulation-storage.requests.item.delete",
+          "circulation-storage.request-preferences.collection.get",
           "tags.collection.get",
           "tags.item.post"
         ],


### PR DESCRIPTION
Provide the missing permission,
`circulation-storage.request-preferences.collection.get`, to the
request-create and request-edit psets in order to allow for the
retrieval of users' preferred pickup points.

Refs [UIREQ-628](https://issues.folio.org/browse/UIREQ-628)