### PR TITLE
UIREQ-734: add permission `circulation.requests.queue.collection.get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Fulfillment Preference field not respecting user fulfillment preferences in edit mode. Refs UIREQ-658.
 * Fix `view requests in queue` link behaviour. Refs UIREQ-727.
 * Add link for `Requests on item` field if level of request is `Title`. Refs UIREQ-730.
+* Add `circulation.requests.queue.collection.get` permission. Refs UIREQ-734.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "displayName": "Requests: Reorder queue",
         "visible": true,
         "subPermissions": [
+          "circulation.requests.queue.collection.get",
           "circulation.requests.queue.reorder.collection.post",
           "circulation.rules.request-policy.get"
         ]


### PR DESCRIPTION
## Purpose
Add `circulation.requests.queue.collection.get` as subpermission for `Requests: Reorder queue` permission.

## Refs
https://issues.folio.org/browse/UIREQ-734