### PR TITLE
UIREQ-729: Requester name displayed incorrectly in hold shelf clearan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Add `circulation.requests.queue.collection.get` permission. Refs UIREQ-734.
 * When scrolling, a white background appears and the blue focus indicator is cut off. Refs UIREQ-733.
 * The item requested is duplicated in the queue. Refs UIREQ-737.
+* Requester name displayed incorrectly in hold shelf clearance report. Refs UIREQ-729.
 
 ## [6.0.0](https://github.com/folio-org/ui-requests/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v5.1.0...v6.0.0)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -115,6 +115,21 @@ const urls = {
   },
 };
 
+export const buildHoldRecords = (records) => {
+  return records.map(record => {
+    if (record.requester) {
+      const {
+        firstName,
+        lastName,
+      } = record.requester;
+
+      record.requester.name = [lastName, firstName].filter(namePart => namePart).join(', ');
+    }
+
+    return record;
+  });
+};
+
 class RequestsRoute extends React.Component {
   static contextType = CalloutContext;
 
@@ -769,25 +784,10 @@ class RequestsRoute extends React.Component {
       return;
     }
 
-    const recordsToCSV = this.buildHoldRecords(requests);
+    const recordsToCSV = buildHoldRecords(requests);
     exportCsv(recordsToCSV, {
       onlyFields: this.expiredHoldsReportColumnHeaders,
       excludeFields: ['id'],
-    });
-  };
-
-  buildHoldRecords = (records) => {
-    return records.map(record => {
-      if (record.requester) {
-        const {
-          firstName,
-          lastName,
-        } = record.requester;
-
-        record.requester.name = [firstName, lastName].filter(e => e).join(',');
-      }
-
-      return record;
     });
   };
 

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -11,7 +11,9 @@ import {
   SearchAndSort,
 } from '@folio/stripes/smart-components';
 
-import RequestsRoute from './RequestsRoute';
+import RequestsRoute, {
+  buildHoldRecords,
+} from './RequestsRoute';
 
 import {
   duplicateRequest,
@@ -194,6 +196,96 @@ describe('RequestsRoute', () => {
 
       expect(duplicateRequest).toHaveBeenCalledWith(mockedRequest);
       expect(mockedUpdateFunc).toHaveBeenCalledWith(defaultExpectedResultForUpdate);
+    });
+  });
+
+  describe('buildHoldRecords method', () => {
+    it('should build hold records when there are first name and last name', () => {
+      const records = [{
+        requester: {
+          firstName: 'Pasha',
+          lastName: 'Abramov',
+        },
+      }, {
+        requester: {
+          firstName: 'Alex',
+          lastName: 'Green',
+        },
+      }];
+      const expectedResult = [{
+        requester: {
+          firstName: 'Pasha',
+          lastName: 'Abramov',
+          name: 'Abramov, Pasha',
+        },
+      }, {
+        requester: {
+          firstName: 'Alex',
+          lastName: 'Green',
+          name: 'Green, Alex',
+        },
+      }];
+
+      expect(buildHoldRecords(records)).toEqual(expectedResult);
+    });
+
+    it('should build hold records when there is only first name', () => {
+      const records = [{
+        requester: {
+          firstName: 'firstNameWithoutLastName',
+        },
+      }];
+      const expectedResult = [{
+        requester: {
+          firstName: 'firstNameWithoutLastName',
+          name: 'firstNameWithoutLastName',
+        },
+      }];
+
+      expect(buildHoldRecords(records)).toEqual(expectedResult);
+    });
+
+    it('should build hold records when there is only last name', () => {
+      const records = [{
+        requester: {
+          lastName: 'lastNameWithoutFirstName',
+        },
+      }];
+      const expectedResult = [{
+        requester: {
+          lastName: 'lastNameWithoutFirstName',
+          name: 'lastNameWithoutFirstName',
+        },
+      }];
+
+      expect(buildHoldRecords(records)).toEqual(expectedResult);
+    });
+
+    it('should build hold records when there is middle name', () => {
+      const records = [{
+        requester: {
+          firstName: 'Pasha',
+          lastName: 'Abramov',
+          middleName: 'Patric',
+        },
+      }];
+      const expectedResult = [{
+        requester: {
+          firstName: 'Pasha',
+          lastName: 'Abramov',
+          middleName: 'Patric',
+          name: 'Abramov, Pasha',
+        },
+      }];
+
+      expect(buildHoldRecords(records)).toEqual(expectedResult);
+    });
+
+    it('should build hold records when there is no requester', () => {
+      const records = [{}];
+      const expectedResult = [{}];
+
+      expect(buildHoldRecords(records)).toEqual(expectedResult);
     });
   });
 });


### PR DESCRIPTION
## Purpose
Requester name displayed incorrectly in hold shelf clearance report

## Refs
https://issues.folio.org/browse/UIREQ-729