### PR TITLE
lint: only one stripes/core import

### DIFF
--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -17,6 +17,7 @@ import {
 import moment from 'moment-timezone';
 
 import {
+  IfPermission,
   IntlConsumer,
   TitleManager
 } from '@folio/stripes/core';
@@ -39,7 +40,6 @@ import {
   withTags,
   NotesSmartAccordion,
 } from '@folio/stripes/smart-components';
-import { IfPermission } from '@folio/stripes/core';
 
 import CancelRequestDialog from './CancelRequestDialog';
 import ItemDetail from './ItemDetail';


### PR DESCRIPTION
Resolve the following warning: 
```
$ yarn lint
yarn run v1.22.11
$ eslint .

/Users/zburke/projects/folio-org/ui-requests/src/ViewRequest.js
  22:8   error  '/Users/zburke/projects/folio-org/ui-requests/node_modules/@folio/stripes/core/index.js' imported multiple times  import/no-duplicates
  42:30  error  '/Users/zburke/projects/folio-org/ui-requests/node_modules/@folio/stripes/core/index.js' imported multiple times  import/no-duplicates

✖ 2 problems (2 errors, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```