### PR TITLE
UIREQ-670: fix patron block modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change history for ui-requests
 
 ## IN PROGRESS
+
 * Fix the issue when proxy pop-up and block pop-up appear at the same time for requests. Refs UIREQ-668.
+* Fix the issue when `block` modal appears even if no manual blocks and vice versa. Refs UIREQ-670
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -378,7 +378,6 @@ class RequestForm extends React.Component {
   findUser(fieldName, value) {
     const {
       change,
-      parentResources,
       findResource,
       onChangePatron,
       asyncValidate: validate,
@@ -400,6 +399,7 @@ class RequestForm extends React.Component {
         this.setState({ isAwaitingForProxySelection: true });
 
         if (result.totalRecords === 1) {
+          const { parentResources } = this.props;
           const blocks = this.getPatronManualBlocks(parentResources);
           const automatedPatronBlocks = this.getAutomatedPatronBlocks(parentResources);
           const isAutomatedPatronBlocksRequestInPendingState = parentResources.automatedPatronBlocks.isPending;


### PR DESCRIPTION
## Purpose
Fix the issue when `block` modal appears even if no manual blocks and vice versa.

## Approach
`parentResources` has been moved into function that directly use it. Looks like the problem is `findResource` is asynchronous, and `parentResources` may not be equal before and after the function call.

## Refs
https://issues.folio.org/browse/UIREQ-670