### PR TITLE
UIREQ-639: Use == not = for item barcode search

### DIFF
--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -115,7 +115,7 @@ class RequestsRoute extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1',
-            '(requesterId=="%{query.query}" or requester.barcode="%{query.query}*" or item.title="%{query.query}*" or item.barcode="%{query.query}*" or itemId=="%{query.query}" or itemIsbn="%{query.query}")',
+            '(requesterId=="%{query.query}" or requester.barcode="%{query.query}*" or item.title="%{query.query}*" or item.barcode=="%{query.query}*" or itemId=="%{query.query}" or itemIsbn="%{query.query}")',
             {
               'title': 'item.title',
               'itemBarcode': 'item.barcode',
@@ -426,7 +426,7 @@ class RequestsRoute extends React.Component {
     const filterQuery = filters2cql(RequestsFiltersConfig, deparseFilters(this.getActiveFilters()));
 
     if (queryTerm) {
-      queryString = `(requesterId=="${queryTerm}" or requester.barcode="${queryTerm}*" or item.title="${queryTerm}*" or item.barcode="${queryTerm}*" or itemId=="${queryTerm}")`;
+      queryString = `(requesterId=="${queryTerm}" or requester.barcode="${queryTerm}*" or item.title="${queryTerm}*" or item.barcode=="${queryTerm}*" or itemId=="${queryTerm}")`;
       queryClauses.push(queryString);
     }
 


### PR DESCRIPTION
Searching for an item barcode takes minutes in a large DB when using the full text match operator =.

mod-inventory-storage no longer has a database index for this full text item barcode search: https://issues.folio.org/browse/MODINVSTOR-523

Use the exact match operator == instead, it also allows right truncation when appending a star.

There are no use cases where the search term 123456 should find barcode 98765-123456, all other item barcode searches have already switched to ==.

Learn about CQL string matching at https://dev.folio.org/faqs/explain-cql/