### PR TITLE
UIREQ-727: Fix `view requests in queue` link behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Fix unnecessary add of the `numberOfNotYetFilledRequests` field to the request data. Refs UIREQ-726.
 * Make translation keys more specific. Refs UIREQ-715.
 * Fulfillment Preference field not respecting user fulfillment preferences in edit mode. Refs UIREQ-658.
+* Fix `view requests in queue` link behaviour. Refs UIREQ-727.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/PositionLink.js
+++ b/src/PositionLink.js
@@ -4,7 +4,10 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 
+import { NoValue } from '@folio/stripes-components';
+
 import {
+  requestOpenStatuses,
   requestStatuses,
   REQUEST_DATE,
 } from './constants';
@@ -18,7 +21,7 @@ export default function PositionLink({
   const id = request[isTlrEnabled ? 'instanceId' : 'itemId'];
   const openRequestsPath = `/requests?filters=requestStatus.${requestStatuses.NOT_YET_FILLED}&query=${id}&sort=${REQUEST_DATE}`;
 
-  return request
+  return requestOpenStatuses.includes(request.status)
     ? (
       <div>
         <span>
@@ -30,7 +33,7 @@ export default function PositionLink({
         </Link>
       </div>
     )
-    : '-';
+    : <NoValue />;
 }
 
 PositionLink.propTypes = {

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -142,6 +142,7 @@ class RequestForm extends React.Component {
         GET: PropTypes.func.isRequired,
       }).isRequired,
     }).isRequired,
+    isTlrEnabledOnEditPage: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -150,6 +151,7 @@ class RequestForm extends React.Component {
     optionLists: {},
     pristine: true,
     submitting: false,
+    isTlrEnabledOnEditPage: false,
   };
 
   constructor(props) {
@@ -1100,6 +1102,7 @@ class RequestForm extends React.Component {
       },
       errorMessage,
       onCancel,
+      isTlrEnabledOnEditPage,
     } = this.props;
 
     const {
@@ -1530,7 +1533,12 @@ class RequestForm extends React.Component {
                         <Col xs={3}>
                           <KeyValue
                             label={<FormattedMessage id="ui-requests.position" />}
-                            value={<PositionLink request={request} />}
+                            value={
+                              <PositionLink
+                                request={request}
+                                isTlrEnabled={isTlrEnabledOnEditPage}
+                              />
+                          }
                           />
                         </Col>
                       </Row> }

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -315,6 +315,9 @@ class ViewRequest extends React.Component {
       patronGroups,
       parentMutator,
     } = this.props;
+    const {
+      titleLevelRequestsFeatureEnabled,
+    } = this.state;
 
     const query = location.search ? queryString.parse(location.search) : {};
 
@@ -354,6 +357,7 @@ class ViewRequest extends React.Component {
                 query={this.props.query}
                 parentMutator={parentMutator}
                 findResource={findResource}
+                isTlrEnabledOnEditPage={titleLevelRequestsFeatureEnabled}
               />
             </Layer>
           ) }

--- a/src/constants.js
+++ b/src/constants.js
@@ -43,6 +43,13 @@ export const requestStatuses = {
   UNFILLED: 'Closed - Unfilled',
 };
 
+export const requestOpenStatuses = [
+  requestStatuses.AWAITING_DELIVERY,
+  requestStatuses.AWAITING_PICKUP,
+  requestStatuses.IN_TRANSIT,
+  requestStatuses.NOT_YET_FILLED,
+];
+
 // map from API's enum-value to translation key
 export const requestStatusesTranslations = {
   'Closed - Cancelled': 'ui-requests.filters.requestStatus.cancelled',


### PR DESCRIPTION
## Purpose
The user should be redirected at the same page if click on the "view requests in queue" link from `request detail` page and from `edit` page.
Also if request has one of `closed` status we should display `dash` in queue field.

## Approach
On `edit` page we didn't pass `isTlrEnabled` in `PositionLink` component. Thats the reason why we always was redirected on `item` queue insead of `instance`.
I tried to pass `parrentResources` into the `RequestForm` component from `ViewRequest` to get TLR feature status directly in `RequestForm`, but this broke some logic.
So I passed just `isTlrEnabled` flag from `ViewRequest` thru `RequestForm` into `PositionLink` component.

## Refs
https://issues.folio.org/browse/UIREQ-727