### PR TITLE
UIREQ-629: Disable hold shelf clearance report when a request for hold shelf data is pending.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix proxy bug in request duplication. Fixes UIREQ-626.
 * Include `request-preferences` permission in edit and create psets. Refs UIREQ-628.
 * Omit request-cancellation details in duplicated requests. Refs UIREQ-627.
+* Disable hold shelf clearance report button when a request for `hold-shelf-clearance` data is pending. Fixes UIREQ-629.
 
 ## [5.1.0](https://github.com/folio-org/ui-requests/tree/v5.1.0) (2021-06-17)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.0.0...v5.1.0)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -457,6 +457,7 @@ class RequestsRoute extends React.Component {
   setCurrentServicePointId = () => {
     const { mutator } = this.props;
     const { id } = this.getCurrentServicePointInfo();
+
     mutator.currentServicePoint.update({ id });
     this.buildRecordsForHoldsShelfReport();
   };
@@ -624,6 +625,10 @@ class RequestsRoute extends React.Component {
       stripes: { user },
     } = this.props;
 
+    this.setState({
+      holdsShelfReportPending: true,
+    });
+
     reset();
 
     const servicePointId = get(user, 'user.curServicePoint.id', '');
@@ -633,6 +638,7 @@ class RequestsRoute extends React.Component {
     this.setState({
       servicePointId,
       requests,
+      holdsShelfReportPending: false,
     });
   }
 
@@ -757,6 +763,7 @@ class RequestsRoute extends React.Component {
       errorModalData,
       requests,
       servicePointId,
+      holdsShelfReportPending,
     } = this.state;
     const { name: servicePointName } = this.getCurrentServicePointInfo();
     const pickSlips = get(resources, 'pickSlips.records', []);
@@ -828,7 +835,7 @@ class RequestsRoute extends React.Component {
                 <Button
                   buttonStyle="dropdownItem"
                   id="exportExpiredHoldsToCsvPaneHeaderBtn"
-                  disabled={servicePointId && requestsEmpty}
+                  disabled={holdsShelfReportPending || (servicePointId && requestsEmpty)}
                   onClick={() => {
                     onToggle();
                     this.exportExpiredHoldsToCSV();


### PR DESCRIPTION
https://issues.folio.org/browse/UIREQ-629

This is a similar pattern to what has been done with `Print pick slips for API` option. 
