### PR TITLE
UIREQ-609 import via @folio/stripes/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix the issue when `block` modal appears even if no manual blocks and vice versa. Refs UIREQ-670
 * Move reusable part of `move request dialog box` to reusable component. Refs UIREQ-660.
 * When newly added patron is deleted after making and canceling request, requests page is unstable. Refs UIREQ-672.
+* Import `stripes-core` components via `@folio/stripes`. Refs UIREQ-609.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -39,7 +39,7 @@ import {
   withTags,
   NotesSmartAccordion,
 } from '@folio/stripes/smart-components';
-import { IfPermission } from '@folio/stripes-core';
+import { IfPermission } from '@folio/stripes/core';
 
 import CancelRequestDialog from './CancelRequestDialog';
 import ItemDetail from './ItemDetail';


### PR DESCRIPTION
Components in `@folio/stripes-*` should be imported via their public
paths in `@folio/stripes` instead of directly.

Fixes [UIREQ-609](https://issues.folio.org/browse/UIREQ-609)