### PR TITLE
UIREQ-730: Add link for `Requests on item` field if level of request is `Title`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Make translation keys more specific. Refs UIREQ-715.
 * Fulfillment Preference field not respecting user fulfillment preferences in edit mode. Refs UIREQ-658.
 * Fix `view requests in queue` link behaviour. Refs UIREQ-727.
+* Add link for `Requests on item` field if level of request is `Title`. Refs UIREQ-730.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -17,6 +17,8 @@ import {
 
 import { openRequestStatusFilters } from './utils';
 
+const DEFAULT_COUNT_VALUE = 0;
+
 const ItemDetail = ({
   currentInstanceId,
   request,
@@ -34,18 +36,20 @@ const ItemDetail = ({
   const holdingsRecordId = request?.holdingsRecordId || item.holdingsRecordId;
   const title = request?.instance.title || item.title || <NoValue />;
   const contributor = request?.instance.contributorNames?.[0]?.name || item.contributorNames?.[0]?.name || <NoValue />;
-  const count = request?.itemRequestCount || requestCount;
+  const count = request?.itemRequestCount || requestCount || DEFAULT_COUNT_VALUE;
   const status = item.status.name || item.status || <NoValue />;
   const effectiveLocationName = item.effectiveLocation?.name || item.location?.name || <NoValue />;
   const dueDate = loan?.dueDate ? <FormattedDate value={loan.dueDate} /> : <NoValue />;
 
   const effectiveCallNumberString = effectiveCallNumber(item);
   const recordLink = itemId ? <Link to={`/inventory/view/${instanceId}/${holdingsRecordId}/${itemId}`}>{item.barcode || itemId}</Link> : <NoValue />;
-  const positionLink = (
-    <Link to={`/requests?filters=${openRequestStatusFilters}&query=${itemId}&sort=Request Date`}>
-      {count}
-    </Link>
-  );
+  const positionLink = count
+    ? (
+      <Link to={`/requests?filters=${openRequestStatusFilters}&query=${itemId}&sort=Request Date`}>
+        {count}
+      </Link>
+    )
+    : count;
   const itemLabel = item.barcode ? 'ui-requests.item.barcode' : 'ui-requests.item.id';
 
   return (
@@ -99,9 +103,10 @@ const ItemDetail = ({
           data-test-requests-on-item
           xs={4}
         >
-          <KeyValue label={<FormattedMessage id="ui-requests.item.requestsOnItem" />}>
-            {positionLink}
-          </KeyValue>
+          <KeyValue
+            label={<FormattedMessage id="ui-requests.item.requestsOnItem" />}
+            value={positionLink}
+          />
         </Col>
       </Row>
     </>

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -603,17 +603,21 @@ class RequestsRoute extends React.Component {
   }
 
   // Called as a map function
-  addRequestFields(r) {
-    const { requestLevel } = r;
+  addRequestFields(request) {
+    const {
+      requesterId,
+      instanceId,
+      itemId,
+    } = request;
     const { titleLevelRequestsFeatureEnabled } = this.state;
 
     return Promise.all(
       [
-        this.findResource('user', r.requesterId),
-        this.findResource('requestsForInstance', r.instanceId),
-        ...(requestLevel === REQUEST_LEVEL_TYPES.ITEM
+        this.findResource('user', requesterId),
+        this.findResource('requestsForInstance', instanceId),
+        ...(itemId
           ? [
-            this.findResource('requestsForItem', r.itemId),
+            this.findResource('requestsForItem', itemId),
           ]
           : []),
       ],
@@ -625,14 +629,14 @@ class RequestsRoute extends React.Component {
       const dynamicProperties = {};
       const requestsForFilter = titleLevelRequestsFeatureEnabled ? titleRequests : itemRequests;
 
-      dynamicProperties.numberOfNotYetFilledRequests = requestsForFilter.requests.filter(request => request.status === requestStatuses.NOT_YET_FILLED).length;
+      dynamicProperties.numberOfNotYetFilledRequests = requestsForFilter.requests.filter(currentRequest => currentRequest.status === requestStatuses.NOT_YET_FILLED).length;
 
-      if (requestLevel === REQUEST_LEVEL_TYPES.ITEM) {
+      if (itemId) {
         dynamicProperties.itemRequestCount = get(itemRequests, 'totalRecords', 0);
       }
 
       return {
-        ...r,
+        ...request,
         requester,
         titleRequestCount,
         ...dynamicProperties,


### PR DESCRIPTION
## Purpose
Add link for `Requests on item` field if level of request is `Title`.

## Approach
We should not rely on request `level` because `title` requests in some moment can have item in their record.
According to discussing with PO, we should display `0` if have no requests on item (such case can be for closed requests), and this value should not be a `link`.

## Refs
https://issues.folio.org/browse/UIREQ-730