### PR TITLE
UIREQ-691: Closed TLR should not be able to be duplicated when TLR is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Create title level request checkbox. Refs UIREQ-655.
 * Update request results page. Refs UIREQ-614.
 * Update request details pane. Refs UIREQ-613.
+* Closed TLR should not be able to be duplicated when TLR is disabled. Refs UIREQ-691.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -56,6 +56,7 @@ import {
   toUserAddress,
   isDelivery,
   getFullName,
+  getTlrSettings,
 } from './utils';
 import urls from './routes/urls';
 
@@ -97,6 +98,9 @@ class ViewRequest extends React.Component {
     paneWidth: PropTypes.string,
     patronGroups: PropTypes.arrayOf(PropTypes.object),
     parentMutator: PropTypes.object,
+    parentResources: PropTypes.shape({
+      configs: PropTypes.object.isRequired,
+    }).isRequired,
     resources: PropTypes.shape({
       selectedRequest: PropTypes.shape({
         hasLoaded: PropTypes.bool.isRequired,
@@ -128,6 +132,8 @@ class ViewRequest extends React.Component {
   constructor(props) {
     super(props);
 
+    const { titleLevelRequestsFeatureEnabled } = getTlrSettings(props.parentResources.configs.records[0]?.value);
+
     this.state = {
       request: {},
       accordions: {
@@ -138,6 +144,7 @@ class ViewRequest extends React.Component {
         'staff-notes': true,
       },
       moveRequest: false,
+      titleLevelRequestsFeatureEnabled,
     };
 
     const { stripes: { connect } } = props;
@@ -163,12 +170,21 @@ class ViewRequest extends React.Component {
   componentDidUpdate(prevProps) {
     const prevRQ = prevProps.resources.selectedRequest;
     const currentRQ = this.props.resources.selectedRequest;
+    const prevSettings = prevProps.parentResources.configs.records[0]?.value;
+    const currentSettings = this.props.parentResources.configs.records[0]?.value;
 
     // Only update if actually needed (otherwise, this gets called way too often)
     if (prevRQ && currentRQ && currentRQ.hasLoaded) {
       if ((!isEqual(prevRQ.records[0], currentRQ.records[0]))) {
         this.loadFullRequest(currentRQ.records[0]);
       }
+    }
+
+    if (prevSettings !== currentSettings) {
+      const { titleLevelRequestsFeatureEnabled } = getTlrSettings(currentSettings);
+
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ titleLevelRequestsFeatureEnabled });
     }
   }
 
@@ -414,6 +430,10 @@ class ViewRequest extends React.Component {
 
     const actionMenu = ({ onToggle }) => {
       if (isRequestClosed) {
+        if (request.requestLevel === REQUEST_LEVEL_TYPES.TITLE && !this.state.titleLevelRequestsFeatureEnabled) {
+          return null;
+        }
+
         return (
           <IfPermission perm="ui-requests.create">
             <Button

--- a/src/ViewRequest.test.js
+++ b/src/ViewRequest.test.js
@@ -1,28 +1,65 @@
 import React from 'react';
 import {
   render,
+  screen,
 } from '@testing-library/react';
 import moment from 'moment-timezone';
 
 import '../test/jest/__mock__';
 
+import {
+  Pane,
+} from '@folio/stripes/components';
+
 import ViewRequest from './ViewRequest';
 import RequestForm from './RequestForm';
+import { requestStatuses, REQUEST_LEVEL_TYPES } from './constants';
 
 jest.mock('./RequestForm', () => jest.fn(() => null));
 jest.mock('./MoveRequestManager', () => jest.fn(() => null));
+jest.mock('./ItemDetail', () => jest.fn(() => null));
+jest.mock('./UserDetail', () => jest.fn(() => null));
+jest.mock('./CancelRequestDialog', () => jest.fn(() => null));
+jest.mock('./PositionLink', () => jest.fn(() => null));
+jest.mock('./components/TitleInformation', () => jest.fn(() => null));
+Pane.mockImplementation(({ children, actionMenu }) => (
+  <div>
+    {children}
+    {actionMenu({ onToggle: jest.fn() })}
+  </div>
+));
 
 describe('ViewRequest', () => {
+  const labelIds = {
+    duplicateRequest: 'ui-requests.actions.duplicateRequest',
+  };
   const mockedRequest = {
+    instance: {
+      title: 'Title',
+    },
+    item: {
+      barcode: 'barcode',
+    },
     id: 'testId',
     holdShelfExpirationDate: 'Wed Nov 24 2021 14:38:30',
-  };
-
-  const defaultProps = {
-    location: {
-      pathname: 'pathname',
-      search: '?layer=edit',
+    requestLevel: REQUEST_LEVEL_TYPES.TITLE,
+    status: requestStatuses.CANCELLED,
+    pickupServicePointId: 'servicePoint',
+    metadata: {
+      createdDate: 'createdDate',
     },
+  };
+  const mockedLocation = {
+    pathname: 'pathname',
+    search: null,
+  };
+  const mockedConfig = {
+    records: [
+      { value: '{"titleLevelRequestsFeatureEnabled":true}' },
+    ],
+  };
+  const defaultProps = {
+    location: mockedLocation,
     history: {
       push: jest.fn(),
     },
@@ -34,6 +71,18 @@ describe('ViewRequest', () => {
     onClose: jest.fn(),
     onCloseEdit: jest.fn(),
     buildRecordsForHoldsShelfReport: jest.fn(),
+    optionLists: {
+      cancellationReasons: [
+        { id: '1' },
+        { id: '2' },
+      ],
+      servicePoints: [
+        { id: 'servicePoint' },
+      ],
+    },
+    parentResources: {
+      configs: mockedConfig,
+    },
     resources: {
       selectedRequest: {
         hasLoaded: true,
@@ -43,8 +92,8 @@ describe('ViewRequest', () => {
       },
     },
     stripes: {
-      hasPerm: jest.fn(),
-      connect: jest.fn(),
+      hasPerm: jest.fn(() => true),
+      connect: jest.fn((component) => component),
       logger: {
         log: jest.fn(),
       },
@@ -66,17 +115,49 @@ describe('ViewRequest', () => {
     RequestForm.mockClear();
   });
 
-  it('should set `createTitleLevelRequest` to false when try to edit existed request', () => {
-    const expectedResult = {
-      initialValues : {
-        requestExpirationDate: null,
-        holdShelfExpirationDate: mockedRequest.holdShelfExpirationDate,
-        holdShelfExpirationTime: moment(mockedRequest.holdShelfExpirationDate).format('HH:mm'),
-        createTitleLevelRequest: false,
-        ...mockedRequest,
-      },
-    };
+  describe('when work with request editing', () => {
+    beforeAll(() => {
+      mockedLocation.search = '?layer=edit';
+    });
 
-    expect(RequestForm).toHaveBeenCalledWith(expect.objectContaining(expectedResult), {});
+    it('should set `createTitleLevelRequest` to false when try to edit existed request', () => {
+      const expectedResult = {
+        initialValues : {
+          requestExpirationDate: null,
+          holdShelfExpirationDate: mockedRequest.holdShelfExpirationDate,
+          holdShelfExpirationTime: moment(mockedRequest.holdShelfExpirationDate).format('HH:mm'),
+          createTitleLevelRequest: false,
+          ...mockedRequest,
+        },
+      };
+      screen.debug();
+      expect(RequestForm).toHaveBeenCalledWith(expect.objectContaining(expectedResult), {});
+    });
+  });
+
+  describe('when not working with request editing', () => {
+    beforeAll(() => {
+      mockedLocation.search = null;
+    });
+
+    describe('when current request is closed and TLR in enabled', () => {
+      beforeAll(() => {
+        mockedConfig.records[0].value = '{"titleLevelRequestsFeatureEnabled":true}';
+      });
+
+      it('should render `Duplicate` button', () => {
+        expect(screen.getByText(labelIds.duplicateRequest)).toBeInTheDocument();
+      });
+    });
+
+    describe('when current request is closed and TLR in disabled', () => {
+      beforeAll(() => {
+        mockedConfig.records[0].value = '{"titleLevelRequestsFeatureEnabled":false}';
+      });
+
+      it('should not render `Duplicate` button', () => {
+        expect(screen.queryByText(labelIds.duplicateRequest)).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -19,6 +19,7 @@ jest.mock('@folio/stripes/components', () => ({
       </span>
     </button>
   )),
+  Callout: jest.fn(() => <div>Callout</div>),
   Checkbox: jest.fn(() => <div>Checkbox</div>),
   Col: jest.fn(({ children }) => (
     <div data-test-col>
@@ -32,7 +33,7 @@ jest.mock('@folio/stripes/components', () => ({
       {children}
     </div>
   )),
-  Icon: jest.fn(() => <div>Icon</div>),
+  Icon: jest.fn(({ children }) => <div>{children}</div>),
   Modal: jest.fn(({ children }) => (
     <div>
       {children}

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -14,4 +14,6 @@ jest.mock('@folio/stripes/core', () => ({
   }),
   stripesConnect: jest.fn((component) => component),
   Pluggable: jest.fn(() => null),
+  IfPermission: jest.fn(({ children }) => <div>{children}</div>),
+  TitleManager: jest.fn(jest.fn(() => null)),
 }));


### PR DESCRIPTION
## Purpose
Closed title-level request should not be able to be duplicated when TLR is disabled in settings.
Also if we have no any action for request,`Actions` button should not apear.

## Approach
We just need to check the level of `Closed` request and TLR feature state in settings.
If there are no buttons in action menu, the `Actions` button is not rendered by default.

## Refs
https://issues.folio.org/browse/UIREQ-691