### PR TITLE
UIREQ-672 When newly added patron is deleted after making and canceling request, requests page is unstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix the issue when proxy pop-up and block pop-up appear at the same time for requests. Refs UIREQ-668.
 * Fix the issue when `block` modal appears even if no manual blocks and vice versa. Refs UIREQ-670
 * Move reusable part of `move request dialog box` to reusable component. Refs UIREQ-660.
+* When newly added patron is deleted after making and canceling request, requests page is unstable. Refs UIREQ-672.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/UserDetail.js
+++ b/src/UserDetail.js
@@ -34,7 +34,7 @@ class UserDetail extends React.Component {
 
     const id = user?.id ?? request.requesterId;
     const name = getFullName(user);
-    const barcode = user.barcode;
+    const barcode = user ? user.barcode : '';
     const patronGroup = getPatronGroup(user, patronGroups) || {};
 
     let proxyName;

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ import css from './requests.css';
 
 // eslint-disable-next-line import/prefer-default-export
 export function getFullName(user) {
-  const userNameObj = user.personal || user;
+  const userNameObj = user?.personal || user;
   const lastName = get(userNameObj, ['lastName'], '');
   const firstName = get(userNameObj, ['firstName'], '');
   const middleName = get(userNameObj, ['middleName'], '');


### PR DESCRIPTION
## Purpose
Display missing requester fields as blanks

## Refs
https://issues.folio.org/browse/UIREQ-672


