### PR TITLE
UIREQ-698 upgrade to current react-beautiful-dnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Create reusable component for render title level information. Refs UIREQ-654.
 * Add preferred name to Requests UI. Refs UIREQ-605.
 * After the "Select item" window appears, the size of the Request information changes. Refs UIREQ-690.
+* Upgrade `react-beautiful-dnd` to `v13.1.0`. Refs UIREQ-698.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "prop-types": "^15.5.10",
     "query-string": "^5.1.0",
     "react-barcode": "^1.3.2",
-    "react-beautiful-dnd": "^11.0.5",
+    "react-beautiful-dnd": "^13.1.0",
     "react-fast-compare": "^3.2.0",
     "react-hot-loader": "^4.3.12",
     "react-router-prop-types": "^1.0.4",

--- a/test/bigtest/interactors/sortable-list.js
+++ b/test/bigtest/interactors/sortable-list.js
@@ -9,8 +9,17 @@ import {
 import DraggableRow from './draggable-row';
 
 @interactor class SortableListInteractor {
-  log = text('[role="log"]');
-  logPresent = isPresent('[role="log"]');
+  // rbd v11 placed three attributes, role=log, aria-live=assertive, and aria-atomic
+  // on the container of the sortable list.
+  // `role=log` was removed in https://github.com/atlassian/react-beautiful-dnd/commit/45ef30cd3ea422f8b9fb7eb142072f7e97b5272b#diff-98d5d7eb2b2f94535a8212ec54f4ec17c94c1bf123d9ffd0f22d0ec687a60a33
+  // as part of https://github.com/atlassian/react-beautiful-dnd/pull/1741
+  // to clean up lift announcements (https://github.com/atlassian/react-beautiful-dnd/issues/1695)
+  //
+  // because log and logPresent are part of the public API here,
+  // the name has been left in place
+  log = text('[aria-live="assertive"][aria-atomic]');
+  logPresent = isPresent('[aria-live="assertive"][aria-atomic]');
+
   rows = collection('[data-test-draggable-row]', DraggableRow);
 
   row = scoped('#row-1', DraggableRow);


### PR DESCRIPTION
Older versions of `react-beautiful-dnd` drag in an unsupported version
of `core-js` that causes a build warning. Update to a current version
and adjust the `sortable-list` interactor to reflect changes to the
attributes on the list-wrapper element.

Refs [UIREQ-698](https://issues.folio.org/browse/UIREQ-698), [STRIPES-675](https://issues.folio.org/browse/STRIPES-675)