### PR TITLE
UIREQ-726: Fix unnecessary add of the `numberOfNotYetFilledRequests` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Fulfillment in progress accordion should have position column in Request queue page. Refs UIREQ-705.
 * Upgrade `circulation` to `13.0`. Refs UIREQ-717.
 * Fix the issue when user is not redirected to "Item page". Refs UIREQ-714.
+* Fix unnecessary add of the `numberOfNotYetFilledRequests` field to the request data. Refs UIREQ-726.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -1000,6 +1000,7 @@ class RequestForm extends React.Component {
     unset(requestData, 'itemRequestCount');
     unset(requestData, 'titleRequestCount');
     unset(requestData, 'createTitleLevelRequest');
+    unset(requestData, 'numberOfNotYetFilledRequests');
     unset(requestData, RESOURCE_TYPES.INSTANCE);
 
     return this.props.onSubmit(requestData);

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -215,6 +215,7 @@ class ViewRequest extends React.Component {
     delete updatedRecord.itemStatus;
     delete updatedRecord.titleRequestCount;
     delete updatedRecord.itemRequestCount;
+    delete updatedRecord.numberOfNotYetFilledRequests;
     delete updatedRecord.holdShelfExpirationTime;
 
     this.props.mutator.selectedRequest.PUT(updatedRecord).then(() => {


### PR DESCRIPTION
## Purpose
Fix unnecessary add of the `numberOfNotYetFilledRequests` field to the request data.

## Refs
https://issues.folio.org/browse/UIREQ-726