### PR TITLE
UIREQ-704: Change render dependency for item link and information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@
 * BREAKING: TLR - data migration for dialogboxes and reorder list. Refs UIREQ-665.
 * BREAKING: TLR - data migration for hold shelf clearance report. Refs UIREQ-677.
 * BREAKING: TLR - data migration, move `holdingsRecordId`. Refs UIREQ-685.
-* TLR - data migration for request list, view, create, edit, duplicate. Refs UIREQ-664.
-* TLR - data migration for dialogboxes and reorder list. Refs UIREQ-665.
-* TLR - data migration for hold shelf clearance report. Refs UIREQ-677.
-* TLR - data migration, move `holdingsRecordId`. Refs UIREQ-685.
 * Create title level request checkbox. Refs UIREQ-655.
 * Update request results page. Refs UIREQ-614.
 * Update request details pane. Refs UIREQ-613.
@@ -31,6 +27,7 @@
 * View & reorder requests (second accordion). Refs UIREQ-644.
 * Migrate requests queue/reorder page on new end-points. Refs UIREQ-695.
 * Create new request filter. Refs UIREQ-612.
+* Change render dependency for item link and information from `requestLevel` to `item`. Refs UIREQ-704.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -995,9 +995,11 @@ class RequestForm extends React.Component {
 
     if (requestData.requestLevel === REQUEST_LEVEL_TYPES.TITLE) {
       unset(requestData, 'itemId');
+      unset(requestData, 'holdingsRecordId');
       unset(requestData, RESOURCE_TYPES.ITEM);
     }
 
+    unset(requestData, 'itemRequestCount');
     unset(requestData, 'titleRequestCount');
     unset(requestData, 'createTitleLevelRequest');
     unset(requestData, RESOURCE_TYPES.INSTANCE);

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -400,7 +400,10 @@ class ViewRequest extends React.Component {
       isCancellingRequest,
       moveRequest,
     } = this.state;
-    const { requestLevel } = request;
+    const {
+      requestLevel,
+      item,
+    } = request;
 
     const getPickupServicePointName = this.getPickupServicePointName(request);
     const requestStatus = get(request, ['status'], '-');
@@ -588,13 +591,8 @@ class ViewRequest extends React.Component {
               />
             }
           >
-            {requestLevel === REQUEST_LEVEL_TYPES.TITLE
+            { item
               ? (
-                <FormattedMessage
-                  id="ui-requests.item.noInformation"
-                />
-              )
-              : (
                 <ItemDetail
                   item={{
                     ...request.item,
@@ -605,6 +603,11 @@ class ViewRequest extends React.Component {
                   }}
                   loan={request.loan}
                   requestCount={request.itemRequestCount}
+                />
+              )
+              : (
+                <FormattedMessage
+                  id="ui-requests.item.noInformation"
                 />
               )
             }

--- a/src/views/components/ItemLink.js
+++ b/src/views/components/ItemLink.js
@@ -4,20 +4,18 @@ import PropTypes from 'prop-types';
 
 import {
   MISSING_VALUE_SYMBOL,
-  REQUEST_LEVEL_TYPES,
 } from '../../constants';
 
 
 const ItemLink = ({
   request: {
-    requestLevel,
     instanceId,
     holdingsRecordId,
     itemId,
     item,
   },
 }) => (
-  requestLevel === REQUEST_LEVEL_TYPES.ITEM
+  item
     ? (<Link to={`/inventory/view/${instanceId}/${holdingsRecordId}/${itemId}`}>{item.barcode}</Link>)
     : MISSING_VALUE_SYMBOL
 );

--- a/src/views/components/ItemLink.test.js
+++ b/src/views/components/ItemLink.test.js
@@ -10,7 +10,6 @@ import '../../../test/jest/__mock__';
 import ItemLink from './ItemLink';
 
 import {
-  REQUEST_LEVEL_TYPES,
   MISSING_VALUE_SYMBOL,
 } from '../../constants';
 
@@ -19,18 +18,21 @@ describe('ItemLink', () => {
     barcode: 'testItemBarcode',
   };
   const mockedRequest = {
-    requestLevel: REQUEST_LEVEL_TYPES.ITEM,
     instanceId: 'testInstanceId',
     holdingsRecordId: 'testHoldingsRecordId',
     itemId: 'testItemId',
-    item: mockedItem,
   };
 
-  describe(`if request level is ${REQUEST_LEVEL_TYPES.ITEM}`, () => {
+  describe('if `item` is present in request', () => {
     beforeEach(() => {
       render(
         <BrowserRouter>
-          <ItemLink request={mockedRequest} />
+          <ItemLink
+            request={{
+              ...mockedRequest,
+              item: mockedItem,
+            }}
+          />
         </BrowserRouter>
       );
     });
@@ -46,15 +48,12 @@ describe('ItemLink', () => {
     });
   });
 
-  describe(`if request level is ${REQUEST_LEVEL_TYPES.TITLE}`, () => {
+  describe('if there is no `item` in request', () => {
     beforeEach(() => {
       render(
         <BrowserRouter>
           <ItemLink
-            request={{
-              ...mockedRequest,
-              requestLevel: REQUEST_LEVEL_TYPES.TITLE,
-            }}
+            request={mockedRequest}
           />
         </BrowserRouter>
       );


### PR DESCRIPTION
## Purpose
Change render dependency for item link and information from `requestLevel` to `item`.

## Approach
Additionaly I droped duplicated records in `CHANGELOG`. They probably was added in scope of merge of master and migration branches in feature branch.
Also added `unset` of two fields, which by different reasons can present in `requestData` when they should not.

## Refs
https://issues.folio.org/browse/UIREQ-704