### PR TITLE
UIREQ-690: After the "Select item" window appears, the size of the Request information changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Import `stripes-core` components via `@folio/stripes`. Refs UIREQ-609.
 * Create reusable component for render title level information. Refs UIREQ-654.
 * Add preferred name to Requests UI. Refs UIREQ-605.
+* After the "Select item" window appears, the size of the Request information changes. Refs UIREQ-690.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/ItemsDialog.js
+++ b/src/ItemsDialog.js
@@ -14,7 +14,9 @@ import {
   Modal,
   MultiColumnList,
   Pane,
+  Paneset,
 } from '@folio/stripes/components';
+
 import { Loading } from './components';
 
 import css from './ItemsDialog.css';
@@ -80,29 +82,34 @@ const ItemsDialog = ({
       onClose={onClose}
       dismissible
     >
-      <Pane
-        paneTitle={formatMessage({ id: 'ui-requests.items.instanceItems' }, { title })}
-        paneSub={formatMessage({ id: 'ui-requests.resultCount' }, { count })}
-        defaultWidth="fill"
-        noOverflow
+      <Paneset
+        id="itemsDialog"
+        isRoot
+        static
       >
-        {isLoading
-          ? <Loading />
-          : <MultiColumnList
-            id="instance-items-list"
-            interactive
-            ariaLabel={formatMessage({ id: 'ui-requests.items.instanceItems' })}
-            contentData={contentData}
-            visibleColumns={COLUMN_NAMES}
-            columnMapping={COLUMN_MAP}
-            columnWidths={COLUMN_WIDTHS}
-            formatter={formatter}
-            maxHeight={MAX_HEIGHT}
-            isEmptyMessage={formatMessage({ id: 'ui-requests.items.instanceItems.notFound' })}
-            onRowClick={onRowClick}
-          />
-        }
-      </Pane>
+        <Pane
+          paneTitle={formatMessage({ id: 'ui-requests.items.instanceItems' }, { title })}
+          paneSub={formatMessage({ id: 'ui-requests.resultCount' }, { count })}
+          defaultWidth="fill"
+        >
+          {isLoading
+            ? <Loading />
+            : <MultiColumnList
+              id="instance-items-list"
+              interactive
+              ariaLabel={formatMessage({ id: 'ui-requests.items.instanceItems' })}
+              contentData={contentData}
+              visibleColumns={COLUMN_NAMES}
+              columnMapping={COLUMN_MAP}
+              columnWidths={COLUMN_WIDTHS}
+              formatter={formatter}
+              maxHeight={MAX_HEIGHT}
+              isEmptyMessage={formatMessage({ id: 'ui-requests.items.instanceItems.notFound' })}
+              onRowClick={onRowClick}
+            />
+          }
+        </Pane>
+      </Paneset>
     </Modal>
   );
 };

--- a/src/ItemsDialog.test.js
+++ b/src/ItemsDialog.test.js
@@ -76,7 +76,6 @@ describe('ItemsDialog', () => {
           paneTitle: labelIds.instanceItems,
           paneSub: labelIds.resultCount,
           defaultWidth: 'fill',
-          noOverflow: true,
         }), {}
       );
     });

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -36,6 +36,11 @@ jest.mock('@folio/stripes/components', () => ({
       {children}
     </div>
   )),
+  Paneset: jest.fn(({ children }) => (
+    <div>
+      {children}
+    </div>
+  )),
   Row: jest.fn(({ children }) => (
     <div data-test-row>
       {children}


### PR DESCRIPTION
## Purpose
After the "Select item" window appears, the size of the Request information changes

## Approach
Wrapped `Pane` in `Paneset`

## Refs
https://issues.folio.org/browse/UIREQ-690

## Screenshot
### before
![Request-page](https://user-images.githubusercontent.com/24813219/146039084-1a87b392-1a78-4aac-a85c-603de469cc22.gif)
### after
![image](https://user-images.githubusercontent.com/24813219/146039175-23bf61ae-5133-4d31-91cb-17906a7bd01c.png)
