### PR TITLE
UIREQ-707: Add all required attributes for the `position` field in request info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Change render dependency for item link and information from `requestLevel` to `item`. Refs UIREQ-704.
 * Fixed behavior of `hyperlinks` related to `TLR`. Refs UIREQ-702.
 * Disable validation on reordering for `Page` requests for `TLR` feature. Refs UIREQ-706.
+* Add all required attributes for the `position` field in request info. Refs UIREQ-707.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/PositionLink.js
+++ b/src/PositionLink.js
@@ -2,7 +2,7 @@ import get from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import {
   requestStatuses,
@@ -13,6 +13,7 @@ export default function PositionLink({
   request,
   isTlrEnabled,
 }) {
+  const { formatMessage } = useIntl();
   const queuePosition = get(request, 'position');
   const id = request[isTlrEnabled ? 'instanceId' : 'itemId'];
   const openRequestsPath = `/requests?filters=requestStatus.${requestStatuses.NOT_YET_FILLED}&query=${id}&sort=${REQUEST_DATE}`;
@@ -21,12 +22,11 @@ export default function PositionLink({
     ? (
       <div>
         <span>
-          {queuePosition}
-          &nbsp;
+          {`${queuePosition} (${formatMessage({ id: 'ui-requests.items' }, { number: request.numberOfNotYetFilledRequests })})`}
           &nbsp;
         </span>
         <Link to={openRequestsPath}>
-          <FormattedMessage id="ui-requests.actions.viewRequestsInQueue" />
+          {formatMessage({ id: 'ui-requests.actions.viewRequestsInQueue' })}
         </Link>
       </div>
     )

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -2,6 +2,7 @@
   "routingErrorOops": "Uh-oh!",
   "routingError": "How did you get to {pathname}?",
 
+  "items": "{number} items",
   "meta.title": "Requests",
   "resultCount": "{count, number} {count, plural, one {Record found} other {Records found}}",
   "barcode": "Barcode",
@@ -28,6 +29,7 @@
   "enter": "Enter",
   "requestNotAllowed": "Request not allowed",
   "requestLevel": "Request level",
+
   "itemLevel": "Item",
   "titleLevel": "Title",
   "requests.title": "Title",


### PR DESCRIPTION
## Purpose
Add all required attributes for the `position` field in request info

## Approach
End-points for geting requests was changed because our BE team says that using of `request-storage` is not correct way.
Removed multiple `settings` parsing, now all necessary fields stored in the `state`.

## Refs
https://issues.folio.org/browse/UIREQ-707