### PR TITLE
UIREQ-605 - Add preferred name to Requests UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * When newly added patron is deleted after making and canceling request, requests page is unstable. Refs UIREQ-672.
 * Import `stripes-core` components via `@folio/stripes`. Refs UIREQ-609.
 * Create reusable component for render title level information. Refs UIREQ-654.
+* Add preferred name to Requests UI. Refs UIREQ-605.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,8 +39,10 @@ export function getFullName(user) {
   const lastName = get(userNameObj, ['lastName'], '');
   const firstName = get(userNameObj, ['firstName'], '');
   const middleName = get(userNameObj, ['middleName'], '');
+  const preferredFirstName = get(userNameObj, ['preferredFirstName'], '');
+  const displayedFirstName = preferredFirstName || firstName;
 
-  return `${lastName}${firstName ? ', ' : ' '}${firstName} ${middleName}`;
+  return `${lastName}${displayedFirstName ? ', ' : ' '}${displayedFirstName} ${middleName}`;
 }
 
 export const createUserHighlightBoxLink = (linkText, id) => {


### PR DESCRIPTION
## Purpose
As a staff user
I want to see the patron's preferred first name in the name display in the Checkout and Request UI
so that I might address the patron properly.

## Approach
condition, included preferredFirstName has been added to the getFullName function

## Refs
https://issues.folio.org/browse/UIREQ-605