### PR TITLE
STCOM-904 - Result List Revisions.

### DIFF
--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -826,14 +826,14 @@ class RequestsRoute extends React.Component {
       'proxy': rq => (rq.proxy ? getFullName(rq.proxy) : ''),
       'requestDate': rq => (
         <AppIcon size="small" app="requests">
-          <TextLink to={this.getRowURL(rq.id)} onClick={() => this.setURL(rq.id)}><FormattedTime value={rq.requestDate} day="numeric" month="numeric" year="numeric" /></TextLink>
+          <FormattedTime value={rq.requestDate} day="numeric" month="numeric" year="numeric" />
         </AppIcon>
       ),
       'requester': rq => (rq.requester ? `${rq.requester.lastName}, ${rq.requester.firstName}` : ''),
       'requesterBarcode': rq => (rq.requester ? rq.requester.barcode : ''),
       'requestStatus': rq => <FormattedMessage id={requestStatusesTranslations[rq.status]} />,
       'type': rq => <FormattedMessage id={requestTypesTranslations[rq.requestType]} />,
-      'title': rq => (rq.instance ? rq.instance.title : ''),
+      'title': rq => <TextLink to={this.getRowURL(rq.id)} onClick={() => this.setURL(rq.id)}>{(rq.instance ? rq.instance.title : '')}</TextLink>,
     };
 
     const actionMenu = ({ onToggle, renderColumnsMenu }) => (
@@ -983,7 +983,7 @@ class RequestsRoute extends React.Component {
             renderFilters={this.renderFilters}
             resultIsSelected={this.resultIsSelected}
             onFilterChange={this.handleFilterChange}
-            resultClickHandlers={false}
+            resultRowClickHandlers={false}
             pageAmount={100}
             pagingType="click"
           />


### PR DESCRIPTION
The problem: currently result lists in FOLIO suffer due to poor accessibility. Row-level block anchors is the direct cause.

The solution: render links to detail records within result listing cells and remove the block level anchors.

1. Use the exported `defaultMCLRowFormatter` from stripes-components rather than the built-in anchor formatter of `SearchAndSort`
2. Implement a local function to get the URL of each result item.
3. Render the link in a cell using the `<TextLink>` component from stripes-components.
4. use the `SearchAndSort` prop setting `resultRowClickHandlers={false}` to suppress `SearchAndSort`'s built-in click behavior.
5. supply your app's own `resultIsSelected` logic - in this PR, we hold the selected item in a state key that's set when the record link is clicked and cleared when the view record is dismissed.

![image](https://user-images.githubusercontent.com/20704067/149019525-397c3053-a323-4f79-a5d3-9f41809ea58e.png)
