### PR TITLE
UIREQ-717: Upgrade circulation to 13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Select item modal should display all items in the Instance when user uncheck box. Refs UIREQ-700.
 * Header and Subhead do not match the given form in Request queue page. Refs UIREQ-713.
 * Fulfillment in progress accordion should have position column in Request queue page. Refs UIREQ-705.
+* Upgrade `circulation` to `13.0`. Refs UIREQ-717.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "queryResource": "query",
     "okapiInterfaces": {
       "cancellation-reason-storage": "1.1",
-      "circulation": "12.0",
+      "circulation": "13.0",
       "inventory": "10.0 11.0",
       "request-storage": "4.0",
       "pick-slips": "0.1",


### PR DESCRIPTION
## Purpose
Support okapi interfaces `circulation` `13.0`

## Approach
* Was changed API associated with request queue.

## Refs
https://issues.folio.org/browse/UIREQ-717