### PR TITLE
UIREQ-610 replace SafeHTMLMessage with FormattedMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Add `circulation.requests.queue.collection.get` permission. Refs UIREQ-734.
 * When scrolling, a white background appears and the blue focus indicator is cut off. Refs UIREQ-733.
 * The item requested is duplicated in the queue. Refs UIREQ-737.
+* Replace `SafeHTMLMessage` with `FormattedMessage`. Refs UIREQ-610.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -187,7 +187,6 @@
     "sinon": "^7.2.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^3.1.0",
     "babel-plugin-module-resolver": "^4.1.0",
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.4",

--- a/src/CancelRequestDialog.js
+++ b/src/CancelRequestDialog.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   Modal,
   ModalFooter,
@@ -164,7 +163,7 @@ class CancelRequestDialog extends React.Component {
         footer={footer}
       >
         <p>
-          <SafeHTMLMessage
+          <FormattedMessage
             id="ui-requests.cancel.requestWillBeCancelled"
             values={{ title: request.instance.title }}
           />

--- a/src/ChooseRequestTypeDialog.js
+++ b/src/ChooseRequestTypeDialog.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import {
   Modal,
@@ -106,7 +105,7 @@ class ChooseRequestTypeDialog extends React.Component {
                 </FormattedMessage>
               ))}
             </Select>
-            : <SafeHTMLMessage id="ui-requests.moveRequest.requestTypeChangeMessage" values={{ requestType }} />}
+            : <FormattedMessage id="ui-requests.moveRequest.requestTypeChangeMessage" values={{ requestType }} />}
       </Modal>
     );
   }

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -50,7 +50,6 @@ import {
   Checkbox,
 } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import CancelRequestDialog from './CancelRequestDialog';
 import UserForm from './UserForm';
@@ -1654,7 +1653,7 @@ class RequestForm extends React.Component {
                 onClose={this.hideErrorModal}
                 label={<FormattedMessage id="ui-requests.errorModal.title" />}
                 errorMessage={
-                  <SafeHTMLMessage
+                  <FormattedMessage
                     id="ui-requests.errorModal.message"
                     values={{
                       title: instance?.title,

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -4,4 +4,3 @@ import './intl.mock';
 import './stripesComponents.mock';
 import './stripesCore.mock';
 import './stripesSmartComponents.mock';
-import './reactIntlSafeHtml.mock';

--- a/test/jest/__mock__/reactIntlSafeHtml.mock.js
+++ b/test/jest/__mock__/reactIntlSafeHtml.mock.js
@@ -1,4 +1,0 @@
-jest.mock('@folio/react-intl-safe-html', () => ({
-  __esModule: true,
-  default: jest.fn(() => null),
-}));


### PR DESCRIPTION
Everything `SafeHTMLMessage` can do `FormattedMessage` can do to without
an extra import.

Refs [UIREQ-610](https://issues.folio.org/browse/UIREQ-610), [STRIPES-754](https://issues.folio.org/browse/STRIPES-754)