### PR TITLE
UIREQ-695: Migrate requests queue/reorder page on new end-points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Turn an item level request into a title level request. Refs UIREQ-635.
 * View & reorder requests (first accordion). Refs UIREQ-630.
 * View & reorder requests (second accordion). Refs UIREQ-644.
+* Migrate requests queue/reorder page on new end-points. Refs UIREQ-695.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/PositionLink.js
+++ b/src/PositionLink.js
@@ -12,22 +12,23 @@ import {
 
 export default function PositionLink({ request }) {
   const queuePosition = get(request, 'position');
-  const barcode = get(request, 'item.barcode');
   const id = request[request.requestLevel === REQUEST_LEVEL_TYPES.ITEM ? 'itemId' : 'instanceId'];
   const openRequestsPath = `/requests?filters=${openRequestStatusFilters}&query=${id}&sort=${REQUEST_DATE}`;
 
-  return (request && barcode ?
-    <div>
-      <span>
-        {queuePosition}
-        &nbsp;
-        &nbsp;
-      </span>
-      <Link to={openRequestsPath}>
-        <FormattedMessage id="ui-requests.actions.viewRequestsInQueue" />
-      </Link>
-    </div> : '-'
-  );
+  return request
+    ? (
+      <div>
+        <span>
+          {queuePosition}
+          &nbsp;
+          &nbsp;
+        </span>
+        <Link to={openRequestsPath}>
+          <FormattedMessage id="ui-requests.actions.viewRequestsInQueue" />
+        </Link>
+      </div>
+    )
+    : '-';
 }
 
 PositionLink.propTypes = {

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -776,8 +776,11 @@ class RequestForm extends React.Component {
     }
 
     const instanceItems = await this.getInstanceItems(instance.id);
-
     const requestTypeOptions = getInstanceRequestTypeOptions(instanceItems);
+
+    if (requestTypeOptions.length) {
+      this.props.change('requestType', requestTypeOptions[0].value);
+    }
 
     this.setState({ requestTypeOptions });
   }
@@ -850,7 +853,7 @@ class RequestForm extends React.Component {
   requireUser = (value) => {
     const values = this.getCurrentFormValues();
 
-    if (!value && !values.requesterId) {
+    if (!value && !values?.requesterId) {
       return <FormattedMessage id="ui-requests.errors.selectUser" />;
     }
 
@@ -995,6 +998,7 @@ class RequestForm extends React.Component {
       unset(requestData, RESOURCE_TYPES.ITEM);
     }
 
+    unset(requestData, 'titleRequestCount');
     unset(requestData, 'createTitleLevelRequest');
     unset(requestData, RESOURCE_TYPES.INSTANCE);
 
@@ -1255,7 +1259,7 @@ class RequestForm extends React.Component {
                       type="checkbox"
                       label={formatMessage({ id: 'ui-requests.requests.createTitleLevelRequest' })}
                       component={Checkbox}
-                      disabled={!this.state.titleLevelRequestsFeatureEnabled}
+                      disabled={!this.state.titleLevelRequestsFeatureEnabled || isItemOrInstanceLoading}
                       onChange={this.handleTlrCheckboxChange}
                     />
                   </Col>

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -264,6 +264,17 @@ class ViewRequest extends React.Component {
     this.setState({ moveRequest: true });
   }
 
+  onReorderRequest = (request) => {
+    const {
+      location: { search },
+      history,
+    } = this.props;
+    const { titleLevelRequestsFeatureEnabled } = this.state;
+    const idForHistory = titleLevelRequestsFeatureEnabled ? request.instanceId : request.itemId;
+
+    history.push(`${urls.requestQueueView(request.id, idForHistory)}${search}`, { request });
+  }
+
   onToggleSection({ id }) {
     this.setState((curState) => {
       const newState = cloneDeep(curState);
@@ -382,9 +393,7 @@ class ViewRequest extends React.Component {
     const {
       stripes,
       patronGroups,
-      history,
       optionLists: { cancellationReasons },
-      location: { search },
     } = this.props;
     const {
       accordions,
@@ -516,7 +525,7 @@ class ViewRequest extends React.Component {
                 id="reorder-queue"
                 onClick={() => {
                   onToggle();
-                  history.push(`${urls.requestQueueView(request.id, request.itemId)}${search}`, { request });
+                  this.onReorderRequest(request);
                 }}
                 buttonStyle="dropdownItem"
               >

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const RequestsRouting = (props) => {
   return (
     <Switch>
       <Route
-        path={`${path}/view/:requestId/:itemId/reorder`}
+        path={`${path}/view/:requestId/:id/reorder`}
         component={RequestQueueRoute}
       />
       <Route

--- a/src/routes/RequestQueueRoute.js
+++ b/src/routes/RequestQueueRoute.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 import {
   get,
   keyBy,
-  sortBy,
 } from 'lodash';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { stripesConnect } from '@folio/stripes/core';
 
 import RequestQueueView from '../views/RequestQueueView';
 import urls from './urls';
+import { requestStatuses } from '../constants';
+import { getTlrSettings } from '../utils';
 
 class RequestQueueRoute extends React.Component {
   static getRequest(props) {
@@ -23,6 +24,14 @@ class RequestQueueRoute extends React.Component {
   }
 
   static manifest = {
+    configs: {
+      type: 'okapi',
+      records: 'configs',
+      path: 'configurations/entries',
+      params: {
+        query: '(module==SETTINGS and configName==TLR)',
+      },
+    },
     addressTypes: {
       type: 'okapi',
       path: 'addresstypes',
@@ -62,16 +71,23 @@ class RequestQueueRoute extends React.Component {
       type: 'okapi',
       path: 'circulation/requests',
       records: 'requests',
-      params: {
-        query: 'itemId==:{itemId} and status="Open"',
-        limit: '1000',
-      },
+      accumulate: true,
+      fetch: false,
       shouldRefresh: () => false,
     },
-    reorder: {
+    reorderInstanceQueue: {
       type: 'okapi',
       POST: {
-        path: 'circulation/requests/queue/:{itemId}/reorder',
+        path: 'circulation/requests/queue/instance/:{id}/reorder',
+      },
+      fetch: false,
+      clientGeneratePk: false,
+      throwErrors: false,
+    },
+    reorderItemQueue: {
+      type: 'okapi',
+      POST: {
+        path: 'circulation/requests/queue/item/:{id}/reorder',
       },
       fetch: false,
       clientGeneratePk: false,
@@ -90,16 +106,65 @@ class RequestQueueRoute extends React.Component {
       }),
       requests: PropTypes.shape({
         records: PropTypes.array,
-      }),
+      }).isRequired,
+      configs: PropTypes.shape({
+        records: PropTypes.array.isRequired,
+        hasLoaded: PropTypes.bool.isRequired,
+      }).isRequired,
     }),
+    match: PropTypes.object.isRequired,
     mutator: PropTypes.shape({
-      reorder: PropTypes.object,
+      reorderInstanceQueue: PropTypes.object.isRequired,
+      reorderItemQueue: PropTypes.object.isRequired,
+      requests: PropTypes.object.isRequired,
     }),
     history: PropTypes.shape({
       push: PropTypes.func.isRequired,
       goBack: PropTypes.func.isRequired,
     }).isRequired,
   };
+
+  componentDidMount() {
+    this.setTlrSettings();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { configs: prevConfigs } = prevProps.resources;
+    const { configs } = this.props.resources;
+
+    if ((prevConfigs.hasLoaded !== configs.hasLoaded && configs.hasLoaded)) {
+      this.setTlrSettings();
+    }
+  }
+
+  setTlrSettings = () => {
+    const { configs } = this.props.resources;
+    const { titleLevelRequestsFeatureEnabled } = getTlrSettings(configs.records[0]?.value);
+
+    this.setState({ titleLevelRequestsFeatureEnabled }, this.getRequests);
+  }
+
+  getRequests = () => {
+    const {
+      mutator: { requests },
+      resources: {
+        configs,
+      },
+      match: {
+        params,
+      },
+    } = this.props;
+    const { titleLevelRequestsFeatureEnabled } = this.state;
+
+    if (!configs.hasLoaded) {
+      return;
+    }
+
+    const path = `circulation/requests/queue/${titleLevelRequestsFeatureEnabled ? 'instance' : 'item'}/${params.id}`;
+
+    requests.reset();
+    requests.GET({ path });
+  }
 
   getRequest = () => {
     return RequestQueueRoute.getRequest(this.props);
@@ -120,13 +185,21 @@ class RequestQueueRoute extends React.Component {
   }
 
   reorder = (requests) => {
-    const { mutator: { reorder } } = this.props;
+    const {
+      mutator: {
+        reorderInstanceQueue,
+        reorderItemQueue,
+      },
+    } = this.props;
+    const { titleLevelRequestsFeatureEnabled } = this.state;
     const reorderedQueue = requests.map(({ id, position: newPosition }) => ({
       id,
       newPosition,
     }));
 
-    return reorder.POST({ reorderedQueue });
+    return titleLevelRequestsFeatureEnabled
+      ? reorderInstanceQueue.POST({ reorderedQueue })
+      : reorderItemQueue.POST({ reorderedQueue });
   }
 
   isLoading = () => {
@@ -151,11 +224,23 @@ class RequestQueueRoute extends React.Component {
     const { resources, location } = this.props;
     const request = this.getRequest();
     const requests = this.getRequestsWithDeliveryTypes();
+    const notYetFilledRequests = [];
+    const inProgressRequests = [];
+
+    requests
+      .forEach(r => {
+        if (r.status === requestStatuses.NOT_YET_FILLED) {
+          notYetFilledRequests.push(r);
+        } else {
+          inProgressRequests.push(r);
+        }
+      });
 
     return (
       <RequestQueueView
         data={{
-          requests: sortBy(requests, r => r.position),
+          notYetFilledRequests,
+          inProgressRequests,
           item: get(resources, 'items.records[0]', {}),
           holding: get(resources, 'holdings.records[0]', {}),
           request,

--- a/src/routes/urls.js
+++ b/src/routes/urls.js
@@ -1,7 +1,7 @@
 const urls = {
   requests: () => '/requests',
   requestView: id => `/requests/view/${id}`,
-  requestQueueView: (requestId, itemId) => `/requests/view/${requestId}/${itemId}/reorder`,
+  requestQueueView: (requestId, id) => `/requests/view/${requestId}/${id}/reorder`,
 };
 
 export default urls;

--- a/src/views/RequestQueueView.test.js
+++ b/src/views/RequestQueueView.test.js
@@ -31,14 +31,14 @@ describe('RequestQueueView', () => {
       status: requestStatuses.IN_TRANSIT,
     },
   ];
-  const notYetFilledRequest = {
-    status: requestStatuses.NOT_YET_FILLED,
-  };
+  const notYetFilledRequests = [
+    {
+      status: requestStatuses.NOT_YET_FILLED,
+    },
+  ];
   const mockedData = {
-    requests: [
-      ...inProgressRequests,
-      notYetFilledRequest,
-    ],
+    inProgressRequests,
+    notYetFilledRequests,
   };
 
   afterEach(() => {

--- a/src/views/components/ItemLink.js
+++ b/src/views/components/ItemLink.js
@@ -14,11 +14,11 @@ const ItemLink = ({
     instanceId,
     holdingsRecordId,
     itemId,
-    item: { barcode },
+    item,
   },
 }) => (
   requestLevel === REQUEST_LEVEL_TYPES.ITEM
-    ? (<Link to={`/inventory/view/${instanceId}/${holdingsRecordId}/${itemId}`}>{barcode}</Link>)
+    ? (<Link to={`/inventory/view/${instanceId}/${holdingsRecordId}/${itemId}`}>{item.barcode}</Link>)
     : MISSING_VALUE_SYMBOL
 );
 

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -10,11 +10,11 @@ export default function config() {
   this.get('_/proxy/tenants/:id/modules', []);
 
   this.get('/saml/check', {
-    ssoEnabled: false
+    ssoEnabled: false,
   });
 
   this.get('/configurations/entries', {
-    configs: []
+    configs: [],
   });
 
   this.get('/tags');
@@ -28,7 +28,7 @@ export default function config() {
 
   this.post('/bl-users/login', () => {
     return new Response(201, {
-      'X-Okapi-Token': `myOkapiToken:${Date.now()}`
+      'X-Okapi-Token': `myOkapiToken:${Date.now()}`,
     }, {
       user: {
         id: 'test',
@@ -37,11 +37,11 @@ export default function config() {
           lastName: 'User',
           firstName: 'Test',
           email: 'user@folio.org',
-        }
+        },
       },
       permissions: {
-        permissions: []
-      }
+        permissions: [],
+      },
     });
   });
   this.get('/groups', {
@@ -74,7 +74,7 @@ export default function config() {
       'desc': 'Undergraduate Student',
       'id': 'group7',
     }],
-    'totalRecords': 7
+    'totalRecords': 7,
   });
   this.get('/addresstypes', {
     'addressTypes': [{
@@ -102,7 +102,7 @@ export default function config() {
       'desc': 'Work Address',
       'id': 'Type6',
     }],
-    'totalRecords': 6
+    'totalRecords': 6,
   });
 
   this.get('/users', ({ users }, request) => {
@@ -130,7 +130,7 @@ export default function config() {
     const cqlParser = new CQLParser();
     cqlParser.parse(cqlQuery);
     return servicePointsUsers.where({
-      userId: cqlParser.tree.term
+      userId: cqlParser.tree.term,
     });
   });
 
@@ -143,7 +143,7 @@ export default function config() {
       const cqlParser = new CQLParser();
       cqlParser.parse(request.queryParams.query);
       return requestPreferences.where({
-        userId: cqlParser.tree.term
+        userId: cqlParser.tree.term,
       });
     } else {
       return [];
@@ -234,7 +234,7 @@ export default function config() {
       active: true,
       template: '<p><strong>{{item.title}}</strong></p>',
     }],
-    totalRecords: 1
+    totalRecords: 1,
   });
 
   this.get('circulation/pick-slips/servicepointId1', {
@@ -290,6 +290,8 @@ export default function config() {
 
   this.get('/cancellation-reason-storage/cancellation-reasons');
 
+  this.get('circulation/requests/queue/item/:{id}', ({ requests }) => requests.all());
+
   this.get('/circulation/requests', ({ requests }, request) => {
     const sortby = request.queryParams.query.split('sortby ')[1]?.split(' ')[0].split('/');
 
@@ -323,7 +325,7 @@ export default function config() {
 
     return this.create('request', {
       id: body.id,
-      itemId: body.destinationItemId
+      itemId: body.destinationItemId,
     });
   });
 
@@ -342,7 +344,7 @@ export default function config() {
     cqlParser.parse(cqlQuery);
 
     return requests.where({
-      itemId: cqlParser.tree.term
+      itemId: cqlParser.tree.term,
     });
   });
 
@@ -361,7 +363,7 @@ export default function config() {
     }
   });
 
-  this.post('/circulation/requests/queue/:itemId/reorder', []);
+  this.post('circulation/requests/queue/item/:{id}/reorder', []);
 
   this.get('/circulation/loans', ({ loans }, request) => {
     if (request.queryParams.query) {
@@ -369,11 +371,11 @@ export default function config() {
       cqlParser.parse(request.queryParams.query);
       if (cqlParser.tree instanceof CQLBoolean) {
         return loans.where({
-          itemId: cqlParser.tree.left.term
+          itemId: cqlParser.tree.left.term,
         });
       } else {
         return loans.where({
-          itemId: cqlParser.tree.term
+          itemId: cqlParser.tree.term,
         });
       }
     } else {

--- a/test/bigtest/tests/request-queue-test.js
+++ b/test/bigtest/tests/request-queue-test.js
@@ -20,7 +20,7 @@ describe('RequestQueue', () => {
 
   beforeEach(async function () {
     requests = this.server.db.requests;
-    this.visit(urls.requestQueueView(requests[0].id, requests[0].itemId));
+    this.visit(urls.requestQueueView(requests[0].id, requests[0].instanceId));
 
     await requestQueue.whenSortableListPresent();
     await requestQueue.sortableList.whenLogIsPresent();


### PR DESCRIPTION
## Purpose
Migrate requests queue/reorder page on new end-points

## Approach
Depends on is TLR swithced on or off we should pass instanceId or itemId in path and handle this inside component. Depends on what was passed, we should do fetch requests from correct endpoints, and send back reordered queue on correct end-point.

When we send back reorderd queue we should send full queue from first to last position, according this fact `notYetFilledRequests` and `inProgressRequests` collections was extracted one layer highe.

As we now have two separate accordions with requests but still one queue, reorder approach was a little bit changed.

Additionaly I removed `sort` of requests by position because new queue end-points return already sorted array.

Also fixed some small issues which can lead to errors or bugs.

## Refs
https://issues.folio.org/browse/UIREQ-695