### PR TITLE
UIREQ-728: Move page requests to first accordion of unified queue whe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add id for Pane component. Refs UIREQ-742.
 * Add pull request template. Refs UIREQ-746.
 * Replace `SafeHTMLMessage` with `FormattedMessage`. Refs UIREQ-610.
+* Move page requests to first accordion of unified queue when reordering. Refs UIREQ-728.
 
 ## [7.0.0](https://github.com/folio-org/ui-requests/tree/v7.0.0) (2022-02-25)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v6.0.2...v7.0.0)

--- a/src/routes/RequestQueueRoute.js
+++ b/src/routes/RequestQueueRoute.js
@@ -10,7 +10,10 @@ import { stripesConnect } from '@folio/stripes/core';
 import RequestQueueView from '../views/RequestQueueView';
 import urls from './urls';
 import { requestStatuses } from '../constants';
-import { getTlrSettings } from '../utils';
+import {
+  getTlrSettings,
+  isPageRequest,
+} from '../utils';
 
 class RequestQueueRoute extends React.Component {
   static getRequest(props) {
@@ -226,16 +229,24 @@ class RequestQueueRoute extends React.Component {
     const request = this.getRequest();
     const requests = this.getRequestsWithDeliveryTypes();
     const notYetFilledRequests = [];
-    const inProgressRequests = [];
+    let inProgressRequests = [];
+    const pageRequests = [];
 
     requests
-      .forEach(r => {
-        if (r.status === requestStatuses.NOT_YET_FILLED) {
+      .forEach((r) => {
+        if (isPageRequest(r)) {
+          pageRequests.push(r);
+        } else if (r.status === requestStatuses.NOT_YET_FILLED) {
           notYetFilledRequests.push(r);
         } else {
           inProgressRequests.push(r);
         }
       });
+
+    inProgressRequests = [
+      ...inProgressRequests,
+      ...pageRequests, // page requests should be shown at the bottom of the accordion
+    ];
 
     return (
       <RequestQueueView

--- a/test/bigtest/network/scenarios/requestQueueScenario.js
+++ b/test/bigtest/network/scenarios/requestQueueScenario.js
@@ -1,3 +1,3 @@
 export default function (server) {
-  server.createList('request', 3, { requestType: 'Page' }, 'withPagedItems', 'withCallNumber');
+  server.createList('request', 3, { requestType: 'Hold' }, 'withPagedItems', 'withCallNumber');
 }

--- a/test/bigtest/tests/request-queue-test.js
+++ b/test/bigtest/tests/request-queue-test.js
@@ -36,42 +36,6 @@ describe('RequestQueue', () => {
     });
   });
 
-  describe('Confirm reorder', () => {
-    beforeEach(async function () {
-      await requestQueue.sortableList.moveRowUp();
-    });
-
-    it('shows dialog about moving request to position 2 of the queue', () => {
-      expect(requestQueue.confirmReorderModalIsPresent).to.equal(true);
-    });
-  });
-
-  describe('Keep item on position 2 after reorder confirmation', () => {
-    beforeEach(async function () {
-      await requestQueue.sortableList.moveRowUp();
-      await requestQueue.confirmReorderModalPresent();
-      await requestQueue.confirmReorderModal.clickConfirm();
-    });
-
-    it('closes confirm dialog and keeps request on second position', () => {
-      expect(requestQueue.confirmReorderModalIsPresent).to.equal(false);
-      expect(requestQueue.sortableList.rows(1).cols(6).text).to.equal(requests[1].requester.barcode);
-    });
-  });
-
-  describe('Cancel reorder', () => {
-    beforeEach(async function () {
-      await requestQueue.sortableList.moveRowUp();
-      await requestQueue.confirmReorderModalPresent();
-      await requestQueue.confirmReorderModal.clickCancel();
-    });
-
-    it('closes confirm dialog and keeps requests unchanged', () => {
-      expect(requestQueue.confirmReorderModalIsPresent).to.equal(false);
-      expect(requestQueue.sortableList.rows(1).cols(6).text).to.equal(requests[1].requester.barcode);
-    });
-  });
-
   describe('Close reorder screen', () => {
     beforeEach(async function () {
       await requestQueue.close();


### PR DESCRIPTION
## Purpose
Move page requests to first accordion of unified queue when reordering

## Approach
Some big tests related to confirmation dialog are removed because confirmation dialog is not shown anymore. It was shown before when accordion which allowed drag and drop requests had **page** requests. Now it does not have **page** requests. That is why confirmation dialog is not shown anymore.

## Refs
https://issues.folio.org/browse/UIREQ-728

## Screenshots
<img width="1268" alt="Screen Shot 2022-03-09 at 2 09 35 PM" src="https://user-images.githubusercontent.com/47976677/157430394-d695fbea-416e-4562-b6c8-06f587a5a0c3.png">
