### PR TITLE
UIREQ-678 use shared babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.1.0",
     "@folio/stripes": "^7.0.0",
-    "@folio/stripes-cli": "^2.0.0",
+    "@folio/stripes-cli": "^2.4.0",
     "@folio/stripes-components": "^10.0.0",
     "@folio/stripes-core": "^8.0.0",
     "@formatjs/cli": "^4.2.20",
@@ -187,6 +187,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^3.1.0",
+    "babel-plugin-module-resolver": "^4.1.0",
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.14",

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -1,12 +1,17 @@
+const { babelOptions } = require('@folio/stripes-cli');
+
+babelOptions.plugins.push([
+  'babel-plugin-module-resolver',
+  {
+    root: ['./'],
+    alias: {
+      __mock__: './test/jest/__mock__',
+      fixtures: './test/jest/fixtures',
+      helpers: './test/jest/helpers',
+    },
+  },
+]);
+
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    ['@babel/preset-react', { 'runtime': 'automatic' }],
-  ],
-  plugins: [
-    ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-private-methods', { loose: true }],
-    '@babel/plugin-transform-runtime',
-  ],
+  ...babelOptions,
 };


### PR DESCRIPTION
Don't maintain a local copy; import the common config file from
`@folio/stripes-cli`. This has the added benefit of silencing the 10
billion "The "loose" option must be the same ..." messages that show up
when running Jest tests.

Refs [UIREQ-678](https://issues.folio.org/browse/UIREQ-678), [STCLI-182](https://issues.folio.org/browse/STCLI-182)