### PR TITLE
UIREQ-706: Disable validation on reordering for `Page` requests for `TLR` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Create new request filter. Refs UIREQ-612.
 * Change render dependency for item link and information from `requestLevel` to `item`. Refs UIREQ-704.
 * Fixed behavior of `hyperlinks` related to `TLR`. Refs UIREQ-702.
+* Disable validation on reordering for `Page` requests for `TLR` feature. Refs UIREQ-706.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/routes/RequestQueueRoute.js
+++ b/src/routes/RequestQueueRoute.js
@@ -221,6 +221,7 @@ class RequestQueueRoute extends React.Component {
   }
 
   render() {
+    const titleLevelRequestsFeatureEnabled = !!this.state?.titleLevelRequestsFeatureEnabled;
     const { resources, location } = this.props;
     const request = this.getRequest();
     const requests = this.getRequestsWithDeliveryTypes();
@@ -245,6 +246,7 @@ class RequestQueueRoute extends React.Component {
           holding: get(resources, 'holdings.records[0]', {}),
           request,
         }}
+        isTlrEnabled={titleLevelRequestsFeatureEnabled}
         onClose={this.handleClose}
         isLoading={this.isLoading()}
         onReorder={this.reorder}

--- a/src/views/RequestQueueView.js
+++ b/src/views/RequestQueueView.js
@@ -58,6 +58,7 @@ class RequestQueueView extends React.Component {
       holding: PropTypes.object,
       request: PropTypes.object,
     }),
+    isTlrEnabled: PropTypes.bool.isRequired,
     onClose: PropTypes.func,
     onReorder: PropTypes.func,
     isLoading: PropTypes.bool,
@@ -121,6 +122,7 @@ class RequestQueueView extends React.Component {
     }
 
     const { notYetFilledRequests } = this.state;
+    const { isTlrEnabled } = this.props;
     const destIndex = destination.index;
     const sourceIndex = source.index;
     const destRequest = notYetFilledRequests[destIndex];
@@ -130,11 +132,7 @@ class RequestQueueView extends React.Component {
       return;
     }
 
-    if (destIndex === 0 && !isNotYetFilled(destRequest)) {
-      confirmMessage = 'ui-requests.requestQueue.confirmReorder.message1';
-    }
-
-    if (destIndex === 0 && isPageRequest(destRequest)) {
+    if (destIndex === 0 && isPageRequest(destRequest) && !isTlrEnabled) {
       confirmMessage = 'ui-requests.requestQueue.confirmReorder.message2';
     }
 


### PR DESCRIPTION
## Purpose
Disable validation on reordering for `Page` requests for `TLR` feature.

## Approach
We just need to check is our TLR feature enabled.
Also we can remove validation on not yet filled request, because now we have two accordions for requests with different statuses. At the second accordion, where we can reorder queue, will not be requests with status differ than `Open - Not yet filled`.

## Refs
https://issues.folio.org/browse/UIREQ-706