### PR TITLE
UIREQ-739 candidate...

### DIFF
--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -37,7 +37,7 @@ const ItemDetail = ({
   const title = request?.instance.title || item.title || <NoValue />;
   const contributor = request?.instance.contributorNames?.[0]?.name || item.contributorNames?.[0]?.name || <NoValue />;
   const count = request?.itemRequestCount || requestCount || DEFAULT_COUNT_VALUE;
-  const status = item.status.name || item.status || <NoValue />;
+  const status = item.status?.name || item.status || <NoValue />;
   const effectiveLocationName = item.effectiveLocation?.name || item.location?.name || <NoValue />;
   const dueDate = loan?.dueDate ? <FormattedDate value={loan.dueDate} /> : <NoValue />;
 

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -569,6 +569,7 @@ class ViewRequest extends React.Component {
         dismissible
         {... (showActionMenu ? { actionMenu } : {})}
         onClose={this.props.onClose}
+        id="request-detail-pane"
       >
         <TitleManager record={get(request, ['instance', 'title'])} />
         <AccordionSet accordionStatus={accordions} onToggle={this.onToggleSection}>
@@ -753,6 +754,7 @@ class ViewRequest extends React.Component {
         lastMenu={this.renderDetailMenu()}
         dismissible
         onClose={this.props.onClose}
+        id="request-detail-pane"
       >
         <div style={{ paddingTop: '1rem' }}>
           <Icon icon="spinner-ellipsis" width="100px" />


### PR DESCRIPTION
See https://issues.folio.org/browse/UIREQ-739 about pane size truncation.

Panes use the pane's id to track their widths in the resizing logic... if an id is not provided, a random number id is generated. This can give the resize logic some issues.

This PR assigns an id to the requests detail `<Pane>` AND the spinner-rendering `<Pane>` which might at least lend stability if it doesn't fix the issue.

Could someone please try this out to see if it resolves? thanks.
The centralized fix is on a branch of stripes-components: https://github.com/folio-org/stripes-components/pull/1721
