### PR TITLE
UIREQ-609 import @folio/stripes/core only once

### DIFF
--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -17,6 +17,7 @@ import {
 import moment from 'moment-timezone';
 
 import {
+  IfPermission,
   IntlConsumer,
   TitleManager
 } from '@folio/stripes/core';
@@ -39,7 +40,6 @@ import {
   withTags,
   NotesSmartAccordion,
 } from '@folio/stripes/smart-components';
-import { IfPermission } from '@folio/stripes/core';
 
 import CancelRequestDialog from './CancelRequestDialog';
 import ItemDetail from './ItemDetail';


### PR DESCRIPTION
Once upon a time not so long ago

@zburke used to work on this code, his brain's been on strike
He's down his luck, it's tough, so tough
Lint, it works the PRs all day, reading all the lines
On errors, shouts, "Hey!" for love, for love

It says, listen here now, [seven nine three](/folio-org/ui-requests/pull/793) was rot
It doesn't make a difference if you fix things like that
But you've got me now and that's a lot for code
So give lint a shot!

Woah, you're halfway there
Woah, import `stripes/core` up there
Just run lint and you'll make it I swear
Woah, lint answers your prayers!

Refs [UIREQ-609](https://issues.folio.org/browse/UIREQ-609)