### PR TITLE
UIREQ-646: Add interface version for inventory optimistic locking

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "okapiInterfaces": {
       "cancellation-reason-storage": "1.1",
       "circulation": "10.0 11.0",
-      "inventory": "10.0",
+      "inventory": "10.0 11.0",
       "request-storage": "3.0",
       "pick-slips": "0.1",
       "automated-patron-blocks": "0.1"


### PR DESCRIPTION
Depend on the new inventory interface version for optimistic locking
in addition to the old interface version.

This modules uses GET for instance, holdings and item, but doesn't
PUT them. Therefore no code change is needed to support the
_version property in these records that are needed for
optimistic locking.