### PR TITLE
UIREQ-668: fix proxy and block pop-ups issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-requests
 
+## IN PROGRESS
+* Fix the issue when proxy pop-up and block pop-up appear at the same time for requests. Refs UIREQ-668.
+
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)
 

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -118,6 +118,12 @@ class RequestForm extends React.Component {
     query: PropTypes.object,
     onSubmit: PropTypes.func,
     reset: PropTypes.func,
+    parentMutator: PropTypes.shape({
+      proxy: PropTypes.shape({
+        reset: PropTypes.func.isRequired,
+        GET: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
   };
 
   static defaultProps = {
@@ -147,6 +153,7 @@ class RequestForm extends React.Component {
       blocked: false,
       ...this.getDefaultRequestPreferences(),
       isPatronBlocksOverridden: false,
+      isAwaitingForProxySelection: false,
     };
 
     this.connectedCancelRequestDialog = props.stripes.connect(CancelRequestDialog);
@@ -334,6 +341,8 @@ class RequestForm extends React.Component {
       this.props.change('proxyUserId', selectedUser.id);
       this.findRequestPreferences(proxy.id);
     }
+
+    this.setState({ isAwaitingForProxySelection: false });
   }
 
   onUserClick() {
@@ -343,6 +352,27 @@ class RequestForm extends React.Component {
     if (!barcode) return;
 
     this.findUser('barcode', barcode);
+  }
+
+  async hasProxies(user) {
+    if (!user) {
+      this.setState({ isAwaitingForProxySelection: false });
+
+      return;
+    }
+
+    const { parentMutator: mutator } = this.props;
+    const query = `query=(proxyUserId==${user.id})`;
+
+    mutator.proxy.reset();
+
+    const userProxies = await mutator.proxy.GET({ params: { query } });
+
+    if (userProxies.length) {
+      this.setState({ isAwaitingForProxySelection: true });
+    } else {
+      this.setState({ isAwaitingForProxySelection: false });
+    }
   }
 
   findUser(fieldName, value) {
@@ -365,32 +395,36 @@ class RequestForm extends React.Component {
       isUserLoading: true,
     });
 
-    findResource('user', value, fieldName).then((result) => {
-      if (result.totalRecords === 1) {
-        const blocks = this.getPatronManualBlocks(parentResources);
-        const automatedPatronBlocks = this.getAutomatedPatronBlocks(parentResources);
-        const isAutomatedPatronBlocksRequestInPendingState = parentResources.automatedPatronBlocks.isPending;
-        const selectedUser = result.users[0];
-        const state = { selectedUser };
-        onChangePatron(selectedUser);
-        change('requesterId', selectedUser.id);
+    findResource('user', value, fieldName)
+      .then((result) => {
+        this.setState({ isAwaitingForProxySelection: true });
 
-        this.setState(state);
-        this.findRequestPreferences(selectedUser.id);
+        if (result.totalRecords === 1) {
+          const blocks = this.getPatronManualBlocks(parentResources);
+          const automatedPatronBlocks = this.getAutomatedPatronBlocks(parentResources);
+          const isAutomatedPatronBlocksRequestInPendingState = parentResources.automatedPatronBlocks.isPending;
+          const selectedUser = result.users[0];
+          const state = { selectedUser };
+          onChangePatron(selectedUser);
+          change('requesterId', selectedUser.id);
 
-        if ((blocks.length && blocks[0].userId === selectedUser.id) || (!isEmpty(automatedPatronBlocks) && !isAutomatedPatronBlocksRequestInPendingState)) {
-          this.setState({
-            blocked: true,
-            isPatronBlocksOverridden: false,
-          });
+          this.setState(state);
+          this.findRequestPreferences(selectedUser.id);
+
+          if ((blocks.length && blocks[0].userId === selectedUser.id) || (!isEmpty(automatedPatronBlocks) && !isAutomatedPatronBlocksRequestInPendingState)) {
+            this.setState({
+              blocked: true,
+              isPatronBlocksOverridden: false,
+            });
+          }
+
+          return selectedUser;
         }
 
-        return selectedUser;
-      }
-
-      return null;
-    })
+        return null;
+      })
       .then(user => (!user ? validate() : user))
+      .then(user => this.hasProxies(user))
       .finally(() => {
         this.setState({ isUserLoading: false });
       });
@@ -811,6 +845,8 @@ class RequestForm extends React.Component {
       isUserLoading,
       isErrorModalOpen,
       isPatronBlocksOverridden,
+      isAwaitingForProxySelection,
+      proxy,
     } = this.state;
 
     const patronBlocks = this.getPatronManualBlocks(parentResources);
@@ -861,6 +897,17 @@ class RequestForm extends React.Component {
     const patronGroup = getPatronGroup(selectedUser, patronGroups);
     const requestTypeError = hasNonRequestableStatus(selectedItem);
     const itemStatus = selectedItem?.status?.name;
+    const getPatronBlockModalOpenStatus = () => {
+      if (isAwaitingForProxySelection) {
+        return false;
+      }
+
+      const isBlockedAndOverriden = blocked && !isPatronBlocksOverridden;
+
+      return proxy?.id
+        ? isBlockedAndOverriden && (proxy.id === selectedUser?.id)
+        : isBlockedAndOverriden;
+    };
 
     return (
       <Paneset isRoot>
@@ -1198,7 +1245,7 @@ class RequestForm extends React.Component {
               stripes={this.props.stripes}
             />
             <PatronBlockModal
-              open={blocked && !isPatronBlocksOverridden}
+              open={getPatronBlockModalOpenStatus()}
               onClose={this.onCloseBlockedModal}
               onOverride={this.overridePatronBlocks}
               viewUserPath={() => this.onViewUserPath(selectedUser, patronGroup)}

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -219,6 +219,13 @@ class RequestsRoute extends React.Component {
       },
       records: 'tags',
     },
+    proxy: {
+      type: 'okapi',
+      records: 'proxiesFor',
+      path: 'proxiesfor',
+      accumulate: true,
+      fetch: false,
+    },
   };
 
   static propTypes = {
@@ -256,6 +263,10 @@ class RequestsRoute extends React.Component {
       }).isRequired,
       currentServicePoint: PropTypes.shape({
         update: PropTypes.func.isRequired,
+      }).isRequired,
+      proxy: PropTypes.shape({
+        reset: PropTypes.func.isRequired,
+        GET: PropTypes.func.isRequired,
       }).isRequired,
     }).isRequired,
     resources: PropTypes.shape({


### PR DESCRIPTION
## Purpose
Fix the issue when proxy pop-up and block pop-up appear at the same time for requests.

## Approach
We must get user proxies, and if they are, don't show `blocks` modal while `act as` modal is visible and user not selected.
When we try to find user, we set flag  `awatingForProxySelect` to `true`. If we find user with proxies, the flag will set to `false` only when user or proxy is selected in `act as` pop-up. If we didn't find user, or user have no proxies, we set the `awatingForProxySelect` flag to `false` and then show `blocks` modal if need it.

## Refs
https://issues.folio.org/browse/UIREQ-668

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/139067332-dd8ea736-f0d1-4426-9bdf-8e0b7f76c7b5.png)
![image](https://user-images.githubusercontent.com/88130496/139067373-6d929755-d3c3-4bb6-b0f6-a934a37d9e44.png)