### PR TITLE
increase failed tests timeout

### DIFF
--- a/test/bigtest/tests/all-requests-test.js
+++ b/test/bigtest/tests/all-requests-test.js
@@ -12,7 +12,9 @@ const servicePoint = {
   pickupLocation: true,
 };
 
-describe('Requests', () => {
+describe('Requests', function () {
+  this.timeout(5000);
+
   setupApplication({
     currentUser: {
       servicePoints: [servicePoint],


### PR DESCRIPTION
## Purpose
Tests for requests fail because of default timeout(2000 milliseconds).

## Approach
Increase timeout for requests tests
