### PR TITLE
UI req 588

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add pull request template. Refs UIREQ-746.
 * Replace `SafeHTMLMessage` with `FormattedMessage`. Refs UIREQ-610.
 * Move page requests to first accordion of unified queue when reordering. Refs UIREQ-728.
+* Add support for baseline keyboard shortcuts Refs UIREQ-588
 
 ## [7.0.0](https://github.com/folio-org/ui-requests/tree/v7.0.0) (2022-02-25)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v6.0.2...v7.0.0)

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
   "scripts": {
     "start": "stripes serve",
     "lint": "eslint .",
+    "lintfix": "eslint . --fix",
     "test": "yarn run test:jest && yarn run test:bigtest ",
     "test:bigtest": "stripes test karma",
     "test:jest": "jest --ci --coverage --colors",

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -37,7 +37,7 @@ const ItemDetail = ({
   const title = request?.instance.title || item.title || <NoValue />;
   const contributor = request?.instance.contributorNames?.[0]?.name || item.contributorNames?.[0]?.name || <NoValue />;
   const count = request?.itemRequestCount || requestCount || DEFAULT_COUNT_VALUE;
-  const status = item.status.name || item.status || <NoValue />;
+  const status = item.status?.name || item.status || <NoValue />;
   const effectiveLocationName = item.effectiveLocation?.name || item.location?.name || <NoValue />;
   const dueDate = loan?.dueDate ? <FormattedDate value={loan.dueDate} /> : <NoValue />;
 

--- a/src/ItemsDialog.js
+++ b/src/ItemsDialog.js
@@ -158,7 +158,7 @@ const ItemsDialog = ({
   return (
     <Modal
       data-test-move-request-modal
-      label={formatMessage({ id: 'ui-requests.items.selectItem' })}
+      label={formatMessage({ id: 'ui-requests.items.selectItem' }, { title: '' })}
       open={open}
       contentClass={css.content}
       onClose={onClose}
@@ -180,14 +180,14 @@ const ItemsDialog = ({
             : <MultiColumnList
               id="instance-items-list"
               interactive
-              ariaLabel={formatMessage({ id: 'ui-requests.items.instanceItems' })}
+              ariaLabel={formatMessage({ id: 'ui-requests.items.instanceItems' }, { title: '' })}
               contentData={contentData}
               visibleColumns={COLUMN_NAMES}
               columnMapping={COLUMN_MAP}
               columnWidths={COLUMN_WIDTHS}
               formatter={formatter}
               maxHeight={MAX_HEIGHT}
-              isEmptyMessage={formatMessage({ id: 'ui-requests.items.instanceItems.notFound' })}
+              isEmptyMessage={formatMessage({ id: 'ui-requests.items.instanceItems.notFound' }, { title: '' })}
               onRowClick={onRowClick}
             />
           }

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -48,13 +48,11 @@ import {
   TextField,
   Timepicker,
   Checkbox,
-  HasCommand,
-  checkScope,
   AccordionStatus,
-  collapseAllSections,
-  expandAllSections,
 } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';
+
+import RequestFormShortcutsWrapper from './components/RequestFormShortcutsWrapper';
 
 import {
   handleKeyCommand,
@@ -1183,38 +1181,21 @@ class RequestForm extends React.Component {
 
     const handleCancelAndClose = () => {
       const keepEditBtn = document.getElementById('clickable-cancel-editing-confirmation-confirm');
-      if (isItemsDialogOpen) handleKeyCommand(this.handleItemsDialogClose);
+      const closeShortcutsModalBtn = document.getElementById('keyboard-shortcuts-modal-close');
+      if (closeShortcutsModalBtn) closeShortcutsModalBtn.click();
+      else if (isItemsDialogOpen) handleKeyCommand(this.handleItemsDialogClose);
       else if (errorMessage) handleKeyCommand(this.onClose);
       else if (keepEditBtn) keepEditBtn.click();
       else onCancel();
     };
 
-    const keyCommands = [
-      {
-        name: 'save',
-        handler: handleKeyCommand(handleSubmit(this.onSave), { disabled: this.isSubmittingButtonDisabled() }),
-      },
-      {
-        name: 'expandAllSections',
-        handler: (e) => expandAllSections(e, this.accordionStatusRef),
-      },
-      {
-        name: 'collapseAllSections',
-        handler: (e) => collapseAllSections(e, this.accordionStatusRef),
-      },
-      {
-        name: 'cancel',
-        shortcut: 'esc',
-        handler: handleKeyCommand(handleCancelAndClose),
-      }
-    ];
-
     return (
       <>
-        <HasCommand
-          commands={keyCommands}
-          isWithinScope={checkScope}
-          scope={document.body}
+        <RequestFormShortcutsWrapper
+          onSubmit={handleSubmit(this.onSave)}
+          onCancel={handleCancelAndClose}
+          accordionStatusRef={this.accordionStatusRef}
+          isSubmittingDisabled={this.isSubmittingButtonDisabled()}
         >
           <Paneset isRoot>
             <form
@@ -1694,7 +1675,7 @@ class RequestForm extends React.Component {
               </Pane>
             </form>
           </Paneset>
-        </HasCommand>
+        </RequestFormShortcutsWrapper>
       </>
     );
   }

--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -13,6 +13,8 @@ import { Field } from 'redux-form';
 import {
   Checkbox,
   TextField,
+  CommandList,
+  defaultKeyboardShortcuts,
 } from '@folio/stripes/components';
 
 import RequestForm from './RequestForm';
@@ -99,9 +101,11 @@ describe.skip('RequestForm', () => {
     };
 
     render(
-      <RequestForm
-        {...props}
-      />
+      <CommandList commands={defaultKeyboardShortcuts}>
+        <RequestForm
+          {...props}
+        />
+      </CommandList>,
     );
   };
 

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -1,7 +1,6 @@
 import {
   get,
   isEqual,
-  cloneDeep,
   keyBy,
 } from 'lodash';
 import React from 'react';
@@ -25,6 +24,7 @@ import {
   Button,
   Accordion,
   AccordionSet,
+  AccordionStatus,
   Col,
   Callout,
   Icon,
@@ -34,6 +34,10 @@ import {
   Pane,
   PaneMenu,
   Row,
+  HasCommand,
+  expandAllSections,
+  collapseAllSections,
+  checkScope,
 } from '@folio/stripes/components';
 import {
   ViewMetaData,
@@ -57,6 +61,7 @@ import {
   isDelivery,
   getFullName,
   getTlrSettings,
+  handleKeyCommand,
 } from './utils';
 import urls from './routes/urls';
 
@@ -136,13 +141,6 @@ class ViewRequest extends React.Component {
 
     this.state = {
       request: {},
-      accordions: {
-        'request-info': true,
-        'title-info': true,
-        'item-info': true,
-        'requester-info': true,
-        'staff-notes': true,
-      },
       moveRequest: false,
       titleLevelRequestsFeatureEnabled,
     };
@@ -151,10 +149,10 @@ class ViewRequest extends React.Component {
 
     this.cViewMetaData = connect(ViewMetaData);
     this.connectedCancelRequestDialog = connect(CancelRequestDialog);
-    this.onToggleSection = this.onToggleSection.bind(this);
     this.cancelRequest = this.cancelRequest.bind(this);
     this.update = this.update.bind(this);
     this.callout = React.createRef();
+    this.accordionStatusRef = React.createRef();
   }
 
   componentDidMount() {
@@ -278,14 +276,6 @@ class ViewRequest extends React.Component {
     history.push(`${urls.requestQueueView(request.id, idForHistory)}${search}`, { request });
   }
 
-  onToggleSection({ id }) {
-    this.setState((curState) => {
-      const newState = cloneDeep(curState);
-      newState.accordions[id] = !curState.accordions[id];
-      return newState;
-    });
-  }
-
   getRequest() {
     const { resources, match: { params: { id } } } = this.props;
     const selRequest = (resources.selectedRequest || {}).records || [];
@@ -403,7 +393,6 @@ class ViewRequest extends React.Component {
       optionLists: { cancellationReasons },
     } = this.props;
     const {
-      accordions,
       isCancellingRequest,
       moveRequest,
       titleLevelRequestsFeatureEnabled,
@@ -560,189 +549,221 @@ class ViewRequest extends React.Component {
       requestCreateDate: request.metadata.createdDate,
     };
 
+    const keyCommands = [
+      {
+        name: 'edit',
+        handler: handleKeyCommand(() => {
+          if (stripes.hasPerm('ui-requests.edit')) this.props.onEdit();
+        }, { disabled: isRequestClosed }),
+      },
+      {
+        name: 'duplicateRecord',
+        handler: handleKeyCommand(() => {
+          if (stripes.hasPerm('ui-requests.create')) this.props.onDuplicate(request);
+        }, { disabled: request.requestLevel === REQUEST_LEVEL_TYPES.TITLE && !this.state.titleLevelRequestsFeatureEnabled }),
+      },
+      {
+        name: 'expandAllSections',
+        handler: (e) => expandAllSections(e, this.accordionStatusRef),
+      },
+      {
+        name: 'collapseAllSections',
+        handler: (e) => collapseAllSections(e, this.accordionStatusRef),
+      },
+    ];
+
     return (
-      <Pane
-        id="instance-details"
-        data-test-instance-details
-        defaultWidth={this.props.paneWidth}
-        paneTitle={<FormattedMessage id="ui-requests.requestMeta.detailLabel" />}
-        lastMenu={this.renderDetailMenu(request)}
-        dismissible
-        {... (showActionMenu ? { actionMenu } : {})}
-        onClose={this.props.onClose}
-      >
-        <TitleManager record={get(request, ['instance', 'title'])} />
-        <AccordionSet accordionStatus={accordions} onToggle={this.onToggleSection}>
-          <Accordion
-            id="title-info"
-            label={
-              <FormattedMessage
-                id="ui-requests.title.information"
-              />
-            }
+      <>
+        <HasCommand
+          commands={keyCommands}
+          isWithinScope={checkScope}
+          scope={document.body}
+        >
+          <Pane
+            id="instance-details"
+            data-test-instance-details
+            defaultWidth={this.props.paneWidth}
+            paneTitle={<FormattedMessage id="ui-requests.requestMeta.detailLabel" />}
+            lastMenu={this.renderDetailMenu(request)}
+            dismissible
+            {... (showActionMenu ? { actionMenu } : {})}
+            onClose={this.props.onClose}
           >
-            <TitleInformation
-              instanceId={request.instanceId}
-              titleLevelRequestsCount={request.titleRequestCount}
-              title={request.instance.title}
-              contributors={request.instance.contributorNames}
-              publications={request.instance.publication}
-              editions={request.instance.editions}
-              identifiers={request.instance.identifiers}
-              titleLevelRequestsLink={false}
-            />
-          </Accordion>
-          <Accordion
-            id="item-info"
-            label={
-              <FormattedMessage
-                id="ui-requests.item.information"
-              />
-            }
-          >
-            { item
-              ? (
-                <ItemDetail
-                  request={request}
-                  item={request.item}
-                  loan={request.loan}
-                  requestCount={request.requestCount}
-                />
-              )
-              : (
-                <FormattedMessage
-                  id="ui-requests.item.noInformation"
-                />
-              )
-            }
-          </Accordion>
-          <Accordion
-            id="request-info"
-            label={<FormattedMessage id="ui-requests.requestMeta.information" />}
-          >
-            <Row>
-              <Col xs={12}>
-                {request.metadata && <this.cViewMetaData metadata={request.metadata} />}
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={3}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.requestType" />}
-                  value={get(request, ['requestType'], '-')}
-                />
-              </Col>
-              <Col xs={3}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.status" />}
-                  value={get(request, ['status'], '-')}
-                />
-              </Col>
-              <Col xs={3}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.requestExpirationDate" />}
-                  value={expirationDate}
-                />
-              </Col>
-              <Col xs={3}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.holdShelfExpirationDate" />}
-                  value={holdShelfExpireDate}
-                />
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={3}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.position" />}
-                  value={
-                    <PositionLink
-                      request={request}
-                      isTlrEnabled={titleLevelRequestsFeatureEnabled}
+            <TitleManager record={get(request, ['instance', 'title'])} />
+            <AccordionStatus ref={this.accordionStatusRef}>
+              <AccordionSet>
+                <Accordion
+                  id="title-info"
+                  label={
+                    <FormattedMessage
+                      id="ui-requests.title.information"
                     />
                   }
-                />
-              </Col>
-              <Col xs={3}>
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.requestLevel" />}
-                  value={<FormattedMessage id={`ui-requests.${requestLevel.toLowerCase()}Level`} />}
-                />
-              </Col>
-              {request.cancellationReasonId &&
-                <Col xs={3}>
-                  <KeyValue
-                    label={<FormattedMessage id="ui-requests.cancellationReason" />}
-                    value={get(cancellationReasonMap[request.cancellationReasonId], 'name', '-')}
+                >
+                  <TitleInformation
+                    instanceId={request.instanceId}
+                    titleLevelRequestsCount={request.titleRequestCount}
+                    title={request.instance.title}
+                    contributors={request.instance.contributorNames}
+                    publications={request.instance.publication}
+                    editions={request.instance.editions}
+                    identifiers={request.instance.identifiers}
+                    titleLevelRequestsLink={false}
                   />
-                </Col> }
-              {request.cancellationAdditionalInformation &&
-                <Col xs={6}>
-                  <KeyValue
-                    label={<FormattedMessage id="ui-requests.cancellationAdditionalInformation" />}
-                    value={request.cancellationAdditionalInformation}
+                </Accordion>
+                <Accordion
+                  id="item-info"
+                  label={
+                    <FormattedMessage
+                      id="ui-requests.item.information"
+                    />
+                  }
+                >
+                  { item
+                    ? (
+                      <ItemDetail
+                        request={request}
+                        item={request.item}
+                        loan={request.loan}
+                        requestCount={request.requestCount}
+                      />
+                    )
+                    : (
+                      <FormattedMessage
+                        id="ui-requests.item.noInformation"
+                      />
+                    )
+                  }
+                </Accordion>
+                <Accordion
+                  id="request-info"
+                  label={<FormattedMessage id="ui-requests.requestMeta.information" />}
+                >
+                  <Row>
+                    <Col xs={12}>
+                      {request.metadata && <this.cViewMetaData metadata={request.metadata} />}
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col xs={3}>
+                      <KeyValue
+                        label={<FormattedMessage id="ui-requests.requestType" />}
+                        value={get(request, ['requestType'], '-')}
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <KeyValue
+                        label={<FormattedMessage id="ui-requests.status" />}
+                        value={get(request, ['status'], '-')}
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <KeyValue
+                        label={<FormattedMessage id="ui-requests.requestExpirationDate" />}
+                        value={expirationDate}
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <KeyValue
+                        label={<FormattedMessage id="ui-requests.holdShelfExpirationDate" />}
+                        value={holdShelfExpireDate}
+                      />
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col xs={3}>
+                      <KeyValue
+                        label={<FormattedMessage id="ui-requests.position" />}
+                        value={
+                          <PositionLink
+                            request={request}
+                            isTlrEnabled={titleLevelRequestsFeatureEnabled}
+                          />
+                        }
+                      />
+                    </Col>
+                    <Col xs={3}>
+                      <KeyValue
+                        label={<FormattedMessage id="ui-requests.requestLevel" />}
+                        value={<FormattedMessage id={`ui-requests.${requestLevel.toLowerCase()}Level`} />}
+                      />
+                    </Col>
+                    {request.cancellationReasonId &&
+                      <Col xs={3}>
+                        <KeyValue
+                          label={<FormattedMessage id="ui-requests.cancellationReason" />}
+                          value={get(cancellationReasonMap[request.cancellationReasonId], 'name', '-')}
+                        />
+                      </Col> }
+                    {request.cancellationAdditionalInformation &&
+                      <Col xs={6}>
+                        <KeyValue
+                          label={<FormattedMessage id="ui-requests.cancellationAdditionalInformation" />}
+                          value={request.cancellationAdditionalInformation}
+                        />
+                      </Col> }
+                    <Col
+                      data-test-request-patron-comments
+                      xsOffset={3}
+                      xs={6}
+                    >
+                      <KeyValue
+                        label={<FormattedMessage id="ui-requests.patronComments" />}
+                        value={request.patronComments}
+                      />
+                    </Col>
+                  </Row>
+                </Accordion>
+                <Accordion
+                  id="requester-info"
+                  label={
+                    <FormattedMessage id="ui-requests.requester.information">
+                      {message => message}
+                    </FormattedMessage>
+                  }
+                >
+                  <UserDetail
+                    user={request.requester}
+                    proxy={request.proxy}
+                    stripes={stripes}
+                    patronGroups={patronGroups}
+                    request={request}
+                    selectedDelivery={selectedDelivery}
+                    deliveryAddress={deliveryAddressDetail}
+                    pickupServicePoint={getPickupServicePointName}
                   />
-                </Col> }
-              <Col
-                data-test-request-patron-comments
-                xsOffset={3}
-                xs={6}
-              >
-                <KeyValue
-                  label={<FormattedMessage id="ui-requests.patronComments" />}
-                  value={request.patronComments}
+                </Accordion>
+                <NotesSmartAccordion
+                  domainName="requests"
+                  entityId={request.id}
+                  entityName={request.instance.title}
+                  entityType="request"
+                  referredRecordData={referredRecordData}
+                  id="staff-notes"
+                  label={<FormattedMessage id="ui-requests.notes.staffNotes" />}
+                  pathToNoteCreate="/requests/notes/new"
+                  pathToNoteDetails="/requests/notes"
                 />
-              </Col>
-            </Row>
-          </Accordion>
-          <Accordion
-            id="requester-info"
-            label={
-              <FormattedMessage id="ui-requests.requester.information">
-                {message => message}
-              </FormattedMessage>
-            }
-          >
-            <UserDetail
-              user={request.requester}
-              proxy={request.proxy}
-              stripes={stripes}
-              patronGroups={patronGroups}
+              </AccordionSet>
+            </AccordionStatus>
+            <this.connectedCancelRequestDialog
+              open={isCancellingRequest}
+              onCancelRequest={this.cancelRequest}
+              onClose={() => this.setState({ isCancellingRequest: false })}
               request={request}
-              selectedDelivery={selectedDelivery}
-              deliveryAddress={deliveryAddressDetail}
-              pickupServicePoint={getPickupServicePointName}
+              stripes={stripes}
             />
-          </Accordion>
-          <NotesSmartAccordion
-            domainName="requests"
-            entityId={request.id}
-            entityName={request.instance.title}
-            entityType="request"
-            referredRecordData={referredRecordData}
-            id="staff-notes"
-            label={<FormattedMessage id="ui-requests.notes.staffNotes" />}
-            pathToNoteCreate="/requests/notes/new"
-            pathToNoteDetails="/requests/notes"
-          />
-        </AccordionSet>
 
-        <this.connectedCancelRequestDialog
-          open={isCancellingRequest}
-          onCancelRequest={this.cancelRequest}
-          onClose={() => this.setState({ isCancellingRequest: false })}
-          request={request}
-          stripes={stripes}
-        />
-
-        {moveRequest &&
-          <MoveRequestManager
-            onMove={this.onMove}
-            onCancelMove={this.closeMoveRequest}
-            request={request}
-          /> }
-        <Callout ref={this.callout} />
-      </Pane>
+            {moveRequest &&
+              <MoveRequestManager
+                onMove={this.onMove}
+                onCancelMove={this.closeMoveRequest}
+                request={request}
+              /> }
+            <Callout ref={this.callout} />
+          </Pane>
+        </HasCommand>
+      </>
     );
   }
 

--- a/src/components/RequestFormShortcutsWrapper/RequestFormShortcutsWrapper.js
+++ b/src/components/RequestFormShortcutsWrapper/RequestFormShortcutsWrapper.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  checkScope,
+  HasCommand,
+  expandAllSections,
+  collapseAllSections,
+} from '@folio/stripes/components';
+import { handleKeyCommand } from '../../utils';
+
+const RequestShortcutsWrapper = ({
+  children,
+  onSubmit,
+  onCancel,
+  accordionStatusRef,
+  isSubmittingDisabled,
+}) => {
+  const keyCommands = [
+    {
+      name: 'save',
+      handler: handleKeyCommand(onSubmit, { disabled: isSubmittingDisabled }),
+    },
+    {
+      name: 'expandAllSections',
+      handler: (e) => expandAllSections(e, accordionStatusRef),
+    },
+    {
+      name: 'collapseAllSections',
+      handler: (e) => collapseAllSections(e, accordionStatusRef),
+    },
+    {
+      name: 'cancel',
+      shortcut: 'esc',
+      handler: handleKeyCommand(onCancel),
+    }
+  ];
+
+  return (
+    <HasCommand
+      commands={keyCommands}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      {children}
+    </HasCommand>
+  );
+};
+
+RequestShortcutsWrapper.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+    PropTypes.func,
+  ]).isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  accordionStatusRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  ]),
+  isSubmittingDisabled: PropTypes.bool.isRequired,
+};
+
+export default RequestShortcutsWrapper;

--- a/src/components/RequestFormShortcutsWrapper/RequestsFormShortcutsWrapper.test.js
+++ b/src/components/RequestFormShortcutsWrapper/RequestsFormShortcutsWrapper.test.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  CommandList,
+  defaultKeyboardShortcuts,
+} from '@folio/stripes-components';
+import RequestsFormShortcutsWrapper from './RequestFormShortcutsWrapper';
+import { cancelShortcut, saveShortcut, collapseSectionsShortcut, expandSectionsShortcut } from '../../../test/jest/helpers/shortcuts';
+
+const mockOnSubmit = jest.fn();
+const mockOnCanel = jest.fn();
+const mockAccordionStatusRef = () => ({
+  current: {
+    state: {},
+    setStatus: jest.fn(),
+  },
+});
+mockAccordionStatusRef.current = {
+  state: {},
+  setStatus: jest.fn(),
+};
+
+const renderRequestsFormShortcuts = (isSubmittingDisabled) => {
+  const childElement = <input data-testid="childElement" id="input-request-search" />;
+
+  const component = () => (
+    <CommandList commands={defaultKeyboardShortcuts}>
+      <RequestsFormShortcutsWrapper
+        onSubmit={mockOnSubmit}
+        onCancel={mockOnCanel}
+        accordionStatusRef={mockAccordionStatusRef}
+        isSubmittingDisabled={isSubmittingDisabled}
+      >
+        <span>{childElement}</span>
+      </RequestsFormShortcutsWrapper>
+    </CommandList>
+  );
+
+  return render(component());
+};
+
+describe('RequestsFormShortcutsWrapper component', () => {
+  afterEach(() => {
+    mockOnSubmit.mockClear();
+    mockOnCanel.mockClear();
+    mockAccordionStatusRef.current.setStatus.mockClear();
+  });
+
+  it('should render children correctly', () => {
+    const { getByTestId } = renderRequestsFormShortcuts(true);
+
+    expect(getByTestId('childElement')).toBeInTheDocument();
+  });
+  describe('when isSubmittingDisabled is true', () => {
+    it('Save shortcut should not work', () => {
+      renderRequestsFormShortcuts(true);
+      saveShortcut(document.body);
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+  describe('when isSubmittingDisabled is false', () => {
+    it('Save shortcut should work', () => {
+      renderRequestsFormShortcuts(false);
+      saveShortcut(document.body);
+      expect(mockOnSubmit).toHaveBeenCalled();
+    });
+  });
+  describe('when escape key is pressed', () => {
+    it('onCancel should be executed', () => {
+      renderRequestsFormShortcuts(false);
+      cancelShortcut(document.body);
+      expect(mockOnCanel).toHaveBeenCalled();
+    });
+  });
+  describe('when accordionStatusRef is defined', () => {
+    it('collapseSectionsShortcut should be executed', () => {
+      renderRequestsFormShortcuts(false);
+      collapseSectionsShortcut(document.body);
+      expect(mockAccordionStatusRef.current.setStatus).toHaveBeenCalled();
+    });
+    it('expandSectionsShortcut should be executed', () => {
+      renderRequestsFormShortcuts(false);
+      expandSectionsShortcut(document.body);
+      expect(mockAccordionStatusRef.current.setStatus).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/RequestFormShortcutsWrapper/index.js
+++ b/src/components/RequestFormShortcutsWrapper/index.js
@@ -1,0 +1,1 @@
+export { default } from './RequestFormShortcutsWrapper';

--- a/src/components/RequestShortcutsWrapper/RequestShortcutsWrapper.js
+++ b/src/components/RequestShortcutsWrapper/RequestShortcutsWrapper.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  checkScope,
+  HasCommand,
+} from '@folio/stripes/components';
+import { handleKeyCommand } from '../../utils';
+
+const RequestShortcutsWrapper = ({
+  children,
+  history,
+  location,
+  stripes,
+}) => {
+  const focusSearchField = () => {
+    const searchInput = document.querySelector('#input-request-search');
+    const openSearchBtn = document.querySelector('.noResultsMessageButton---itbez');
+    if (searchInput) {
+      searchInput.focus();
+    } else if (openSearchBtn) {
+      openSearchBtn.click();
+    }
+  };
+
+  const keyCommands = [
+    {
+      name: 'new',
+      handler: handleKeyCommand(() => {
+        if (stripes.hasPerm('ui-requests.create')) history.push(`${location.pathname}?layer=create`);
+      }),
+    },
+    {
+      name: 'search',
+      handler: handleKeyCommand(focusSearchField),
+    },
+  ];
+
+  return (
+    <HasCommand
+      commands={keyCommands}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      {children}
+    </HasCommand>
+  );
+};
+
+RequestShortcutsWrapper.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+    PropTypes.func,
+  ]).isRequired,
+  history: PropTypes.shape({ push: PropTypes.func.isRequired }).isRequired,
+  location: PropTypes.oneOfType([
+    PropTypes.shape({
+      search: PropTypes.string.isRequired,
+      pathname: PropTypes.string.isRequired,
+    }).isRequired,
+    PropTypes.string.isRequired,
+  ]).isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+export default RequestShortcutsWrapper;

--- a/src/components/RequestsFilters/RequestsFilters.js
+++ b/src/components/RequestsFilters/RequestsFilters.js
@@ -11,6 +11,10 @@ import {
   Accordion,
   AccordionSet,
   FilterAccordionHeader,
+  HasCommand,
+  AccordionStatus,
+  collapseAllSections,
+  expandAllSections,
 } from '@folio/stripes/components';
 import {
   CheckboxFilter,
@@ -34,6 +38,23 @@ export default class RequestsFilters extends React.Component {
     onClear: PropTypes.func.isRequired,
     titleLevelRequestsFeatureEnabled: PropTypes.bool.isRequired,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.accordionStatusRef = React.createRef();
+
+    this.keyCommands = [
+      {
+        name: 'expandAllSections',
+        handler: (e) => expandAllSections(e, this.accordionStatusRef),
+      },
+      {
+        name: 'collapseAllSections',
+        handler: (e) => collapseAllSections(e, this.accordionStatusRef),
+      },
+    ];
+  }
 
   transformRequestFilterOptions = (source = []) => {
     return source.map(({ label, value }) => ({
@@ -64,71 +85,77 @@ export default class RequestsFilters extends React.Component {
     } = this.props;
 
     return (
-      <AccordionSet>
-        <Accordion
-          displayClearButton={!isEmpty(requestType)}
-          id={requestFilterTypes.REQUEST_TYPE}
-          header={FilterAccordionHeader}
-          label={<FormattedMessage id="ui-requests.requestMeta.type" />}
-          name={requestFilterTypes.REQUEST_TYPE}
-          separator={false}
-          onClearFilter={() => onClear(requestFilterTypes.REQUEST_TYPE)}
-        >
-          <CheckboxFilter
-            dataOptions={this.transformRequestFilterOptions(requestTypeFilters)}
-            name={requestFilterTypes.REQUEST_TYPE}
-            selectedValues={requestType}
-            onChange={onChange}
-          />
-        </Accordion>
-        <Accordion
-          displayClearButton={!isEmpty(requestStatus)}
-          id={requestFilterTypes.REQUEST_STATUS}
-          header={FilterAccordionHeader}
-          label={<FormattedMessage id="ui-requests.requestMeta.status" />}
-          name={requestFilterTypes.REQUEST_STATUS}
-          separator={false}
-          onClearFilter={() => onClear(requestFilterTypes.REQUEST_STATUS)}
-        >
-          <CheckboxFilter
-            dataOptions={this.transformRequestFilterOptions(requestStatusFilters)}
-            name={requestFilterTypes.REQUEST_STATUS}
-            selectedValues={requestStatus}
-            onChange={onChange}
-          />
-        </Accordion>
-        {titleLevelRequestsFeatureEnabled && (
-          <RequestLevelFilter
-            activeValues={requestLevels}
-            onChange={onChange}
-            onClear={onClear}
-          />
-        )}
-        <Accordion
-          displayClearButton={!isEmpty(tags)}
-          id={requestFilterTypes.TAGS}
-          header={FilterAccordionHeader}
-          label={<FormattedMessage id="ui-requests.requestMeta.tags" />}
-          name={requestFilterTypes.TAGS}
-          separator={false}
-          onClearFilter={() => onClear(requestFilterTypes.TAGS)}
-        >
-          <MultiSelectionFilter
-            dataOptions={this.transformTagsOptions()}
-            name={requestFilterTypes.TAGS}
-            selectedValues={tags}
-            onChange={onChange}
-            ariaLabelledBy={requestFilterTypes.TAGS}
-          />
-        </Accordion>
+      <>
+        <HasCommand commands={this.keyCommands}>
+          <AccordionStatus ref={this.accordionStatusRef}>
+            <AccordionSet>
+              <Accordion
+                displayClearButton={!isEmpty(requestType)}
+                id={requestFilterTypes.REQUEST_TYPE}
+                header={FilterAccordionHeader}
+                label={<FormattedMessage id="ui-requests.requestMeta.type" />}
+                name={requestFilterTypes.REQUEST_TYPE}
+                separator={false}
+                onClearFilter={() => onClear(requestFilterTypes.REQUEST_TYPE)}
+              >
+                <CheckboxFilter
+                  dataOptions={this.transformRequestFilterOptions(requestTypeFilters)}
+                  name={requestFilterTypes.REQUEST_TYPE}
+                  selectedValues={requestType}
+                  onChange={onChange}
+                />
+              </Accordion>
+              <Accordion
+                displayClearButton={!isEmpty(requestStatus)}
+                id={requestFilterTypes.REQUEST_STATUS}
+                header={FilterAccordionHeader}
+                label={<FormattedMessage id="ui-requests.requestMeta.status" />}
+                name={requestFilterTypes.REQUEST_STATUS}
+                separator={false}
+                onClearFilter={() => onClear(requestFilterTypes.REQUEST_STATUS)}
+              >
+                <CheckboxFilter
+                  dataOptions={this.transformRequestFilterOptions(requestStatusFilters)}
+                  name={requestFilterTypes.REQUEST_STATUS}
+                  selectedValues={requestStatus}
+                  onChange={onChange}
+                />
+              </Accordion>
+              {titleLevelRequestsFeatureEnabled && (
+                <RequestLevelFilter
+                  activeValues={requestLevels}
+                  onChange={onChange}
+                  onClear={onClear}
+                />
+              )}
+              <Accordion
+                displayClearButton={!isEmpty(tags)}
+                id={requestFilterTypes.TAGS}
+                header={FilterAccordionHeader}
+                label={<FormattedMessage id="ui-requests.requestMeta.tags" />}
+                name={requestFilterTypes.TAGS}
+                separator={false}
+                onClearFilter={() => onClear(requestFilterTypes.TAGS)}
+              >
+                <MultiSelectionFilter
+                  dataOptions={this.transformTagsOptions()}
+                  name={requestFilterTypes.TAGS}
+                  selectedValues={tags}
+                  onChange={onChange}
+                  ariaLabelledBy={requestFilterTypes.TAGS}
+                />
+              </Accordion>
 
-        <PickupServicePointFilter
-          activeValues={pickupServicePoints}
-          servicePoints={this.props.resources?.servicePoints?.records}
-          onChange={onChange}
-          onClear={onClear}
-        />
-      </AccordionSet>
+              <PickupServicePointFilter
+                activeValues={pickupServicePoints}
+                servicePoints={this.props.resources?.servicePoints?.records}
+                onChange={onChange}
+                onClear={onClear}
+              />
+            </AccordionSet>
+          </AccordionStatus>
+        </HasCommand>
+      </>
     );
   }
 }

--- a/src/components/RequestsFilters/RequestsFilters.js
+++ b/src/components/RequestsFilters/RequestsFilters.js
@@ -11,8 +11,8 @@ import {
   Accordion,
   AccordionSet,
   FilterAccordionHeader,
-  HasCommand,
-  AccordionStatus,
+  // HasCommand,
+  // AccordionStatus,
   collapseAllSections,
   expandAllSections,
 } from '@folio/stripes/components';
@@ -20,6 +20,9 @@ import {
   CheckboxFilter,
   MultiSelectionFilter,
 } from '@folio/stripes/smart-components';
+
+import HasCommand from '@folio/stripes-components/lib/Commander/HasCommand';
+import AccordionStatus from '@folio/stripes-components/lib/Accordion/AccordionStatus';
 
 import {
   requestFilterTypes,
@@ -29,6 +32,8 @@ import {
 
 import { PickupServicePointFilter } from './PickupServicePointFilter';
 import { RequestLevelFilter } from './RequestLevelFilter';
+
+
 
 export default class RequestsFilters extends React.Component {
   static propTypes = {

--- a/src/components/RequestsRouteShortcutsWrapper/RequestsRouteShortcutsWrapper.js
+++ b/src/components/RequestsRouteShortcutsWrapper/RequestsRouteShortcutsWrapper.js
@@ -27,7 +27,7 @@ const RequestShortcutsWrapper = ({
     {
       name: 'new',
       handler: handleKeyCommand(() => {
-        if (stripes.hasPerm('ui-requests.create')) history.push(`${location.pathname}?layer=create`);
+        if (stripes?.hasPerm('ui-requests.create')) history.push(`${location.pathname}?layer=create`);
       }),
     },
     {

--- a/src/components/RequestsRouteShortcutsWrapper/RequestsRouteShortcutsWrapper.test.js
+++ b/src/components/RequestsRouteShortcutsWrapper/RequestsRouteShortcutsWrapper.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  CommandList,
+  defaultKeyboardShortcuts
+} from '@folio/stripes-components';
+import RequestsRouteShortcutsWrapper from './RequestsRouteShortcutsWrapper';
+import { buildStripes } from '../../../test/jest/helpers';
+import { openNewRecordShortcut, focusSearchFieldShortcut } from '../../../test/jest/helpers/shortcuts';
+
+const history = {
+  push: jest.fn(),
+};
+const locationProp = {
+  search: '',
+  pathname: '',
+};
+const stripes = buildStripes();
+
+stripes.hasPerm = jest.fn(() => true);
+
+const renderRequestsRouteShortcutsWrapper = () => {
+  const childElement = <input data-testid="childElement" id="input-request-search" />;
+
+  const component = () => (
+    <CommandList commands={defaultKeyboardShortcuts}>
+      <RequestsRouteShortcutsWrapper
+        history={history}
+        location={locationProp}
+        stripes={stripes}
+      >
+        <span>{childElement}</span>
+      </RequestsRouteShortcutsWrapper>
+    </CommandList>
+  );
+
+  return render(component());
+};
+
+describe('RequestsRouteShortcutsWrapper component', () => {
+  afterEach(() => {
+    history.push.mockClear();
+    stripes.hasPerm.mockClear();
+  });
+
+  it('should render children correctly', () => {
+    const { getByTestId } = renderRequestsRouteShortcutsWrapper();
+
+    expect(getByTestId('childElement')).toBeInTheDocument();
+  });
+  describe('when openNewRecord shortcut is pressed', () => {
+    it('should call history.push', () => {
+      renderRequestsRouteShortcutsWrapper();
+      openNewRecordShortcut(document.body);
+      expect(history.push).toHaveBeenCalled();
+    });
+  });
+  describe('when focusSearchField shortcut is pressed', () => {
+    it('should focuse search field', () => {
+      const { getByTestId } = renderRequestsRouteShortcutsWrapper();
+      focusSearchFieldShortcut(document.body);
+      expect(getByTestId('childElement')).toHaveFocus();
+    });
+  });
+});

--- a/src/components/RequestsRouteShortcutsWrapper/index.js
+++ b/src/components/RequestsRouteShortcutsWrapper/index.js
@@ -1,0 +1,1 @@
+export { default } from './RequestsRouteShortcutsWrapper';

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,19 @@ import { Route, Switch } from 'react-router-dom';
 import { hot } from 'react-hot-loader';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
+import { FormattedMessage } from 'react-intl';
+
+import { AppContextMenu } from '@folio/stripes/core';
+import {
+  CommandList,
+  defaultKeyboardShortcuts as keyboardCommands,
+  HasCommand,
+  KeyboardShortcutsModal,
+  NavList,
+  NavListItem,
+  NavListSection,
+} from '@folio/stripes-components';
+
 import {
   NoteCreateRoute,
   NoteViewRoute,
@@ -12,31 +25,70 @@ import {
 } from './routes';
 
 const RequestsRouting = (props) => {
+  const [isShortcutsModalOpen, setIsShortcutsModalOpen] = React.useState(false);
   const { match: { path } } = props;
 
+  const toggleModal = () => setIsShortcutsModalOpen(prev => !prev);
+
+  const keyCommands = [
+    {
+      name: 'openShortcutModal',
+      handler: toggleModal,
+    },
+  ];
+
   return (
-    <Switch>
-      <Route
-        path={`${path}/view/:requestId/:id/reorder`}
-        component={RequestQueueRoute}
-      />
-      <Route
-        path={`${path}/notes/new`}
-        component={NoteCreateRoute}
-      />
-      <Route
-        path={`${path}/notes/:noteId/edit`}
-        component={NoteEditRoute}
-      />
-      <Route
-        path={`${path}/notes/:noteId`}
-        component={NoteViewRoute}
-      />
-      <Route
-        path={path}
-        render={() => <RequestsRoute {...props} />}
-      />
-    </Switch>
+    <>
+      <CommandList commands={keyboardCommands}>
+        <HasCommand commands={keyCommands}>
+          <AppContextMenu>
+            {(handleToggle) => (
+              <NavList>
+                <NavListSection>
+                  <NavListItem
+                    id="keyboard-shortcuts-item"
+                    onClick={() => {
+                      handleToggle();
+                      toggleModal();
+                    }}
+                  >
+                    <FormattedMessage id="ui-requests.appMenu.keyboardShortcuts" />
+                  </NavListItem>
+                </NavListSection>
+              </NavList>
+            )}
+          </AppContextMenu>
+          <Switch>
+            <Route
+              path={`${path}/view/:requestId/:id/reorder`}
+              component={RequestQueueRoute}
+            />
+            <Route
+              path={`${path}/notes/new`}
+              component={NoteCreateRoute}
+            />
+            <Route
+              path={`${path}/notes/:noteId/edit`}
+              component={NoteEditRoute}
+            />
+            <Route
+              path={`${path}/notes/:noteId`}
+              component={NoteViewRoute}
+            />
+            <Route
+              path={path}
+              render={() => <RequestsRoute {...props} />}
+            />
+          </Switch>
+        </HasCommand>
+      </CommandList>
+      {isShortcutsModalOpen && (
+        <KeyboardShortcutsModal
+          allCommands={keyboardCommands}
+          onClose={toggleModal}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import '../test/jest/__mock__';
+
+import Requests from './index';
+
+const renderRequest = () => {
+  const component = (
+    <Router>
+      <Requests
+        match={{ path: 'requests', params: {}, isExact: true, url: '/requests' }}
+      />
+    </Router>
+  );
+
+  return render(component);
+};
+
+describe('UI Requests', () => {
+  describe('UI REQUESTS should be rendered', () => {
+    it('should render', () => {
+      expect(renderRequest()).toBeDefined();
+    });
+  });
+});

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -66,6 +66,7 @@ import {
   RequestsFiltersConfig,
 } from '../components/RequestsFilters';
 import { getFormattedYears } from './utils';
+import RequestShortcutsWrapper from '../components/RequestShortcutsWrapper/RequestShortcutsWrapper';
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
@@ -861,6 +862,7 @@ class RequestsRoute extends React.Component {
       mutator,
       stripes,
       history,
+      location,
       intl,
       stripes: {
         timezone,
@@ -997,77 +999,79 @@ class RequestsRoute extends React.Component {
     };
 
     return (
-      <>
-        {
-          isEmpty(errorModalData) ||
-          <ErrorModal
-            onClose={this.errorModalClose}
-            label={intl.formatMessage({ id: errorModalData.label })}
-            errorMessage={intl.formatMessage({ id: errorModalData.errorMessage })}
+      <RequestShortcutsWrapper location={location} history={history} stripes={stripes}>
+        <>
+          {
+            isEmpty(errorModalData) ||
+            <ErrorModal
+              onClose={this.errorModalClose}
+              label={intl.formatMessage({ id: errorModalData.label })}
+              errorMessage={intl.formatMessage({ id: errorModalData.errorMessage })}
+            />
+          }
+          <div data-test-request-instances>
+            <SearchAndSort
+              columnManagerProps={columnManagerProps}
+              hasNewButton={false}
+              actionMenu={actionMenu}
+              packageInfo={packageInfo}
+              objectName="request"
+              initialResultCount={INITIAL_RESULT_COUNT}
+              resultCountIncrement={RESULT_COUNT_INCREMENT}
+              viewRecordComponent={ViewRequest}
+              editRecordComponent={RequestForm}
+              getHelperResourcePath={this.getHelperResourcePath}
+              columnWidths={{
+                requestDate: { max: 165 },
+                title: { max: 300 },
+                year: { max: 58 },
+                position: { max: 150 },
+                requestType: { max: 101 },
+                itemBarcode: { max: 140 },
+                type: { max: 100 },
+              }}
+              columnMapping={this.columnLabels}
+              resultsFormatter={resultsFormatter}
+              newRecordInitialValues={initialValues}
+              massageNewRecord={this.massageNewRecord}
+              onCreate={this.create}
+              onCloseNewRecord={this.handleCloseNewRecord}
+              parentResources={resources}
+              parentMutator={mutator}
+              detailProps={{
+                onChangePatron: this.onChangePatron,
+                stripes,
+                history,
+                errorMessage,
+                findResource: this.findResource,
+                toggleModal: this.toggleModal,
+                joinRequest: this.addRequestFields,
+                optionLists: {
+                  addressTypes,
+                  fulfilmentTypes,
+                  servicePoints,
+                  cancellationReasons,
+                },
+                patronGroups,
+                query: resources.query,
+                onDuplicate: this.onDuplicate,
+                buildRecordsForHoldsShelfReport: this.buildRecordsForHoldsShelfReport,
+              }}
+              viewRecordPerms="ui-requests.view"
+              newRecordPerms="ui-requests.create"
+              renderFilters={this.renderFilters}
+              onFilterChange={this.handleFilterChange}
+              pageAmount={100}
+              pagingType="click"
+            />
+          </div>
+          <PrintContent
+            ref={this.printContentRef}
+            template={printTemplate}
+            dataSource={pickSlipsData}
           />
-        }
-        <div data-test-request-instances>
-          <SearchAndSort
-            columnManagerProps={columnManagerProps}
-            hasNewButton={false}
-            actionMenu={actionMenu}
-            packageInfo={packageInfo}
-            objectName="request"
-            initialResultCount={INITIAL_RESULT_COUNT}
-            resultCountIncrement={RESULT_COUNT_INCREMENT}
-            viewRecordComponent={ViewRequest}
-            editRecordComponent={RequestForm}
-            getHelperResourcePath={this.getHelperResourcePath}
-            columnWidths={{
-              requestDate: { max: 165 },
-              title: { max: 300 },
-              year: { max: 58 },
-              position: { max: 150 },
-              requestType: { max: 101 },
-              itemBarcode: { max: 140 },
-              type: { max: 100 },
-            }}
-            columnMapping={this.columnLabels}
-            resultsFormatter={resultsFormatter}
-            newRecordInitialValues={initialValues}
-            massageNewRecord={this.massageNewRecord}
-            onCreate={this.create}
-            onCloseNewRecord={this.handleCloseNewRecord}
-            parentResources={resources}
-            parentMutator={mutator}
-            detailProps={{
-              onChangePatron: this.onChangePatron,
-              stripes,
-              history,
-              errorMessage,
-              findResource: this.findResource,
-              toggleModal: this.toggleModal,
-              joinRequest: this.addRequestFields,
-              optionLists: {
-                addressTypes,
-                fulfilmentTypes,
-                servicePoints,
-                cancellationReasons,
-              },
-              patronGroups,
-              query: resources.query,
-              onDuplicate: this.onDuplicate,
-              buildRecordsForHoldsShelfReport: this.buildRecordsForHoldsShelfReport,
-            }}
-            viewRecordPerms="ui-requests.view"
-            newRecordPerms="ui-requests.create"
-            renderFilters={this.renderFilters}
-            onFilterChange={this.handleFilterChange}
-            pageAmount={100}
-            pagingType="click"
-          />
-        </div>
-        <PrintContent
-          ref={this.printContentRef}
-          template={printTemplate}
-          dataSource={pickSlipsData}
-        />
-      </>
+        </>
+      </RequestShortcutsWrapper>
     );
   }
 }

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -66,7 +66,7 @@ import {
   RequestsFiltersConfig,
 } from '../components/RequestsFilters';
 import { getFormattedYears } from './utils';
-import RequestShortcutsWrapper from '../components/RequestShortcutsWrapper/RequestShortcutsWrapper';
+import RequestsRouteShortcutsWrapper from '../components/RequestsRouteShortcutsWrapper';
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
@@ -999,7 +999,11 @@ class RequestsRoute extends React.Component {
     };
 
     return (
-      <RequestShortcutsWrapper location={location} history={history} stripes={stripes}>
+      <RequestsRouteShortcutsWrapper
+        history={history}
+        location={location}
+        stripes={stripes}
+      >
         <>
           {
             isEmpty(errorModalData) ||
@@ -1008,7 +1012,7 @@ class RequestsRoute extends React.Component {
               label={intl.formatMessage({ id: errorModalData.label })}
               errorMessage={intl.formatMessage({ id: errorModalData.errorMessage })}
             />
-          }
+            }
           <div data-test-request-instances>
             <SearchAndSort
               columnManagerProps={columnManagerProps}
@@ -1071,7 +1075,7 @@ class RequestsRoute extends React.Component {
             dataSource={pickSlipsData}
           />
         </>
-      </RequestShortcutsWrapper>
+      </RequestsRouteShortcutsWrapper>
     );
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -339,3 +339,16 @@ export const getInstanceRequestTypeOptions = (items) => {
 };
 
 export const getInstanceQueryString = (hrid, id) => `("hrid"=="${hrid}" or "id"=="${id || hrid}")`;
+
+export const handleKeyCommand = (handler, { disabled } = {}) => {
+  return (e) => {
+    if (e) {
+      e.preventDefault();
+    }
+
+    if (!disabled) {
+      handler();
+    }
+  };
+};
+

--- a/src/views/RequestQueueView.js
+++ b/src/views/RequestQueueView.js
@@ -22,6 +22,7 @@ import {
   AccordionStatus,
   expandAllSections,
   collapseAllSections,
+  checkScope,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 
@@ -72,7 +73,7 @@ class RequestQueueView extends React.Component {
   constructor(props) {
     super(props);
 
-    const { data: {
+    const { onClose, data: {
       notYetFilledRequests,
     } } = props;
     const requestsPositionsForReorder = notYetFilledRequests.map(r => r.position);
@@ -85,6 +86,11 @@ class RequestQueueView extends React.Component {
     this.accordionStatusRef = React.createRef();
 
     this.keyCommands = [
+      {
+        name: 'cancel',
+        shortcut: 'esc',
+        handler: onClose
+      },
       {
         name: 'expandAllSections',
         handler: (e) => expandAllSections(e, this.accordionStatusRef),
@@ -267,7 +273,11 @@ class RequestQueueView extends React.Component {
 
     return (
       <>
-        <HasCommand commands={this.keyCommands}>
+        <HasCommand
+          commands={this.keyCommands}
+          isWithinScope={checkScope}
+          scope={document.body}
+        >
           <Paneset isRoot>
             <Pane
               id="request-queue"

--- a/test/jest/__mock__/currencyData.mock.js
+++ b/test/jest/__mock__/currencyData.mock.js
@@ -1,0 +1,1 @@
+jest.mock('currency-codes/data', () => ({ filter: () => [] }));

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -1,6 +1,8 @@
+import './currencyData.mock';
 import './stripesConfig.mock';
 import './stripes.mock';
 import './intl.mock';
 import './stripesComponents.mock';
+import './stripesIcon.mock';
 import './stripesCore.mock';
 import './stripesSmartComponents.mock';

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
   Accordion: jest.fn(({ children, label }) => (
     <div>
       {label}

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  AppContextMenu: ({ children }) => (typeof children === 'function' ? children(jest.fn()) : children),
   IntlConsumer: jest.fn(({ children }) => {
     const intl = {
       formatMessage: jest.fn(({ id }) => id),

--- a/test/jest/__mock__/stripesIcon.mock.js
+++ b/test/jest/__mock__/stripesIcon.mock.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+jest.mock('@folio/stripes-components/lib/Icon', () => {
+  // eslint-disable-next-line react/prop-types
+  return ({ children }) => (
+    <span>
+      Icon
+      <span>{children}</span>
+    </span>
+  );
+});

--- a/test/jest/helpers/index.js
+++ b/test/jest/helpers/index.js
@@ -1,0 +1,2 @@
+export * from './shortcuts';
+export * from './stripesMock';

--- a/test/jest/helpers/shortcuts.js
+++ b/test/jest/helpers/shortcuts.js
@@ -1,0 +1,159 @@
+import { fireEvent } from '@testing-library/react';
+
+export const openEditShortcut = element => {
+  fireEvent.keyDown(element, {
+    key: 'Ctrl',
+    code: 'CtrlLeft',
+    which: 17,
+    keyCode: 17,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'Alt',
+    code: 'AltLeft',
+    which: 18,
+    keyCode: 18,
+    ctrlKey: true,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'e',
+    keyCode: 69,
+    which: 69,
+    altKey: true,
+    ctrlKey: true,
+  });
+};
+
+export const duplicateRecordShortcut = element => {
+  fireEvent.keyDown(element, {
+    key: 'Alt',
+    code: 'AltLeft',
+    which: 18,
+    keyCode: 18,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'c',
+    keyCode: 67,
+    which: 67,
+    altKey: true,
+  });
+};
+
+export const saveShortcut = element => {
+  fireEvent.keyDown(element, {
+    key: 'Ctrl',
+    code: 'CtrlLeft',
+    which: 17,
+    keyCode: 17,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 's',
+    keyCode: 83,
+    which: 83,
+    ctrlKey: true,
+  });
+};
+
+export const cancelShortcut = element => {
+  fireEvent.keyDown(element, {
+    key: 'Esc',
+    code: 'Escape',
+    which: 27,
+    keyCode: 27,
+  });
+};
+
+export const openNewRecordShortcut = element => {
+  fireEvent.keyDown(element, {
+    key: 'Alt',
+    code: 'AltLeft',
+    which: 18,
+    keyCode: 18,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'n',
+    keyCode: 78,
+    which: 78,
+    altKey: true,
+  });
+};
+
+export const focusSearchFieldShortcut = element => {
+  fireEvent.keyDown(element, {
+    key: 'Ctrl',
+    code: 'CtrlLeft',
+    which: 17,
+    keyCode: 17,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'Alt',
+    code: 'AltLeft',
+    which: 18,
+    keyCode: 18,
+    ctrlKey: true,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'h',
+    keyCode: 72,
+    which: 72,
+    altKey: true,
+    ctrlKey: true,
+  });
+};
+
+export const collapseSectionsShortcut = element => {
+  fireEvent.keyDown(element, {
+    key: 'Ctrl',
+    code: 'CtrlLeft',
+    which: 17,
+    keyCode: 17,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'Alt',
+    code: 'AltLeft',
+    which: 18,
+    keyCode: 18,
+    ctrlKey: true,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'g',
+    keyCode: 71,
+    which: 71,
+    altKey: true,
+    ctrlKey: true,
+  });
+};
+
+export const expandSectionsShortcut = element => {
+  fireEvent.keyDown(element, {
+    key: 'Ctrl',
+    code: 'CtrlLeft',
+    which: 17,
+    keyCode: 17,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'Alt',
+    code: 'AltLeft',
+    which: 18,
+    keyCode: 18,
+    ctrlKey: true,
+  });
+
+  fireEvent.keyDown(element, {
+    key: 'b',
+    keyCode: 66,
+    which: 66,
+    altKey: true,
+    ctrlKey: true,
+  });
+};
+

--- a/test/jest/helpers/stripesMock.js
+++ b/test/jest/helpers/stripesMock.js
@@ -1,0 +1,24 @@
+import { noop } from 'lodash';
+
+// eslint-disable-next-line import/prefer-default-export
+export const buildStripes = (otherProperties = {}) => ({
+  hasPerm: noop,
+  hasInterface: noop,
+  clone: noop,
+  logger: { log: noop },
+  config: {},
+  okapi: {
+    url: '',
+    tenant: '',
+  },
+  withOkapi: true,
+  setToken: noop,
+  actionNames: [],
+  setLocale: noop,
+  setTimezone: noop,
+  setCurrency: noop,
+  setSinglePlugin: noop,
+  setBindings: noop,
+  connect: noop,
+  ...otherProperties,
+});

--- a/translations/ui-requests/compiled/ar.json
+++ b/translations/ui-requests/compiled/ar.json
@@ -1,0 +1,1645 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "إلغاء"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "إغلاق الطلب الجديد"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "إنشاء طلب جديد"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "تكرار"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "تحرير"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "تحرير الطلب"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "مربع حوار تحرير الطلب"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "الإجراءات"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "جاري التحميل..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "نقل الطلب"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "طلب جديد"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "إعادة ترتيب الصف"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "تحديد نوع العنوان"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "تحديد موقع الالتقاط"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "قم بتحديد نقطة خدمة الالتقاط"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "عرض الطلبات في الصف"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "عرض تفاصيل الحظر لمعرفة المزيد من أسباب الحظر..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "الباركود"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "تم حظرالمستفيد من الطلب"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "سبب الحظر"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "بيانات إضافية للمستفيد "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "قم بإدخال مزيد من المعلومات حول الإلغاء (اختياري)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "قم بإدخال مزيد من المعلومات حول الإلغاء (مطلوب)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "إلغاء الطلب"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "تأكيد إلغاء الطلب"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "إخطار المستفيد"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "سبب الإلغاء"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "type": 0,
+      "value": "سيتم "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "إلغاء"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "بيانات إضافية للمستفيد"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "سبب الإلغاء"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "إغلاق"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "إلغاء"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "حفظ وإغلاق"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "جاري توليد تقرير نتائج بتنسيق CSV. قد يستغرق هذا بعض الوقت لمجموعات النتائج الأكبر. شكراً لانتظارك."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "جاري توليد تقرير نتائج بتنسيق CSV. يرجى الانتظار."
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "عنوان التوصيل"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "عرض تفاصيل الحظر"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "إدخال"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (باركود: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") له حالة المادة "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " ولا يمكن طلبه"
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "لا يمكن طلب المادة"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "لا يوجد وعاء برقم التعريف القابل للقراءة بشريًا أو المعرّف الفريد العمومي هذا"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "لا توجد مادة بهذا الباركود"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "يمكن حجز المواد المعارة فقط"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "يمكن طلب استعادة المواد المعارة فقط"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "يرجى تحديد وعاء والضغط على إدخال"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "يرجى تحديد مادة"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "يرجى تحديد مادة والضغط على إدخال"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "يرجى ملء بيانات مقدم الطلب للمتابعة"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "تم تحديث صف الطلبات هذا بواسطة شخص آخر أو عملية أخرى وقد يكون غير متزامن."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "صف الطلبات غير متزامن"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "فشلت إعادة ترتيب صف الطلبات"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "خطأ في صف الطلبات"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "لا يوجد مستخدم بهذا الباركود"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "تصدير تقرير مسح رف الحجوزات لـ "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "تصدير نتائج البحث إلى ملف CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "المادة"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "العنوان"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "مفتوح - في انتظار التوصيل"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "مفتوح - في انتظار الالتقاط"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "مغلق -ملغي"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "مغلق - مملوء"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "مفتوح - في النقل"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "مفتوح - غير مملوء بعد"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "مغلق - انتهت صلاحية الالتقاط"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "مغلق - غير مملوء"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "حجوزات"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "تنبيهات للالتقاط"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "طلبات استعادة المادة"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "مفضلات استيفاء الطلب"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "تاريخ انتهاء الحجز على الرف"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "المساهم"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "معلومات العنوان"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "قم بإدخال رقم التعريف القابل للقراءة بشريًا أو المعرّف الفريد العمومي"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "العنوان"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "رقم التعريف القابل للقراءة بشريًا أو المعرّف الفريد العمومي للوعاء"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "باركود المادة"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "مقطع رقم الاستدعاء النشط"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "رقم الاستدعاء النشط"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "بادئة رقم الاستدعاء النشط"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "لاحقة رقم الاستدعاء النشط"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "التسلسل الزمني"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "المساهم"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "نسخة المادة"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "رقم النسخة"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "تاريخ الاستحقاق الحالي"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "الموقع النشط"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "الترقيم"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "معرّف المادة"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "معلومات المادة"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "رمز الموقع النشط"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "المكتبة"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "الموقع النشط"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "لا توجد معلومات مادة لهذا الطلب."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "الطلبات"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "طلبات على المادة"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "قم بمسح باركود المادة ضوئيًا أو إدخاله يدويًا"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "حالة المادة"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "العنوان"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "المجلد"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "المادة"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " مادة"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "مواد أخرى في "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "لم يتم العثور على مواد"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "تحديد مادة"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "تاريخ الاستحقاق الحالي"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "نوع الإعارة"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "الموقع"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "نوع المادة"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "الطلبات"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "يرجى تحديد النوع المسموح به"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "تأكيد"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "نوع الطلبات الحالي غير مسموح به للمادة المحددة"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "سيتم تحويل الطلب إلى "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "لا يمكن نقل الطلبات أعلى طلبات الصفحة، حتى في حالة عدم بدء استيفائها. سيتم نقل هذا الطلب إلى الموضع 2 في صف الطلبات."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "تم نقل الطلب إلى الموضع 2 في الصف"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "تم نقل الطلب بنجاح"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "لا تتوافر أنواع طلب للمادة المحددة"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "يجب عليك تسجيل الدخول إلى نقطة خدمة للوصول إلى تقرير تصفية رف الحجوزات. يرجى إضافة نقطة خدمة أو أكثر إلى تسجيلة المستخدم الخاصة بك في تطبيق المستخدمين. قم بالاتصال بأحد المشرفين إذا لم قادرًا على إضافة نقاط خدمة إلى تسجيلتك."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "لم يتم تحديد نقطة خدمة"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "لـ: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "تاريخ الطلب: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "مقدم الطلب: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "طلب"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "طلب"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "طلباً"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "ملاحظة موظف جديدة"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "ملاحظات الموظفين"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "تخطي"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "تعليقات المستفيد"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "الطلبات: كل الصلاحيات"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "الطلبات: اعرض، أنشئ"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "الطلبات: اعرض، حرّر، الغ"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "الطلبات: انقل إلى مادة جديدة، أعد ترتيب الصف"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "الطلبات: أعد ترتيب الصف"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "الطلبات: اعرض"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "جاري تحميل قسائم الالتقاط، يرجى الانتظار"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "نقطة خدمة الالتقاط"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "الموضع في الصف"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "تحميل خيارات الطباعة قيد التقدم. قد يستغرق الأمر بضع ثوان، يرجى الانتظار."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "طباعة كعوب الالتقاط لـ "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "باركود وكيل مقدم الطلب"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "اسم وكيل مقدم الطلب"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "تاريخ انتهاء الطلب"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "مستوى الطلب"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "تفاصيل الطلب"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "تاريخ انتهاء الطلب"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "التوصيل"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "رف الحجز"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "تاريخ انتهاء الحجز"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "معلومات الطلب"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "الموضع في الصف"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "حالة الطلب"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "وسوم"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "نوع الطلب"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "حجز"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "الحجوزات"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "تنبيه للالتقاط"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "تنبيهات للالتقاط"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "طلب استعادة مادة"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "طلبات استعادة المادة"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "غير مسموح بالطلب"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "صف الطلبات"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "التسلسل الزمني"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "اتركه في الموضع الحالي"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "انتقل إلى الموضع 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "لا يمكن نقل الطلبات من الموضع 1 عند بدء الاستيفاء."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "لا يمكن نقل الطلبات أعلى طلبات الصفحة، حتى في حالة عدم بدء استيفائها."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "تم نقل الطلب إلى الموضع 2 في الصف"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "التوصيل:"
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "الوعاء: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "الترقيم"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "الاستيفاء قيد التقدم"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "الحالة"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "ضف الطلبات على الوعاء • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "انتهاء صلاحية الحجز على الرف"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "باركود المادة"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "لا توجد طلبات قيد الاستيفاء."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "لم يتم العثور على طلبات"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "مفتوح - غير مملوء بعد"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "طلبية"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "تعليقات المستفيد"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "مجموعة المستفيدين"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "الالتقاط/التوصيل"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "تحديث الصف"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "تم تحديث الصف بنجاح."
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "تاريخ الطلب"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "انتهاء صلاحية الطلب"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "قيد التقدم"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "النوع"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "باركود مقدم الطلب"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "مقدم الطلب"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "حالة الطلب"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "المجلد"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "نوع الطلب"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "حدد مادة لعرض أنواع الطلب المتاحة"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "باركود مقدم الطلب"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "بحث مقدم الطلب"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "الاسم الأول لمقدم الطلب"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "مفضلات الاستيفاء"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "بيانات مقدم الطلب"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "اسم مقدم الطلب"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "مجموعة المستفيد الخاصة بمقدم الطلب"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "موقع الالتقاط"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "وكيل مقدم الطلب"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "مقدم الطلب"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "قم بمسح باركود مقدم الطلب ضوئيًا أو إدخاله يدويًا"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "اسم المستخدم"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "إنشاء طلب على مستوى العنوان"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "باركود المادة"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "الوكيل"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "الموضع في الصف"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "تاريخ الطلب"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "مقدم الطلب"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "باركود مقدم الطلب"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "حالة الطلب"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "العنوان"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "النوع"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "السنة"
+    }
+  ],
+  "resultCount": [
+    {
+      "type": 0,
+      "value": "تم العثور على "
+    },
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": " تسجيلة "
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": " تسجيلة "
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "كيف وصلت إلى "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": " ؟"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "أوه!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "عرض الوسوم"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "حالة الطلب"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "الوسوم"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "معلومات العنوان"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "المساهم"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "الطبعة"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "أرقام ردمك"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "تاريخ النشر"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "العنوان"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "طلبات على مستوى العنوان"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "العنوان"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/ber.json
+++ b/translations/ui-requests/compiled/ber.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration time"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/ca.json
+++ b/translations/ui-requests/compiled/ca.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/cs_CZ.json
+++ b/translations/ui-requests/compiled/cs_CZ.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "CSV report is being generated. Please wait."
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration time"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/da.json
+++ b/translations/ui-requests/compiled/da.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Redigér"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Rediger låneanmodning"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Rediger kommunikation for låneanmodning"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Gem & luk"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Låneanmodninger: Se, rediger, og annuller"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/de.json
+++ b/translations/ui-requests/compiled/de.json
@@ -1,0 +1,1653 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Abbrechen"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Neue Bestandsanfrage schließen"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Neue Bestandsanfrage erstellen"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplizieren"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Bearbeiten"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage bearbeiten"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragendialog bearbeiten"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Aktionen"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Wird geladen..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage verschieben"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Neue Bestandsanfrage"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Warteliste neu anordnen"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Adresstyp auswählen"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Abholstandort auswählen"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Abholservicestelle auswählen"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen in Warteliste anzeigen"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Details der Sperre anzeigen, um zusätzliche Gründe für die Sperre anzuzeigen..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Benutzer/-in für Bestandsanfragen gesperrt"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Grund für Sperre"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Zusätzliche Informationen für Benutzer/-in "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Weitere Informationen zur Stornierung eingeben (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Weitere Informationen zur Stornierung eingeben (erforderlich)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage stornieren"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Stornierung der Bestandsanfrage bestätigen"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Benutzer/-in benachrichtigen"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Stornierungsgrund"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": "wird "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "storniert"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Zusätzliche Informationen für Benutzer/-in"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Stornierungsgrund"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Schließen"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Abbrechen"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Speichern & schließen"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "CSV Ergebnisbericht wird generiert. Dies kann bei größeren Ergebnismengen einige Zeit dauern. Bitte geduldig sein."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "CSV Bericht wird generiert. Bitte warten"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Lieferadresse"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Details der Sperre anzeigen"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Eingabe"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") hat den Exemplarstatus "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " und kann nicht vorgemerkt werden."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Exemplar kann nicht bestellt werden."
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Exemplar mit diesem Barcode existiert nicht"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Nur ausgeliehene Exemplare können vorgemerkt werden"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Nur ausgeliehene Exemplare können zurückgerufen werden"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Bitte ein Exemplar auswählen"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Bitte ein Exemplar auswählen und Enter drücken"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Bitte Informationen zum Bestellenden ausfüllen, um fortzufahren"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Diese Bestandsanfrage-Warteliste wurde durch eine andere Person oder Prozess aktualisiert und ist möglicherweise nicht mehr synchron."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage-Warteliste ist nicht synchronisiert"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Neuordnung der Bestandsanfrage-Warteliste fehlgeschlagen"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Fehler Bestandsanfrage-Warteliste"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Person mit diesem Barcode existiert nicht"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Abräumliste für das Abholregal "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    },
+    {
+      "type": 0,
+      "value": " exportieren"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Suchergebnisse in CSV exportieren"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Offen - Lieferung"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Offen - Abholregal"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Geschlossen - storniert"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Geschlossen - erfüllt"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Offen - Im Transport"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Offen - noch nicht erfüllt"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Geschlossen - abgelaufen"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Geschlossen - unerfüllt"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Vormerkungen"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Ausleihbestellungen"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Rückrufe"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage Bereitstellungspräferenz"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Abholregal-Ablaufdatum"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "Abholregal-Ablaufdatum"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Mitwirkende/-r"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Haupttitel"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Exemplarbarcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effektive Signatur"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effektive Signatur"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effektive Signatur Präfix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effektive Signatur Suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronologie"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Mitwirkende/-r"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Exemplarnummer"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Exemplarnummer"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Aktuelles Fälligkeitsdatum"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effektiver Standort"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Zählung"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Exemplar-ID"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Exemplar-Informationen"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effektiver Standortcode"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Bibliothek"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effektiver Standort"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen für Exemplar"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Exemplarbarcode scannen oder eingeben"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Exemplarstatus"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Titel"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Band"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Andere Exemplare in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "Keine Exemplare gefunden"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Exemplar auswählen"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Aktuelles Fälligkeitsdatum"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Ausleihtyp"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Standort"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Materialtyp"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Bitte zulässigen Typ auswählen"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Bestätigen"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Aktueller Bestandsanfragentyp für ausgewähltes Exemplar nicht zulässig"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage wird in "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " umgewandelt."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen können nicht über die Ausleihbestellung verschoben werden, auch wenn die Bereitstellung noch nicht begonnen hat. Diese Bestandsanfrage wird in Position 2 in der Warteliste verschoben."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage an Position 2 der Warteliste verschieben"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage wurde erfolgreich verschoben"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "Kein Bestandsanfragentyp für ausgewähltes Exemplar verfügbar"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Sie müssen an einer Servicestelle angemeldet sein, um auf den Abräumliste für das Abholregal zugreifen zu können. Bitte fügen Sie Ihrem Konto in der Personen-App einen oder mehrere Servicestellen hinzu. Wenden Sie sich an einen Administrator, wenn Sie nicht in der Lage sind, Ihrem Datensatz Servicestellen hinzuzufügen."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Keine Servicestelle ausgewählt"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "Für: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Datum der Bestandsanfrage: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage für: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Bestandsanfrage"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Bestandsanfragen"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "Neue Personalnotizen"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Personalnotizen"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Spezielle Zustimmung"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Kommentar Benutzer/-in"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen: Alle Berechtigungen"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen: Anzeigen, erstellen"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen: Anzeigen, bearbeiten, stornieren"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen: Verschieben zu neuem Exemplar, Warteliste neu anordnen"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen: Warteliste neu anordnen"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen: Anzeigen"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Entnahmezettel wird geladen, bitte warten."
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Abholservicestelle"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in Warteliste"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Druckoptionen werden gerade geladen. Dieses kann einige Sekunden dauern. Bitte geduldig sein."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Entnahmezettel für "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    },
+    {
+      "type": 0,
+      "value": " drucken"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Barcode Vollmachtnehmer/-in"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Name Vollmachtnehmer/-in"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Datum der Bestandsanfrage"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Ablaufdatum Bestandsanfrage"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Detail der Bestandsanfrage"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Ablaufdatum Bestandsanfrage"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Lieferung"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Abholregal"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Abholregal-Ablaufdatum"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Informationen zur Bestandsanfrage"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in Warteliste"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Status der Bestandsanfrage"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragetyp"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Vormerkung"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Vormerkungen"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Ausleihbestellung"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Ausleihbestellungen"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Rückruf"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Rückrufe"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage nicht erlaubt"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage-Warteliste"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "In aktueller Position belassen"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Nach Position 2 verschieben"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen können nicht von Position 1 verschoben werden, wenn Bereitstellung begonnen hat."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen können nicht über die Ausleihbestellung verschoben werden, auch wenn die Bereitstellung noch nicht begonnen hat."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage an Position 2 der Warteliste verschoben"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Bereitstellung: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Abholregal-Ablaufdatum"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Personengruppe"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Abholung / Lieferung"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Warteliste aktualisieren"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Warteliste wurde erfolgreich aktualisiert"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Datum der Bestandsanfrage"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Ablaufdatum Bestandsanfrage"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Typ"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Barcode Benutzer/-in"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage für"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragetyp"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Exemplar auswählen, um verfügbare Bestandsanfragentypen anzuzeigen"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Barcode Benutzer/-in"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Personensuche"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Vorname Benutzer/-in"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Bereitstellungspräferenz"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Informationen über Benutzer/-in"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Name Benutzer- in"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Personengruppe"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Abholstandort"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Vollmachtnehmer/-in "
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage für"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Barcode Benutzer/-in scannen oder eingeben"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Kennung"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Exemplarbarcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Vollmachtnehmer/-in"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Datum der Bestandsanfrage"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Bestandsanfrage für"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Barcode Benutzer/-in"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Status der Bestandsanfrage"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Titel"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Typ"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Datensatz gefunden"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Datensätze gefunden"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "Wie sind Sie zu "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": " gekommen?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Tags anzeigen"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Status der Bestandsanfrage"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Mitwirkende/-r"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Ausgabe"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Erscheinungsdatum"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Haupttitel"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Bestandsanfragen auf Titelebene"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/en.json
+++ b/translations/ui-requests/compiled/en.json
@@ -1,0 +1,1647 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "appMenu.keyboardShortcuts": [
+    {
+      "type": 0,
+      "value": "Keyboard shortcuts"
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "CSV report is being generated. Please wait."
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration time"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/en_GB.json
+++ b/translations/ui-requests/compiled/en_GB.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/en_SE.json
+++ b/translations/ui-requests/compiled/en_SE.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/en_US.json
+++ b/translations/ui-requests/compiled/en_US.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "CSV report is being generated. Please wait."
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration time"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/es.json
+++ b/translations/ui-requests/compiled/es.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Cerrar Nueva Solicitud"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Crear Nueva Solicitud"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicar"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Editar"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Editar solicitud"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Editar Diálogo de Solicitud"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Cargando..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Mover reserva"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Nueva solicitud"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reordenar cola"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Seleccionar el tipo de dirección"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Seleccione lugar de recogida"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Seleccionar punto de servicio de recogida"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "Ver cola de reservas"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Ver detalles de bloqueo para ver las razones adicionales para bloquear..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patrón bloqueado para préstamo"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Motivo del bloqueo"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Información adicional"
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Introducir más información acerca de la cancelación (opcional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Introducir más información acerca de la cancelación (requerido)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar solicitud"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirmar cancelación de solicitud"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notificar al usuario"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Razón de la cancelación"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " será "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelado"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Información adicional para el usuario"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Motivo de la cancelación"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Cerrar"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Guardar & cerrar"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Dirección de entrega"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Ver detalles del bloqueo"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Introducir"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Código de barras: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") tienes el estado de ejemplar "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " y no se puede solicitar."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "No se puede solicitar el ejemplar"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "El artículo con este código de barras no existe"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Sólo se pueden retener los artículos desprotegidos"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Sólo se pueden retirar los artículos desprotegidos"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Por favor seleccione un artículo"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Por favor seleccione un solicitante"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "El usuario con este código de barras no existe"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Exportar resultados de búsqueda a CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Abierto - Entrega en espera"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Abierto - Recogida en espera"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Cerrado - Cancelado"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Cerrado - Cumplimentado"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Abierto - En tránsito"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Abierto - No rellenado todavía"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Cerrado - Recogida expirada"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Cerrado - No cumplimentado"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Páginas"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Avisos"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Preferencia de cumplimentado de la reserva"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de expiración de la reserva de estantería"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del artículo"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Número de llamada"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Número de llamada efectivo"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Prefijo de número de llamada efectivo"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Sufijo de número de llamada efectivo"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Cronología"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Colaborador"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Copiar"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Número de copia"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento actual"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Localización efectiva"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeración"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "ID de ítem"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Información del artículo"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Código de localización de estantería"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Biblioteca"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Localización"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Solicitudes"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Reservas del ítem"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Escanear o introducir el código de barras del artículo"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Estado del artículo"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volumen"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento actual"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Tipo de préstamo"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Localización"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Tipo de material"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Por favor, seleccionar un tipo permitido"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirmar"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Tipo de reservas actuales no permitidas para el ítem seleccionado"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "La reserva se convertirá en "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Las reservas no se pueden mover más arriba, aunque la anterior no esté aún cumplimentada. Esta reserva se moverá a la posición 2 en la cola de reservas."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Reserva movida a la posición 2 de la cola"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "La reserva se movió correctamente"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No hay tipos de reserva disponibles para el ítem seleccionado"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Debe iniciar sesión en un punto de servicio para acceder al informe de aprobación de estantería en espera. Agregue uno o más puntos de servicio a su registro de usuario en la aplicación Usuarios. Póngase en contacto con un administrador si no tiene la capacidad de agregar puntos de servicio a su registro."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Ningún punto de servicio seleccionado"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Todos los permisos"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver, crear"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver, editar, cancelar"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Solicitudes: mover a un ejemplar nuevo, reordenar la cola"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Reordenar la cola"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Punto de servicio de recogida"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Posición en la cola"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Las opciones de impresión se están cargando. Puede que lleve unos segundos, por favor, ten paciencia."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Imprimir recibos para "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del proxy del solicitante"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Nombre del proxy del solicitante"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de expiración de la reserva"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Detalle de la solicitud"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento de la solicitud"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Entrega"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Reserva en estantería"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Mantener la fecha de vencimiento de estantería"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Solicitar información"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Posición en cola"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Estado de la solicitud"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Etiquetas"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Tipo de Solicitud"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Reserva"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Página"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Páginas"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Aviso"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Avisos"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Solicitud no permitida"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Cola de petición"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Dejar en la posición actual"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Confirmar"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Las reservas no pueden ser desplazadas de la posición 1 cuando el cumplimiento ha comenzado. Esta reserva se moverá a la posición 2 en la cola de reservas"
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Las reservas no se pueden mover más arriba, aunque la anterior no esté aún cumplimentada. Esta reserva se moverá a la posición 2 en la cola de reservas."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "La solicitud se ha movido a la posición 2 de la cola"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Entrega: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Caducidad de la reserva en estantería"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Grupo de usuarios"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Recogida/Entrega"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "La cola se actualizó correctamente"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Fecha de solicitud"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Solicitar vencimiento"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Tipo de reserva"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Seleccionar ítem para ver los tipos de reserva disponibles"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Búsqueda del solicitante"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Nombre del solicitante"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Preferencia de cumplimiento"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Información del solicitante"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Nombre"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Grupo de usuarios solicitante"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Lugar de recogida"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy del solicitante"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Escanear o introducir el código de barras del solicitante"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Nombre de usuario"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del ítem"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy (tutor)"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Fecha de reserva"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Estado de la reserva"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "Cómo obtuviste este "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Mostrar etiquetas"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Estado de la reserva"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Etiquetas"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/es_419.json
+++ b/translations/ui-requests/compiled/es_419.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Cerrar Nueva Solicitud"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Crear Nueva Solicitud"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicar"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Editar"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Editar solicitud"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Editar Diálogo de Solicitud"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Acciones"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Cargando..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Mover reserva"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Nueva solicitud"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reordenar cola"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Seleccionar el tipo de dirección"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Seleccione lugar de recogida"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Recoger en"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "Ver cola de reservas"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Ver detalles de bloqueo para ver las razones adicionales para bloquear..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Código barras"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patrón bloqueado para préstamo"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Motivo del bloqueo"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Información adicional para el usuario "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Introducir más información acerca de la cancelación (opcional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Introducir más información acerca de la cancelación (requerido)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar solicitud"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirmar cancelación de solicitud"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notificar al usuario"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Razón de la cancelación"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " será "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelado"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Información adicional para el usuario"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Motivo de la cancelación"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Cerrar"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Guardar & cerrar"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Dirección de entrega"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Ver detalles del bloqueo"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Introducir"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Código de barras: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") tienes el estado de ejemplar "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " y no se puede solicitar."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "No se puede solicitar el ejemplar"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "El artículo con este código de barras no existe"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Sólo se pueden retener los artículos desprotegidos"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Sólo se pueden retirar los artículos desprotegidos"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Por favor seleccione un artículo"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Por favor seleccione un solicitante"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Esta cola de solicitudes ha sido actualizada por otra persona o proceso y es posible que no esté sincronizada."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "La cola de solicitudes no está sincronizada"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Error al reordenar la cola de solicitudes"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Solicitar error de cola"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "El usuario con este código de barras no existe"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Exportar resultados de búsqueda a CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Abierto - Entrega en espera"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Abierto - Recogida en espera"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Cerrado - Cancelado"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Cerrado - Cumplimentado"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Abierto - En tránsito"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Abierto - No rellenado todavía"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Cerrado - Recogida expirada"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Cerrado - No cumplimentado"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Páginas"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Avisos"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Preferencia de cumplimentado de la reserva"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de expiración de la reserva de estantería"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del artículo"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Número de llamada"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Número de llamada efectivo"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Prefijo de número de llamada efectivo"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Sufijo de número de llamada efectivo"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Cronología"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Colaborador"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Copiar"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Número de copia"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento actual"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Localización efectiva"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeración"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "ID de ítem"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Información del artículo"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Código de localización de estantería"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Biblioteca"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Localización"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Solicitudes"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Reservas del ítem"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Escanear o introducir el código de barras del artículo"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Estado del artículo"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volumen"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento actual"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Tipo de préstamo"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Localización"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Tipo de material"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Por favor, seleccionar un tipo permitido"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirmar"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Tipo de reservas actuales no permitidas para el ítem seleccionado"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "La reserva se convertirá en "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Las reservas no se pueden mover más arriba, aunque la anterior no esté aún cumplimentada. Esta reserva se moverá a la posición 2 en la cola de reservas."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Reserva movida a la posición 2 de la cola"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "La reserva se movió correctamente"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No hay tipos de reserva disponibles para el ítem seleccionado"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Debe iniciar sesión en un punto de servicio para acceder al informe de aprobación de estantería en espera. Agregue uno o más puntos de servicio a su registro de usuario en la aplicación Usuarios. Póngase en contacto con un administrador si no tiene la capacidad de agregar puntos de servicio a su registro."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Ningún punto de servicio seleccionado"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "Nueva nota para el staff"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Notas del personal"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Anular"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Todos los permisos"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver, crear"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver, editar, cancelar"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Solicitudes: mover a un ejemplar nuevo, reordenar la cola"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Reordenar la cola"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Punto de servicio de recogida"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Posición en la cola"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Las opciones de impresión se están cargando. Puede que lleve unos segundos, por favor, ten paciencia."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Imprimir recibos para "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del proxy del solicitante"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Nombre del proxy del solicitante"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de expiración de la reserva"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Detalle de la solicitud"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento de la solicitud"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Entrega"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Reserva en estantería"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Mantener la fecha de vencimiento de estantería"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Solicitar información"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Posición en cola"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Estado de la solicitud"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Etiquetas"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Tipo de Solicitud"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Página"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Páginas"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recordatorio"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recordatorios"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Solicitud no permitida"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Cola de petición"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Dejar en la posición actual"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Confirmar"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Las reservas no pueden ser desplazadas de la posición 1 cuando el cumplimiento ha comenzado. Esta reserva se moverá a la posición 2 en la cola de reservas"
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Las reservas no se pueden mover más arriba, aunque la anterior no esté aún cumplimentada. Esta reserva se moverá a la posición 2 en la cola de reservas."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "La solicitud se ha movido a la posición 2 de la cola"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Entrega: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Caducidad de la reserva en estantería"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Grupo de usuarios"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Recogida/Entrega"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Actualizar cola"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "La cola se actualizó correctamente"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Fecha de solicitud"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Solicitar vencimiento"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Tipo de reserva"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Seleccionar ítem para ver los tipos de reserva disponibles"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Búsqueda del solicitante"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Nombre del solicitante"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Preferencia de cumplimiento"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Información del solicitante"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Nombre"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Grupo de usuarios solicitante"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Lugar de recogida"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy del solicitante"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Escanear o introducir el código de barras del solicitante"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Nombre de usuario"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del ítem"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy (tutor)"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Fecha de reserva"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Estado de la reserva"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "¿Cómo llegaste a "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": " ?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "¡UH oh! hubo un error"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Mostrar etiquetas"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Estado de la reserva"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Etiquetas"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/es_ES.json
+++ b/translations/ui-requests/compiled/es_ES.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Cerrar Nueva Solicitud"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Crear Nueva Solicitud"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicar"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Editar"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Editar solicitud"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Editar Diálogo de Solicitud"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Cargando..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Mover reserva"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Nueva solicitud"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reordenar cola"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Seleccionar el tipo de dirección"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Seleccione lugar de recogida"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Seleccionar punto de servicio de recogida"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "Ver cola de reservas"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Ver detalles de bloqueo para ver las razones adicionales para bloquear..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patrón bloqueado para préstamo"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Motivo del bloqueo"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Información adicional"
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Introducir más información acerca de la cancelación (opcional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Introducir más información acerca de la cancelación (requerido)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar solicitud"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirmar cancelación de solicitud"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notificar al usuario"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Razón de la cancelación"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " será "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelado"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Información adicional para el usuario"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Motivo de la cancelación"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Cerrar"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Guardar & cerrar"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Dirección de entrega"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Ver detalles del bloqueo"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Introducir"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Código de barras: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") tienes el estado de ejemplar "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " y no se puede solicitar."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "No se puede solicitar el ejemplar"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "El artículo con este código de barras no existe"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Sólo se pueden retener los artículos desprotegidos"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Sólo se pueden retirar los artículos desprotegidos"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Por favor seleccione un artículo"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Por favor seleccione un solicitante"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "El usuario con este código de barras no existe"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Exportar resultados de búsqueda a CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Abierto - Entrega en espera"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Abierto - Recogida en espera"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Cerrado - Cancelado"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Cerrado - Cumplimentado"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Abierto - En tránsito"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Abierto - No rellenado todavía"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Cerrado - Recogida expirada"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Cerrado - No cumplimentado"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Páginas"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Avisos"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Preferencia de cumplimentado de la reserva"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de expiración de la reserva de estantería"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del artículo"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Número de llamada"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Número de llamada efectivo"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Prefijo de número de llamada efectivo"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Sufijo de número de llamada efectivo"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Cronología"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Colaborador"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Copiar"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Número de copia"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento actual"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Localización efectiva"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeración"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "ID de ítem"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Información del artículo"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Código de localización de estantería"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Biblioteca"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Localización"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Solicitudes"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Reservas del ítem"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Escanear o introducir el código de barras del artículo"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Estado del artículo"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volumen"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento actual"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Tipo de préstamo"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Localización"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Tipo de material"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Por favor, seleccionar un tipo permitido"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirmar"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Tipo de reservas actuales no permitidas para el ítem seleccionado"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "La reserva se convertirá en "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Las reservas no se pueden mover más arriba, aunque la anterior no esté aún cumplimentada. Esta reserva se moverá a la posición 2 en la cola de reservas."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Reserva movida a la posición 2 de la cola"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "La reserva se movió correctamente"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No hay tipos de reserva disponibles para el ítem seleccionado"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Debe iniciar sesión en un punto de servicio para acceder al informe de aprobación de estantería en espera. Agregue uno o más puntos de servicio a su registro de usuario en la aplicación Usuarios. Póngase en contacto con un administrador si no tiene la capacidad de agregar puntos de servicio a su registro."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Ningún punto de servicio seleccionado"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Todos los permisos"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver, crear"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver, editar, cancelar"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Solicitudes: mover a un ejemplar nuevo, reordenar la cola"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Reordenar la cola"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Solicitudes: Ver"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Punto de servicio de recogida"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Posición en la cola"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Las opciones de impresión se están cargando. Puede que lleve unos segundos, por favor, ten paciencia."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Imprimir recibos para "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del proxy del solicitante"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Nombre del proxy del solicitante"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de expiración de la reserva"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Detalle de la solicitud"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Fecha de vencimiento de la solicitud"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Entrega"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Reserva en estantería"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Mantener la fecha de vencimiento de estantería"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Solicitar información"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Posición en cola"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Estado de la solicitud"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Etiquetas"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Tipo de Solicitud"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Reserva"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Reservas"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Página"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Páginas"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Aviso"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Avisos"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Solicitud no permitida"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Cola de petición"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Dejar en la posición actual"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Confirmar"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Las reservas no pueden ser desplazadas de la posición 1 cuando el cumplimiento ha comenzado. Esta reserva se moverá a la posición 2 en la cola de reservas"
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Las reservas no se pueden mover más arriba, aunque la anterior no esté aún cumplimentada. Esta reserva se moverá a la posición 2 en la cola de reservas."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "La solicitud se ha movido a la posición 2 de la cola"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Entrega: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Caducidad de la reserva en estantería"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Grupo de usuarios"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Recogida/Entrega"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "La cola se actualizó correctamente"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Fecha de solicitud"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Solicitar vencimiento"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Tipo de reserva"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Seleccionar ítem para ver los tipos de reserva disponibles"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Búsqueda del solicitante"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Nombre del solicitante"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Preferencia de cumplimiento"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Información del solicitante"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Nombre"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Grupo de usuarios solicitante"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Lugar de recogida"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy del solicitante"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Escanear o introducir el código de barras del solicitante"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Nombre de usuario"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del ítem"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy (tutor)"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Fecha de reserva"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras del solicitante"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Estado de la reserva"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "Cómo obtuviste este "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Mostrar etiquetas"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Estado de la reserva"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Etiquetas"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/fr.json
+++ b/translations/ui-requests/compiled/fr.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/fr_FR.json
+++ b/translations/ui-requests/compiled/fr_FR.json
@@ -1,0 +1,1665 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Annuler"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Fermer la nouvelle demande"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Créer une nouvelle demande"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Dupliquer"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Modifier"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Modifier la demande"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Boîte de dialogue Modifier la demande"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Chargement..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Déplacer la demande"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Nouvelle demande"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Réorganiser la file d'attente"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Sélectionner le type d'adresse"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Sélectionnez l'emplacement de collecte"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Sélectionnez le point de retrait"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "Afficher les demandes / réservations en file d'attente"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Afficher les détails pour voir les raisons supplémentaires de la suspension..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Code-barres"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Utilisateur bloqué"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Raison de la suspension"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Informations supplémentaires pour l'utilisateur "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Saisir davantage d'informations sur l'annulation (facultatif)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Saisir davantage d'informations sur l'annulation (obligatoire)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Annuler la demande"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirmer l'annulation de la demande"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notifier l'utilisateur"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Raison de l'annulation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " sera "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " annulé(e) "
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Informations complémentaires sur l'utilisateur"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Motif de l'annulation"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Fermer"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Annuler"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Sauvegarder et fermer"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "Un rapport de résultats CSV est en cours de création. Cela peut prendre un certain temps pour des ensembles de résultats plus volumineux. Merci de votre patience."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Adresse de livraison"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Voir les détails"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Valider"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ( "
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": " ) (Code-barres: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": " ) a comme statut "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "itemStatus"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " et ne peut pas être réservé."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "L'exemplaire ne peut pas être demandé"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "L'article avec ce code-barres n'existe pas"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Seuls les articles empruntés peuvent être conservés"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Seuls les articles empruntés peuvent être rappelés"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Merci de sélectionner un élément"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Veuillez sélectionner un élément et appuyez sur Entrée"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Veuillez remplir les informations du demandeur pour continuer"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Cette file d'attente a été mise à jour par une autre personne ou un autre processus et peut être désynchronisée."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "La file d'attente des réservations n'est pas synchronisée"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "La réorganisation de la file d'attente de la demande/réservation a échoué"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Erreur de file d'attente de la demande/réservation"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "L'utilisateur avec ce code-barres n'existe pas"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Exporter le rapport pour "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Exporter les résultats au format CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Exemplaire"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Titre"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Ouvert - En attente de livraison"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Ouvert - En attente de retrait"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Fermé - Annulé"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Fermé - Fourni"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Ouvert - En transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Ouvert - Pas encore servi/fourni"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Fermé - Retrait échu"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Fermé - Non fourni"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Demandes/Réservations"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Demandes (réserver, obtenir)"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Rappels"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Préférence de distribution de la demande"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Date d'expiration en rayon d'attente"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributeur / auteur"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Titre"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Code-barres du document"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Chaîne de caractères de la cote"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Chaîne de caractères de la cote"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Préfixe de la cote"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Suffixe de la cote"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronologie"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributeur"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Copie de l'élément"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Numéro d'exemplaire"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Date d'échéance actuelle"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Emplacement"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Tomaison"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "ID de l'exemplaire"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Informations sur le document"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Code de l'emplacement"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Bibliothèque"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Emplacement"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Réservations"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Réservations pour ce document"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scanner ou saisir le code-barres de l'exemplaire"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Statut du document"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Titre"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Date d'échéance actuelle"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Type de prêt"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Emplacement"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Type de ressource"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Réservations"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Merci de sélectionner le type autorisé"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirmer"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Le type de réservation actuel n'est pas autorisé pour le document sélectionné"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "La demande sera convertie en "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "requestType"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " ."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Demande déplacée en position 2 de la file d'attente"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "La demande a été déplacée avec succès"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "Aucun type de réservation disponible pour le document sélectionné"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Vous devez être connecté à un point de service pour accéder au rapport du rayon d'attente. Veuillez ajouter un ou plusieurs points de service à votre fiche utilisateur dans l'application Utilisateurs. Contactez un administrateur si vous n'avez pas la possibilité d'ajouter des points de service à votre dossier."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Aucune unité de services sélectionnée"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "Pour: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ( "
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": " )"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Date de la demande: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Demandeur: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Demande"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": " demande "
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": " demandes "
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "Nouvelle note du personnel"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Notes du personnel"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Substituer"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Commentaires utilisateur"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Demandes/réservations: toutes les autorisations"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Demandes/réservations: afficher, créer"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Demandes/Réservations: afficher, modifier, annuler"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Demandes/réservations: déplacer vers un nouvel élément, réorganiser la file d'attente"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Demandes/réservations: réorganiser la file d'attente"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Demandes/réservations: Afficher"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Les bordereaux de prélèvement sont en cours de chargement, veuillez patienter"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Point de retrait"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position en liste d'attente"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Chargement des options d'impression en cours. Cela peut prendre quelques secondes, merci de patienter."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Imprimer les bordereaux de prélèvement pour "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Code-barres du mandataire du demandeur"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Nom du mandataire du demandeur"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Date d'expiration de la demande"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Détail de la demande"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Date d'expiration de la demande"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Livraison"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Rayon d'attente"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Date d'expiration en rayon"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Informations sur la réservation"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position en liste d'attente"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Statut de la réservation"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Mots-clés"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Type de réservation"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Réservation"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Réservations"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Rappel"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Rappels"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Demande non autorisée"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "File d'attente"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronologie"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Laisser en position actuelle"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Déplacer en position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Les demandes ne peuvent pas être déplacées de la position 1 lorsque l'exécution a commencé."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Les demandes ne peuvent pas être déplacées au-dessus des demandes de page, même si leur traitement n'a pas commencé."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Demande déplacée en position 2 de la file d'attente"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Livraison: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Statut"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Expiration rayon d'attente"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Code-barres de l'exemplaire"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Commande"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Groupe/Catégorie d'utilisateurs"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Retrait / livraison"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Rafraîchir la file d'attente"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "La file d'attente a été mise à jour avec succès"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Date de la demande"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Expiration de la demande"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "En cours"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Code-barres du demandeur"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Demandeur"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Statut de la réservation"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Type de réservation"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Sélectionnez un élément pour afficher les types de demande disponibles"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Code-barres du demandeur"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Recherche du demandeur"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Prénom du demandeur"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Préférence de distribution"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Informations sur le demandeur"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Nom du demandeur"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Groupe utilisateur du demandeur"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Emplacement du point de retrait"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Procuration du demandeur"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Demandeur"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scanner ou saisir le code-barres du demandeur"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Nom d'utilisateur"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Code-barres du document"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Procuration"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Date de la demande"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Demandeur"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Code-barres du demandeur"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Statut de la réservation"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Titre"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": " enregistrement trouvé "
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": " enregistrements trouvés "
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "Comment êtes-vous arrivé à "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": " ?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Ahem!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Afficher les mots-clés"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Statut de la réservation"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Mots-clés"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Informations sur le titre"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributeur / auteur"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Date de publication"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Titre"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/he.json
+++ b/translations/ui-requests/compiled/he.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/hi_IN.json
+++ b/translations/ui-requests/compiled/hi_IN.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/hu.json
+++ b/translations/ui-requests/compiled/hu.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Új kérés bezárása"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Új kérés létrehozása"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Kérés szerkesztése"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Kérés párbeszédpanel szerkesztése"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Betöltés..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Új kérés"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Cím típusának kiválasztása"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Átvételi lelőhely kiválasztása"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Vonalkód"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Írjon be további információt a törlésről (opcionális)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Írjon be további információt a törlésről (szükséges)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Kérés visszavonása"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Erősítse meg a kérés lemondását"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Olvasó értesítése"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "A lemondás oka"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " törölve "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "lesz"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Tétel ilyen vonalkóddal nem létezik"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Csak a kiadott tételeket lehet lefoglalni"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Csak a kiadott tételeket lehet visszahívni"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Kérem, válasszon ki egy tételt"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Kérem, válasszon ki egyigénylőt"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Felhasználó ezzel a vonalkóddal nem létezik"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Tétel vonalkódja"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Raktári jelzet"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Másol"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Jelenlegi lejárati dátum"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Felsorolás"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Tétel információ"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Kérések"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Olvassa vagy írja be a tétel vonalkódját"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Tétel állapota"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Cím"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Kötet"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Kérések"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Igény részletes adati"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Igénylés lejárati dátuma"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Félretételi polc lejárati dátuma"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Igény adatai"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Pozíció sorban"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Igény állapota"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Igény típusa"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Igénylista"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Igénylő vonalkódja"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Igénylő keresése"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Teljesítési preferencia"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Igénylő adatai"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Név"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Átvételi lelőhely"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Igénylő meghatalmazottja"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Igénylő"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Olvassa vagy írja be az igénylő vonalkódját"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Felhasználónév"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "rekord található"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "rekordok találhatók"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/it_IT.json
+++ b/translations/ui-requests/compiled/it_IT.json
@@ -1,0 +1,1649 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Annulla"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Chiudi nuova richiesta"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Crea nuova richiesta"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplica "
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Modifica"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Modifica richiesta"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Modifica finestra Richiesta"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Azioni"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Caricamento in corso..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Sposta la richiesta"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Nuova richiesta"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Riordina coda"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Seleziona tipologia indirizzo"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Selezionare il luogo di ritiro"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Seleziona punto di ritiro"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "Visualizza richieste in coda"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Visualizza i dettagli blocco per vedere le ulteriori motivazioni al blocco."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Utente bloccato per la richiesta"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Motivo del blocco"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Informazioni aggiuntive per l'utente "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Inserisci ulteriori informazioni sulla cancellazione (opzionale)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Inserisci ulteriori informazioni sulla cancellazione (obbligatorio)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancella richiesta"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Conferma l'annullamento della richiesta"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notifica all'utente"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Motivo dell'annullamento"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " sarà "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancellato"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Ulteriori informazioni per l'utente"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Motivo cancellazione"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Chiudi"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Annulla"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Salva e chiudi"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Indirizzo di consegna"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Visualizza dettagli blocco"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Inserisci"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") lo stato dell'item è "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " e non può essere richiesto."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "L'item non può essere richiesto"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item con questo barcode non esistente"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Prenotazione solo su item in prestito"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Sollecito solo su item in prestito"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Seleziona un item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Si prega di compilare le informazioni sul richiedente per continuare"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "L'utente con questo barcode non esiste"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Esporta il report sullo scaffale delle prenotazioni del "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Esporta i risultati della ricerca in CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Aperto - In attesa di spedizione"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Aperto - In attesa di ritiro"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Chiuso - Cancellato"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Chiuso - Completato"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Aperto - In transito"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Aperto - In attesa di lavorazione"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Chiuso - Ritiro scaduto"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Chiuso - Non completato"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Prenotazioni"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Richieste"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Richiami"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Modalità di evasione della richiesta"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data scadenza scaffale prenotazioni"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Barcode dell'item"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Stringa di collocazione effettiva"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Collocazione effettiva"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Prefisso collocazione effettiva"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Suffisso collocazione effettiva"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Cronologia"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Autore"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Copia"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Numero copia"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Attuale data di scadenza"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Sezione effettiva"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumerazione"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "id item"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Informazioni item"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Codice collocazione"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Biblioteca"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Collocazione"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Richieste"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Richieste su item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scansiona o digita il barcode dell'item"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Stato item"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Titolo"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Attuale data di scadenza"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Tipologia prestito"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Sezione"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Tipologia materiale"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Richieste"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Seleziona tipologia consentita"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Conferma"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Tipo di richieste correnti non consentite per l'item selezionato"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "La richiesta verrà convertita in "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "requestType"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " ."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Le richieste non possono essere spostate in cima alla pagina richieste se la procedura non è iniziata. La richiesta sarà spostata in posizione 2 nella coda richieste."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Richiesta spostata nella posizione 2 della coda"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "La richiesta è stata spostata con successo"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "Nessun tipo di richiesta disponibile per l'item selezionato"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Devi essere collegato ad almeno un service point per avere il report sulle tue prenotazioni.  Aggiungi uno o più punti service point al tuo utente nell'app Utenti. Contatta un amministratore se non hai la possibilità di aggiungere service point al tuo record utente."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Nessun punto di distribuzione selezionato"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "Per: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Data della richiesta: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Nome del richiedente: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Richiesta"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "richiesta"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "richieste"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "Nuova nota per lo staff"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Note per lo staff"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Richieste: tutte le autorizzazioni"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Richieste: Visualizzare, creare"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Richieste: visualizza, crea, annulla"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Richieste: sposta la richiesta, riordina coda"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Richieste: riordina coda"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Richieste: visualizza"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Punto di ritiro"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Posizione in coda"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Stampa ricevuta selezionati per "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Barcode proxy del richiedente"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Nome del delegato del richiedente"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data di scadenza della richiesta"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Dettagli richiesta"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Data di scadenza della richiesta"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Consegna"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Scaffale prenotazioni"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data scadenza scaffale prenotazioni"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Richiesta informazioni"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Posizione in coda"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Stato richiesta"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tag"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Tipologia richiesta"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Prenotazione"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Prenotazioni"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Richiesta"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Richieste"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Sollecito"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Richiami"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Richiesta non consentita"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Coda delle richieste"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Mantieni nella posizione corrente"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Sposta in posizione 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Le richieste non possono essere spostate dalla posizione 1 dopo l’inizio della procedura."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Richiesta spostata nella posizione 2 della coda"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Consegna: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Scadenza scaffale prenotazioni"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Categoria utente"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Ritiro/Consegna"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "La coda è stata aggiornata con successo"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Data della richiesta"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Scadenza richiesta"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Barcode del richiedente"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Richiedente"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Tipologia richiesta"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Seleziona item per visualizzare tipi di richiesta disponibili"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Barcode del richiedente"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Ricerca utente"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Nome del richiedente"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Modalità di evasione della richiesta"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Informazioni richiedente"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Nome del richiedente"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Categoria utente del richiedente"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Luogo di ritiro"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy del richiedente"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Richiedente"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scansiona o digita il barcode del richiedente"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Barcode item"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Delega"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Data della richiesta"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Richiedente"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Barcode del richiedente"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Stato richiesta"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Titolo"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Tipologia"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "record trovato"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "record trovati"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "Come sei arrivato a "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Oh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Mostra tag"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Stato richiesta"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tag"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/ja.json
+++ b/translations/ui-requests/compiled/ja.json
@@ -1,0 +1,1649 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "キャンセル"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "新しいリクエストを閉じる"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "新しいリクエストを作成"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "編集"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "リクエストを編集"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "読み込み中..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "新規リクエスト"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "キューを並べ替える"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "住所の種類を選択"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "受取サービスポイントを選択"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "バーコード"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "利用者の追加情報"
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "キャンセルリクエスト"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "利用者に通知する"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "キャンセルの理由"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": "は"
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "キャンセルされます"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "キャンセル理由"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "閉じる"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "キャンセル"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "保存して閉じる"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "入力"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    },
+    {
+      "type": 0,
+      "value": "の取置棚クリアランスレポートをエクスポートする"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "検索結果をCSVにエクスポートする"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "オープン - 配達待ち"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "オープン - 受取待ち"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "クローズ - キャンセル"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "クローズ - 完了"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "オープン - 輸送中"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "オープン - 未完了"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "クローズ済み - 取置期限切れ"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "クローズ - 未完了"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "予約"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "分館取寄"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "期限前返却依頼"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "取り置き期限"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "資料バーコード"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "寄与者"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "現在の期日"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "有効な場所"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "有効な場所コード"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "有効な場所"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "リクエスト"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "資料バーコードのスキャンまたは入力"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "タイトル"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "巻"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "現在の期日"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "場所"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "資料種別"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "リクエスト"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "取置棚クリアランスレポートにアクセスするには、サービスポイントにログインする必要があります。ユーザーアプリのユーザーレコードに1つ以上のサービスポイントを追加してください。レコードにサービスポイントを追加する権限がない場合は、管理者に連絡してください。"
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "サービスポイントが選択されていません"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "リクエスト：すべての権限"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "受取サービスポイント"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "リクエスト失効日"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "リクエスト失効日"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "取り置き棚"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "期限切れ取り置き棚"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "リクエスト状況"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "タグ"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "リクエストの種類"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "予約"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "分館取寄"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "期限前返却依頼"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "確認"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "フルフィルメントが開始されると、リクエストをポジション1から移動することはできません。このリクエストはリクエストキューの位置2に移動します"
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "フルフィルメントが開始されていない場合でも、リクエストをページリクエストの上に移動することはできません。このリクエストはリクエストキューの位置2に移動します"
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "リクエストはキューの2番目に移動しました"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "デリバリー:"
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "取り置き期限切れ"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "利用者グループ"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "ピックアップ/デリバリー"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "キューは正常に更新されました"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "リクエスト日"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "リクエストの期限切れ"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "タイプ"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "依頼者バーコード"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "依頼者"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "リクエストの種類"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "依頼者の利用者グループ"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "リクエスト者バーコードをスキャンまたは入力する"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "ユーザー名"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "資料バーコード"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "代理"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "リクエスト状況"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "タイトル"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "種類"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": " 見つかったレコード "
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": " 見つかったレコード"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "タグを表示"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "リクエスト状況"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "タグ"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/ko.json
+++ b/translations/ui-requests/compiled/ko.json
@@ -1,0 +1,1649 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "배달 주소"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "입력"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ( "
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": " ) (바코드 : "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": " )의 항목 상태는 "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "itemStatus"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " 이며 요청할 수 없습니다."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "항목을 요청할 수 없습니다."
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "검색 결과를 CSV로 내보내기"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "보류"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "페이지"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "리콜"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "신청(Requests)"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " 의 다른 항목"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "항목을 찾지 못했습니다."
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "항목 선택"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "신청(Requests)"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/nb.json
+++ b/translations/ui-requests/compiled/nb.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "CSV report is being generated. Please wait."
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration time"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/nn.json
+++ b/translations/ui-requests/compiled/nn.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "CSV report is being generated. Please wait."
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration time"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/pl.json
+++ b/translations/ui-requests/compiled/pl.json
@@ -1,0 +1,1645 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Anuluj"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Zamknij nowe zamówienie"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Utwórz nowe zamówienie"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Powiel"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edytuj"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edytuj zamówienie"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Okno edycji zamówienia"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Ładowanie..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Przesuń zamówienie"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Nowe zamówienie"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Zmień kolejność w kolejce"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Wybierz typ adresu"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Wybierz miejsce odbioru"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Wybierz punkt odbioru"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "wyświetl zamówienia w kolejce"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Wyświetl szczegóły blokady, aby zobaczyć dodatkowe przyczyny blokady ..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Kod kreskowy"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Czytelnika ma zablokowane zamówienia"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Przyczyna blokady"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Dodatkowe informacje dla czytelnika "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Wprowadź więcej informacji o anulowaniu (opcjonalnie)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Wprowadź więcej informacji o anulowaniu (wymagane)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Anuluj zamówienie"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Potwierdź anulowanie zamówienia"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Powiadom czytelnika"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Powód anulowania"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " zostanie "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "anulowane"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Dodatkowe informacje dla czytelnika"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Powód anulowania"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Zamknij"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Anuluj"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Zapisz i zamknij"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "Raport CSV jest generowany. Może to być operacja długotrwała. Prosimy o cierpliwość."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "Trwa generowanie raportu CSV. Proszę czekać."
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Adres dostawy"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Wyświetl szczegóły blokady"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Wprowadź"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Kod kreskowy: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") ma status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " i nie może zostać zamówiony."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Egzemplarz nie może zostać zamówiony"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Egzemplarz o takim kodzie kreskowym nie istnieje"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Tylko wypożyczone egzemplarze mogą być rezerwowane"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Tylko dla wypożyczonych egzemplarzy mogą być tworzone upomnienia"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Proszę wybrać egzemplarz"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Proszę zaznaczyć pozycję i nacisnąć enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Proszę wypełnić informacje o zamawiajacym aby kontynuować"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Użytkownik o takim kodzie kreskowym nie istnieje"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Wyeksportuj raport o zwolnionych rezerwacjach dla "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Eksportuj wynik wyszukiwania do CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Otwarte - oczekuje na dostawę"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Otwarte - oczekuje na odbiór"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Zamknięte - anulowane"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Zamknięte - wypełnione"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Otwarte - w trakcie realizacji"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Otwarte - jeszcze niewypełnione"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Zamknięte - nieodebrane"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Zamknięte - niewypełnione"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Umieszczone"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Strony"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Przypomnienia"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Preferencje realizacji zamówienia"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data ważności rezerwacji"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Kod kreskowy egzemplarza"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Ciąg znaków efektywnej sygnatury"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Efektywna sygnatura"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Prefiks efektywnej sygnatury"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Sufiks efektywnej sygnatury"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronologia"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Współtwórca"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Kopia egzemplarza"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Numer egzemplarza"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Aktualny termin zwrotu"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Efektywna lokalizacja"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Wyliczenie"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "ID egzemplarza"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Informacje o egzemplarzu"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Kod efektywnej lokalizacji"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Biblioteka"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Efektywna lokalizacja"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Zamówienia"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "zamówienia egzemplarzy"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Zeskanuj lub wprowadź kod kreskowy egzemplarza"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Status egzemplarza"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Tytuł"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Wolumin"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Aktualny termin zwrotu"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Sposób wypożyczania"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Lokalizacja"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Typ materiału"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Zamówienia"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Proszę wybrać dopuszczalny typ"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Potwierdź"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Ten typ zamówień nie jest dostępny dla wybranego egzemplarza"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Zamówienie zostanie zmienione na "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Zamówienia nie mogą być modyfikowane powyżej zamówionych stron, nawet jeśli ich realizacja jeszcze się nie rozpoczęła. To zamówienie zostanie przeniesione na pozycję 2 w kolejce zamówień."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Zamówienie zostało przesunięte na 2 pozycję w kolejce"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Zamówienie zostało pomyślnie przeniesione"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "Brak dostępnych zamówień dla wybranej pozycji"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Musisz być zalogowany do punktu obsługi, aby uzyskać dostęp do raportu o zwolnionych rezerwacjach. Dodaj co najmniej jeden punkt obsługi do rekordu użytkownika w aplikacji Użytkownicy. Skontaktuj się z administratorem, jeśli nie masz możliwości dodawania punktów obsługi do rekordu."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Nie wybrano punktu obsługi"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "Dla "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Data zamówienia: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Zamawiający: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Zamówienie"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "zamówienie"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "zamówienia"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "Nowa uwaga dla pracowników"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Uwagi pracowników"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Zastąp"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Uwagi czytelnika"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Zamówienia: wszystkie uprawnienia"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Zamówienie: wyświetlanie, tworzenie"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Zamówienie: wyświetlanie, edycja, anulowanie"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Zamówienia: przejdź do nowego egzemplarza, zmień kolejkę"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Zamówienia: kolejka zamówień"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Zamówienie: wyświetlanie"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Trwa ładowanie pokwitowań, proszę czekać"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Punkt odbioru"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Pozycja w kolejce"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Trwa ładowanie opcji drukowania. Może to zająć kilka sekund, prosimy o cierpliwość."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Wydrukuj pokwitowania dla "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Kod kreskowy pełnomocnika zamawiającego"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Nazwa pełnomocnika zamawiającego"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Data zamówienia"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data ważności zamówienia"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Szczegóły zamówienia"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Data ważności zamówienia"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Dostawa"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Umieść na półce"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data ważności rezerwacji"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Informacja o zamówieniu"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Pozycja w kolejce"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Status zamówienia"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Etykiety"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Typ zamówienia"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Umieść"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Umieszczone"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Strona"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Strony"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Przypomnienie"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Przypomnienia"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Zamówienie niedozwolone"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Kolejka zamówień"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Pozostaw na aktualnej pozycji"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Przesuń na pozycję 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Zamówienia nie mogą zostać przesunięte z pozycji 1 po rozpoczęciu realizacji."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Zamówienia nie mogą być modyfikowane powyżej zamówionych strony, nawet jeśli ich realizacja jeszcze się nie rozpoczęła."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Zamówienie zostało przesunięte na 2 pozycję w kolejce"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Dostawa: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Ważność rezerwacji"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Grupa czytelnika"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Odbiór/Dostawa"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Kolejka została pomyślnie zaktualizowana"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Data zamówienia"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Ważność zamówienia"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Rodzaj"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Kod kreskowy zamawiającego"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Zamawiający"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Typ zamówienia"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Wybierze egzemplarz aby zobaczyć dostępne zamówienia"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Kod kreskowy zamawiającego"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Wyszukiwanie zamawiającego"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Imię zamawiającego"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Preferencje realizacji"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Informacje o zamawiającym"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Nazwa zamawiającego"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Grupa czytelników zamawiającego"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Miejsce odbioru"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Pełnomocnik zamawiającego"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Zamawiający"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Zeskanuj lub wprowadź kod kreskowy zamawiającego"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Nazwa użytkownika"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Kod kreskowy egzemplarza"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Pełnomocnika"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Data zamówienia"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Zamawiający"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Kod kreskowy zamawiającego"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Status zamówienia"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Tytuł"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Rodzaj"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "znaleziony rekord"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "znalezione rekordy"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "Jak udało ci się dotrzeć do "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "O o!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Pokaż etykiety"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Status zamówienia"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Etykiety"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/pt_BR.json
+++ b/translations/ui-requests/compiled/pt_BR.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Fechar a nova solicitação"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Criar nova solicitação"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicar"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Editar"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Editar solicitação"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Editar caixa de diálogo de solicitações de compra"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Ações"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Carregando..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Pedido de mudança"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Nova solicitação"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reordenar fila"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Selecione o tipo de endereço"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Selecione a localização de retirada"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Selecione o ponto de serviço para retirada"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "ver solicitações na fila"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Exibir detalhes da suspensão para ver as razões adicionais para a suspensão..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Usuário suspenso de solicitação de compra"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Razão para suspensão"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Informações adicionais para o usuário "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Digite mais informações sobre o cancelamento (opcional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Informe mais informações sobre o cancelamento (obrigatório)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar pedido"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirme o cancelamento da solicitação"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notificar usuário"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Razão para o cancelamento"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " será "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelado"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Informações adicionais para o usuário"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Motivo do cancelamento"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Fechar"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Salvar e fechar"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "Um relatório de resultados CSV está sendo gerado. Isso pode levar algum tempo para conjuntos de resultados maiores. Por favor, seja paciente."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Endereço de entrega"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Ver detalhes da suspensão"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Entrar"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Código de barras: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") tem o status do item "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " e não pode ser requisitado."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "O item não pode ser solicitado"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item com este código de barras não existe"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Somente itens emprestados podem ser mantidos"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Somente itens emprestados podem ter recall"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Por favor selecione um item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Selecione um item e pressione Enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Preencha as informações do solicitante para continuar"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Esta fila de pedidos foi atualizada por outra pessoa ou processo e pode estar fora de sincronia."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "A fila de solicitações está fora de sincronia"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Falha na reordenação da fila de pedidos"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Erro na fila de requisições"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Usuário com este código de barras não existe"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Exportar relatório de liberação de estante de reservas para "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Exportar resultados da pesquisa para CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Aberto - Aguardando entrega"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Aberto - Aguardando retirada"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Fechado - Cancelado"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Fechado - Completo"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Aberto - Em trânsito"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Aberto - Ainda não atendido"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Fechado - a retirada expirou"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Fechado - Não atendido"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Acervos"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Páginas"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Solicitar preferência de atendimento"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento da estante de reservas"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contribuidor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras do item"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Seqüência efetiva do número de chamada"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Número de chamada efetivo"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Prefixo efetivo do número de chamada"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Sufixo efetivo do número de chamada"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Cronologia"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contribuidor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Exemplar"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Número do exemplar"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento atual"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Localização efetiva"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeração"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "ID do item"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Informações sobre o item"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Código de localização efetivo"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Biblioteca"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Localização efetiva"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requisições"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requisições no item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Escaneie ou insira o código de barras do item"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Status do item"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Outros itens em "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "Nenhum item encontrado"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Selecionar item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento atual"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Tipo de empréstimo"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Localização"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Tipo de material"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requisições"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Por favor, selecione o tipo permitido"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirmar"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Tipo de solicitações atuais não são permitidos para o item selecionado"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "A requisição será convertida em "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "As requisições não podem ser movidas acima das requisições da página, mesmo quando a conclusão não foi iniciada. Essa requisição será movida para a posição 2 na fila de requisições."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "A requisição foi movida para a posição 2 da fila"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Requisição foi movida com sucesso"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "Nenhum tipo de solicitação disponível para o item selecionado"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Você deve estar logado em um ponto de serviço para acessar o relatório de liberação de prateleira da reserva. Por favor, adicione um ou mais pontos de serviço ao seu registro de usuário no aplicativo Usuários. Entre em contato com um administrador se você não tiver a capacidade de adicionar pontos de serviço ao seu registro."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Nenhum ponto de serviço selecionado"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "Para: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Data da requisição: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Solicitante: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Requisição"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requisição"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requisições"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "Nova Nota da equipe"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Notas da equipe"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Sobrescrever"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Comentários do usuário"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requisições: Todas as permissões"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requisições: Ver, criar"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requisições: Ver, editar, cancelar"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requisições: Mover para novo item, reordenar fila"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requisições: Reordenar fila"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requisições: Ver"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "As guias de carregamento estão sendo carregadas. Aguarde"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Ponto de serviço para retirada"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Posição na fila"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Carregamento das opções de impressão em andamento. Pode demorar alguns segundos, por favor seja paciente."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Imprimir ficha de encaminhamento para "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras dos autorizados para solicitação"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Nome dos autorizados para solicitação"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento da solicitação"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Detalhes sobre a solicitação"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento da solicitação de compra"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Entrega"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Prateleira de espera"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento da estante de reservas"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Informações sobre a solicitação"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Posição na fila"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Status da solicitação"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Tipo de solicitação"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Acervo"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Acervos"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Página"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Páginas"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Pedido de compra não permitido"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Fila de pedidos"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Deixar na posição atual"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Mover para a posição 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "As solicitações não podem ser deslocadas da posição 1 quando o atendimento tiver começado."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "As solicitações não podem ser movidas acima das solicitações de página, mesmo quando o atendimento não foi iniciado."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Solicitação movida para a posição 2 da fila"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Entrega: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Expiração na prateleira de espera"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Grupo do usuário"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Coleta/Entrega"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Atualizar fila"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "A fila foi atualizada com sucesso"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Data do pedido"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Expiração da requisição"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras do solicitante"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Tipo de solicitação"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Selecione o item para visualizar os tipos de solicitação disponíveis"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras do solicitante"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Busca de solicitante"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Nome do solicitante"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Preferência de atendimento"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Informações sobre o solicitante"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Nome do solicitante"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Grupo do usuário solicitante"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Localização de retirada"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Autorizados para solicitação"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Solicitante"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Escaneie ou insira o código de barras do solicitante"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Nome de usuário"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras do item"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Data da solicitação"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requerente"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Código de barras do requerente"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Status da requisição"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Tipo"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Registro encontrado"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Registros encontrados"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "Como você chegou ao "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Ops!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Mostrar tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Status da solicitação"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contribuidor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edição"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Data de publicação"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Solicitações de nível de título"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/pt_PT.json
+++ b/translations/ui-requests/compiled/pt_PT.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Fechar novo pedido"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Criar novo pedido"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Editar pedido"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Editar caixa de diálogo de pedidos"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Carregando..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Novo pedido"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Selecione tipo de endereço"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Selecione local de recolha"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Pedidos bloqueados ao utilizador"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Razão para o bloqueio"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Informações adicionais "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Insira mais informação sobre o cancelamento (opcional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Insira mais informação sobre o cancelamento (obrigatório)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancelar pedido"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirmar cancelamento do pedido"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notificar utilizador"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Razão para o cancelamento"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " será "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelado"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Fechar"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Detalhes do bloqueio"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Não existe item com este código de barras"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Só itens emprestados podem ser levantados"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Só itens emprestados podem ser reservados"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Por favor selecione um item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Por favor selecione um requerente"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Não existe utilizador com este código de barras"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras do item"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Número de chamada"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Colaborador"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Copiar"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento atual"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Contagem"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Informações do item"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Pedidos"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Digitalize ou insira o código de barras do item"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Status do item"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Data atual de vencimento"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Pedidos"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Detalhes do pedido"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento do pedido"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Data de vencimento da estante de reservas"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Informações do pedido"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Posição na fila"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Status do pedido"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Tipo de pedido"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Código de barras do requerente"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Procurar requerente"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Preferência de preenchimento"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Informações do requerente"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Nome do requerente"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Grupo do utilizador requerente"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Local de recolha"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy do requerente"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requerente"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Digitalize ou insira o código de barras do requerente"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Nome do utilizador"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Título"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Registo encontrado"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Registos encontrados"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/ru.json
+++ b/translations/ui-requests/compiled/ru.json
@@ -1,0 +1,1657 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Отмена"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Закрыть новый запрос"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Создать новый запрос"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Дубликат"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Редактировать"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Редактировать запрос"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Диалог Редактирования Запроса "
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Загрузка..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Переместить запрос"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "Новый запрос"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Переупорядочить очередь"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Выберите тип адреса"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Выберите пункт выдачи"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Выберите пункт выдачи"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "Просмотр запросов в очереди"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "Просмотреть детали блока, чтобы увидеть дополнительные причины для блока ..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Штрихкод"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Читатель заблокирован от запроса"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Причина блокировки"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Дополнительная информация для читателя "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Введите дополнительную информацию об отмене (необязательно)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Введите дополнительную информацию об отмене (обязательно)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Отменить запрос"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Подтвердите отмену запроса"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Уведомить читателя"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Причина отмены"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " будет "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " отменен "
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Дополнительная информация для читателя"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Причина отмены"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Закрыть"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Адрес доставки"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "Посмотреть детали блока"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Введите"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Штрихкод: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") имеет статус экземпляра "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " и не может быть заказан."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Экземпляр не может быть заказан"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Экземпляр с таким штрихкодом не существует"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Только проверенные элементы могут быть удержаны"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Только проверенные товары могут быть отозваны"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Пожалуйста, выберите элемент"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Пожалуйста, выберите экземпляр и нажмите Enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Пожалуйста, выберите заявителя"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Пользователь с таким штрихкодом не существует"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Предпочтительное выполнение запроса"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Дата окончания нахождения на бронеполке"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Штрихкод экземпляра"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Строка актуального шифра хранения"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Актуальный шифр хранения"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Актуальный префикс шифра хранения"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Актуальный суффикс шифра хранения"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Автор"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Копировать"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Номер копии"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Текущая дата платежа"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Перечисление"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Идентификатор элемента"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Информация об элементе"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Код постоянного хранения"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Библиотека"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Постоянное хранение"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Запросы"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Запросы по пункту"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Сканирование или ввод штрихкода"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Состояние элемента"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Заголовок"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Том"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Текущая дата платежа"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Тип книговыдачи"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Расположение"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Тип материала"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Запросы"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Пожалуйста, выберите допустимый тип"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Подтвердить"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Тип текущего запроса не разрешен для выбранного элемента"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Запрос будет преобразован в "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "requestType"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " ."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Запросы нельзя перемещать выше запросов страниц, даже если их выполнение еще не началось. Этот запрос будет перемещен в позицию 2 в очереди запросов."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Запрос перемещен в положение 2 очереди"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Запрос был успешно перемещен"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "Для выбранного экземпляра нет доступных типов заказов"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "Вы должны войти в сервисную точку, чтобы получить доступ к отчету об очистке полки. Добавьте одну или несколько точек обслуживания в свою запись пользователя в приложении «Пользователи». Обратитесь к администратору, если у вас нет возможности добавлять точки обслуживания в вашу запись."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "Точка обслуживания не выбрана"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "Для: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Дата запроса: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Запрос"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "запрос"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "запросы"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "Новая служебная заметка"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Служебные примечания"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Заказы: Все разрешения"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Заказы: Просматривать, создавать"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Заказы: Просматривать, редактировать, отменять"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Заказы: Переходить к следующему экземпляру, изменять очередь"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Заказы: Изменять очередь"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Заказы: Просматривать"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Пункт выдачи"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Позиция в очереди"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Распечатать бланк выдачи для "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Штрихкод представителя заказчика"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Имя представителя заказчика"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Дата окончания запроса"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Детали запроса "
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Дата окончания запроса"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Доставка"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Бронеполка"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Дата окончания нахождения на бронеполке"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Информация о запросе"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Позиция в очереди"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Статус запроса"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Тип запроса"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Страница"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Страницы"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Отзыв"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Запрос не разрешен"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Очередь запросов"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Оставить в текущей позиции"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Подтвердить"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Ваш запрос будет выполнен в порядке существующей очереди. Выполняется предыдущий запрос."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Ваш запрос будет выполнен в порядке существующей очереди"
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Запрос перемещен в положение 2 очереди"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Доставка: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Дата окончания нахождения на бронеполке"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Группа читателей"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Самовывоз / Доставка"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Очередь была успешно обновлена"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Дата запроса"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Окончание запроса"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Тип"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Штрихкод заявителя"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Заявитель"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Тип запроса"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Выберите элемент для просмотра доступных типов запросов"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Запрос штрихкода"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Поиск заявителя"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Имя заявителя"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Предпочтение выполнения"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Информация о заявителе"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Имя заявителя"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Группа читателя-заявителя"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Место доставки "
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Представитель заказчика"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Заявитель"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Сканирование или введите штрихкод запроса"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Имя пользователя"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Штрихкод экземпляра"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Представитель"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Дата запроса"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Заявитель"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Штрихкод заявителя"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Статус запроса"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Название"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Тип"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "Как вы попали в "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": " ?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Ой-ой!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Показать теги"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Статус запроса"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Теги"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/sv.json
+++ b/translations/ui-requests/compiled/sv.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "CSV report is being generated. Please wait."
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration time"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "Item copy"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "Effective location code"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/ur.json
+++ b/translations/ui-requests/compiled/ur.json
@@ -1,0 +1,1641 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "Close New Request"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "Create New Request"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "Duplicate"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "Edit"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "Edit request"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "Edit Request Dialog"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "Actions"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "Loading..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "Move request"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "New request"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Reorder queue"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "Select address type"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "Select pickup location"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "Select pickup service point"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "view requests in queue"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "View block details to see additional reasons for block..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "Barcode"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "Patron blocked from requesting"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "Reason for block"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "Additional information for patron "
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (optional)"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "Enter more information about the cancellation (required)"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "Cancel request"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "Confirm request cancellation"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "Notify patron"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "Reason for cancellation"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " will be "
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "cancelled"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "Additional information for patron"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "Cancellation reason"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "Close"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "Save & close"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "A CSV results report is being generated. This may take some time for larger result sets. Please be patient."
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "Delivery address"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "View block details"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "Enter"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": ") (Barcode: "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": ") has the item status "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "itemStatus"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " and cannot be requested."
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "Item cannot be requested"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Item with this barcode does not exist"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be held"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "Only checked out items can be recalled"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "Please select an item"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "Please select an item and hit enter"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "Please fill out requestor information to continue"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "User with this barcode does not exist"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "Export hold shelf clearance report for "
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "Export search results to CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting delivery"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "Open - Awaiting pickup"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "Closed - Cancelled"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "Closed - Filled"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "Open - In transit"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "Closed - Pickup expired"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "Closed - Unfilled"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "Request fulfillment preference"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number string"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "Effective call number"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "Effective call number prefix"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "Effective call number suffix"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "آئٹم کاپی"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "Copy number"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "Effective location"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "Item id"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "Item information"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "موثر کوڈ کا مقام"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "Library"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "موثر مقام"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "Requests on item"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter item barcode"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "Item status"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "Current due date"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "Loan type"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "Location"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "Material type"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "Requests"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "Please select allowed type"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "Confirm"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "Current requests type not allowed for selected item"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "Request will be converted to "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "requestType"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue."
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "Request has been moved successfully"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "No request types available for selected item"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "You must be logged into a service point to access the Hold shelf clearance report. Please add one or more service points to your user record in the Users app. Contact an administrator if you do not have the ability to add service points to your record."
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "No service point selected"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "For: "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " ("
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": ")"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date: "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "Requester: "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "Request"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "request"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "requests"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "New staff note"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "Staff notes"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "Override"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "Requests: All permissions"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "Requests: View, create"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "Requests: View, edit, cancel"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "Requests: Move to new item, reorder queue"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "Requests: Reorder queue"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "Requests: View"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "Pick slips are loading, please wait"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "Pickup service point"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "Print options loading in progress. It might take a few seconds, please be patient."
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "Print pick slips for "
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "Requester's proxy barcode"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "Requester's proxy name"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "Request Detail"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration date"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "Delivery"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "Hold Shelf"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration date"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "Request information"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "Position in queue"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "Hold"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "Holds"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "Page"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "Pages"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "Recall"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "Recalls"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "Request not allowed"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "Request queue"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "Leave in current position"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "Move to position 2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "Requests cannot be displaced from position 1 when fulfillment has begun."
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "Requests cannot be moved above page requests, even when fulfillment hasn't begun."
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "Request moved to position 2 of the queue"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "Delivery: "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "Hold shelf expiration"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "Patron group"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "Pickup/Delivery"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "Queue was successfully updated"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "Request date"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "Request expiration"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "Request type"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "Select item to view available request types"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "Requester barcode"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "Requester look-up"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "Requester First Name"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "Fulfillment preference"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "Requester information"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "Requester name"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "Requester patron group"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "Pickup location"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "Requester's proxy"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Scan or enter requester barcode"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "Username"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "Proxy"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "Request Date"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "Requester"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "Requester Barcode"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "Type"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Record found"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Records found"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "How did you get to "
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "Uh-oh!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "Show Tags"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "Tags"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/zh_CN.json
+++ b/translations/ui-requests/compiled/zh_CN.json
@@ -1,0 +1,1665 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "取消"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "关闭 \"新建请求\""
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "创建“新建请求”"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "复制"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "编辑"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "编辑请求"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "编辑请求对话框"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "操作"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "正在加载..."
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "移动请求"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "新建请求"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "重新排序队列"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "选择地址类型"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "选择取件地"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "选择取件服务点"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "查看队列中的请求"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "查看冻结详情以了解冻结的其他原因..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "条码"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "读者请求被冻结"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "冻结原因"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "读者的附加信息"
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "输入关于取消(可选)的更多信息"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "输入关于取消(必填)的更多信息"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "取消请求"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "确认取消请求"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "通知读者"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "取消原因"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " 将被"
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "取消"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "读者附加信息"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "取消原因"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "关闭"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "取消"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "保存并关闭"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "正在生成CSV结果报告。对于较大的结果集，可能需要一些时间。请耐心等待。"
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "传递地址"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "查看冻结详情"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "输入"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " （ "
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": " ）（条码： "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": " ）的单件状态为"
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "itemStatus"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " ，因此无法请求。"
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "单件无法请求"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "此 HRID 或 UUID 的实例不存在"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "不存在此条码对应的单件"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "只能预约已出借单件"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "只能召回已出借单件"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "请选择一个实例，然后按回车"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "请选择一个单件"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "请选择一个单件，然后按回车"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "请填写请求者信息以继续"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "本请求队列已由其他人或进程更新，可能不同步。"
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "请求队列不同步"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "请求队列重新排序失败"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "请求队列错误"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "不存在此条码对应的读者"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "导出"
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    },
+    {
+      "type": 0,
+      "value": "预约架清仓报告"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "将搜索结果导出到 CSV"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "单件"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "题名"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "未结 - 等待传递"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "未结 - 等待取件"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "已关闭 - 已取消"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "已关闭 - 已满足"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "未结 - 转运中"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "未结 - 尚未满足"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "已关闭 - 取件已过期"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "已关闭 - 未满足"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "预约"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "传呼"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "召回"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "请求履行首选项"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "预约架到期日期"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "添加贡献者"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "题名信息"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "输入 HRID 或 UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "题名"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "实例 HRID 或 UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "单件条码"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "有效的索书号字符串"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "有效的索书号"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "有效的索书号前缀"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "有效的索书号后缀"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "年表"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "贡献者名称"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "单件复本"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "复本号"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "当前到期日"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "有效馆藏地"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "期次"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "单件ID"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "单件信息"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "有效馆藏地代码"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "图书馆"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "有效馆藏地"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "没有关于此项请求的单件信息"
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "请求"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "请求单件"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "扫描或输入单件条码"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "单件状态"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "题名"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "卷"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "单件"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": "单件"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": "中其他单件"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "未找到单件"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "选择单件"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "当前到期日"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "借阅类型"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "馆藏地"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "资料类型"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "请求"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "请选择允许的类型"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "确认"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "所选单件不允许使用当前请求类型"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "请求将转换为"
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "requestType"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " 。"
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "即使尚未开始执行，也无法将请求移至传呼请求之上。此请求将移至请求队列中的位置2。"
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "请求已移至队列的第2位"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "请求已成功移动"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "没有适用于所选单件的请求类型"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "您必须登录服务点才能访问预约架清关报告。请在“用户”应用中为您的用户记录添加一个或多个服务点。如果无法在记录中添加服务点，请与管理员联系。"
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "未选择服务点"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "对于： "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " （ "
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": " ）"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "请求日期： "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "请求者： "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "请求"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "请求"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "请求"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "新建员工附注"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "员工附注"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "越权"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "读者备注"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "请求：所有权限"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "请求：查看、创建"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "请求：查看、编辑、取消"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "请求：移至新单件，重新排序队列"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "请求：重新排序队列"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "请求：查看"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "选取单正在加载，请稍候"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "取件服务点"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "队列中的位置"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "正在加载打印选项。可能需要几秒钟，请耐心等待。"
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "打印"
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    },
+    {
+      "type": 0,
+      "value": "选取单"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "请求者的代理条码"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "请求者的代理名称"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "请求到期日"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "请求级别"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "请求详情"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "请求到期日"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "传递"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "预约架"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "预约架到期日期"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "请求信息"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "队列中的位置"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "请求状态"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "标签"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "请求类型"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "馆藏"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "馆藏"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "传呼"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "传呼"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "召回"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "召回"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "请求不被允许"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "请求队列"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "年表"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "留在当前位置"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "移至位置2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "开始执行后，无法将请求从位置1移开。"
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "即使尚未开始执行，也无法将请求移到传呼请求之前。"
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "请求已移至队列的第2位"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "传递： "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "实例: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "期次"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "执行中"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "状态"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "实例 "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " / "
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": " 上的请求队列。"
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "预约架到期"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "单件条码"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "没有执行中的请求"
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "找不到请求"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "未结 - 尚未满足"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "订单"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "读者备注"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "读者组"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "取件/传递"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "刷新队列"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "队列更新成功"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "请求日期"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "请求过期"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "进行中"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "类型"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "请求者条码"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "请求者"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "请求状态"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "卷"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "请求类型"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "选择单件以查看可用的请求类型"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "请求者条码"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "请求者查找"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "请求者名字"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "履行首选项"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "请求者信息"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "请求者名称"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "请求者读者组"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "取件地"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "请求者的代理"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "请求者"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "扫描或输入请求者条码"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "用户名"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "创建标题级别的请求"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "单件条码"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "代理"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "队列位置"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "请求日期"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "请求者"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "请求者条码"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "请求状态"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "题名"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "类型"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "年份"
+    }
+  ],
+  "resultCount": [
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "记录找到"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "记录找到"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "你是怎么到"
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": " 的？"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "呃-哦!"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "显示标签"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "请求状态"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "标签"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "题名信息"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "贡献者"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "版本"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "出版日期"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "标题/品种"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "标题/品种级请求"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "题名"
+    }
+  ]
+}

--- a/translations/ui-requests/compiled/zh_TW.json
+++ b/translations/ui-requests/compiled/zh_TW.json
@@ -1,0 +1,1669 @@
+{
+  "actions.cancelNewRequest": [
+    {
+      "type": 0,
+      "value": "取消"
+    }
+  ],
+  "actions.closeNewRequest": [
+    {
+      "type": 0,
+      "value": "關閉新的預約"
+    }
+  ],
+  "actions.createNewRequest": [
+    {
+      "type": 0,
+      "value": "新增預約"
+    }
+  ],
+  "actions.duplicateRequest": [
+    {
+      "type": 0,
+      "value": "複製預約"
+    }
+  ],
+  "actions.edit": [
+    {
+      "type": 0,
+      "value": "編輯"
+    }
+  ],
+  "actions.editRequest": [
+    {
+      "type": 0,
+      "value": "編輯預約"
+    }
+  ],
+  "actions.editRequestLink": [
+    {
+      "type": 0,
+      "value": "編輯預約對話框"
+    }
+  ],
+  "actions.label": [
+    {
+      "type": 0,
+      "value": "動作"
+    }
+  ],
+  "actions.loading": [
+    {
+      "type": 0,
+      "value": "載入中…"
+    }
+  ],
+  "actions.moveRequest": [
+    {
+      "type": 0,
+      "value": "移動預約"
+    }
+  ],
+  "actions.newRequest": [
+    {
+      "type": 0,
+      "value": "新增預約"
+    }
+  ],
+  "actions.reorderQueue": [
+    {
+      "type": 0,
+      "value": "調整排隊順序"
+    }
+  ],
+  "actions.selectAddressType": [
+    {
+      "type": 0,
+      "value": "選擇地址類型"
+    }
+  ],
+  "actions.selectPickupLoc": [
+    {
+      "type": 0,
+      "value": "選擇取件地"
+    }
+  ],
+  "actions.selectPickupSp": [
+    {
+      "type": 0,
+      "value": "選擇取書工作區"
+    }
+  ],
+  "actions.viewRequestsInQueue": [
+    {
+      "type": 0,
+      "value": "查看預約排隊順序"
+    }
+  ],
+  "additionalReasons": [
+    {
+      "type": 0,
+      "value": "查看冻结详情以了解冻结的其他原因..."
+    }
+  ],
+  "barcode": [
+    {
+      "type": 0,
+      "value": "條碼"
+    }
+  ],
+  "blockModal": [
+    {
+      "type": 0,
+      "value": "讀者被禁止預約"
+    }
+  ],
+  "blockedLabel": [
+    {
+      "type": 0,
+      "value": "冻结原因"
+    }
+  ],
+  "cancel.additionalInfoLabel": [
+    {
+      "type": 0,
+      "value": "讀者的附加訊息"
+    },
+    {
+      "type": 1,
+      "value": "required"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderOptional": [
+    {
+      "type": 0,
+      "value": "輸入有關取消的更多資訊（非必填）"
+    }
+  ],
+  "cancel.additionalInfoPlaceholderRequired": [
+    {
+      "type": 0,
+      "value": "輸入有關取消的更多資訊（必填）"
+    }
+  ],
+  "cancel.cancelRequest": [
+    {
+      "type": 0,
+      "value": "取消預約"
+    }
+  ],
+  "cancel.modalLabel": [
+    {
+      "type": 0,
+      "value": "確認取消預約"
+    }
+  ],
+  "cancel.notifyLabel": [
+    {
+      "type": 0,
+      "value": "通知讀者"
+    }
+  ],
+  "cancel.reasonLabel": [
+    {
+      "type": 0,
+      "value": "取消原因"
+    }
+  ],
+  "cancel.requestWillBeCancelled": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    },
+    {
+      "type": 0,
+      "value": " 將被"
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": "取消"
+        }
+      ],
+      "type": 8,
+      "value": "b"
+    }
+  ],
+  "cancellationAdditionalInformation": [
+    {
+      "type": 0,
+      "value": "读者附加信息"
+    }
+  ],
+  "cancellationReason": [
+    {
+      "type": 0,
+      "value": "取消原因"
+    }
+  ],
+  "close": [
+    {
+      "type": 0,
+      "value": "关闭"
+    }
+  ],
+  "common.cancel": [
+    {
+      "type": 0,
+      "value": "取消"
+    }
+  ],
+  "common.saveAndClose": [
+    {
+      "type": 0,
+      "value": "保存并关闭"
+    }
+  ],
+  "csvReportInProgress": [
+    {
+      "type": 0,
+      "value": "正在生成CSV结果报告。对于较大的结果集，可能需要一些时间。请耐心等待。"
+    }
+  ],
+  "csvReportPending": [
+    {
+      "type": 0,
+      "value": "csvReportPending"
+    }
+  ],
+  "deliveryAddress": [
+    {
+      "type": 0,
+      "value": "送货地址"
+    }
+  ],
+  "detailsButton": [
+    {
+      "type": 0,
+      "value": "查看冻结详情"
+    }
+  ],
+  "enter": [
+    {
+      "type": 0,
+      "value": "輸入"
+    }
+  ],
+  "errorModal.message": [
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " （ "
+    },
+    {
+      "type": 1,
+      "value": "materialType"
+    },
+    {
+      "type": 0,
+      "value": " ）（条码： "
+    },
+    {
+      "type": 1,
+      "value": "barcode"
+    },
+    {
+      "type": 0,
+      "value": " ）的单件状态为"
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "itemStatus"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " ，因此无法请求。"
+    }
+  ],
+  "errorModal.title": [
+    {
+      "type": 0,
+      "value": "单件无法请求"
+    }
+  ],
+  "errors.instanceUuidOrHridDoesNotExist": [
+    {
+      "type": 0,
+      "value": "Instance with this HRID or UUID does not exist"
+    }
+  ],
+  "errors.itemBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "沒有此條碼的單件"
+    }
+  ],
+  "errors.onlyCheckedOutForHold": [
+    {
+      "type": 0,
+      "value": "只能預約已借出的單件"
+    }
+  ],
+  "errors.onlyCheckedOutForRecall": [
+    {
+      "type": 0,
+      "value": "只能催還已借出的單件"
+    }
+  ],
+  "errors.selectInstanceRequired": [
+    {
+      "type": 0,
+      "value": "Please select an instance and hit enter"
+    }
+  ],
+  "errors.selectItem": [
+    {
+      "type": 0,
+      "value": "請選擇一個單件"
+    }
+  ],
+  "errors.selectItemRequired": [
+    {
+      "type": 0,
+      "value": "请选择一个单件，然后按回车"
+    }
+  ],
+  "errors.selectUser": [
+    {
+      "type": 0,
+      "value": "透過條碼選擇一個要求者"
+    }
+  ],
+  "errors.sync.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "This request queue has been updated by another person or process and may be out of synch."
+    }
+  ],
+  "errors.sync.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue is out of sync"
+    }
+  ],
+  "errors.unknown.requestQueueBody": [
+    {
+      "type": 0,
+      "value": "Request queue reorder failed"
+    }
+  ],
+  "errors.unknown.requestQueueLabel": [
+    {
+      "type": 0,
+      "value": "Request queue error"
+    }
+  ],
+  "errors.userBarcodeDoesNotExist": [
+    {
+      "type": 0,
+      "value": "沒有此條碼的使用者"
+    }
+  ],
+  "exportExpiredHoldShelfToCsv": [
+    {
+      "type": 0,
+      "value": "导出"
+    },
+    {
+      "type": 1,
+      "value": "currentServicePoint"
+    },
+    {
+      "type": 0,
+      "value": "预约架清仓报告"
+    }
+  ],
+  "exportSearchResultsToCsv": [
+    {
+      "type": 0,
+      "value": "輸出查詢結果到 CSV 檔案"
+    }
+  ],
+  "filters.requestLevel.item": [
+    {
+      "type": 0,
+      "value": "館藏"
+    }
+  ],
+  "filters.requestLevel.title": [
+    {
+      "type": 0,
+      "value": "題名"
+    }
+  ],
+  "filters.requestStatus.awaitingDelivery": [
+    {
+      "type": 0,
+      "value": "开放 - 等待交付"
+    }
+  ],
+  "filters.requestStatus.awaitingPickup": [
+    {
+      "type": 0,
+      "value": "开放 - 等待取件"
+    }
+  ],
+  "filters.requestStatus.cancelled": [
+    {
+      "type": 0,
+      "value": "已关闭 - 已取消"
+    }
+  ],
+  "filters.requestStatus.filled": [
+    {
+      "type": 0,
+      "value": "已关闭 - 已满足"
+    }
+  ],
+  "filters.requestStatus.inTransit": [
+    {
+      "type": 0,
+      "value": "开放 - 传送中"
+    }
+  ],
+  "filters.requestStatus.notYetFilled": [
+    {
+      "type": 0,
+      "value": "开放 - 尚未满足"
+    }
+  ],
+  "filters.requestStatus.pickupExpired": [
+    {
+      "type": 0,
+      "value": "已关闭 - 取件已过期"
+    }
+  ],
+  "filters.requestStatus.unfilled": [
+    {
+      "type": 0,
+      "value": "已关闭 - 未满足"
+    }
+  ],
+  "filters.requestType.holds": [
+    {
+      "type": 0,
+      "value": "預約"
+    }
+  ],
+  "filters.requestType.pages": [
+    {
+      "type": 0,
+      "value": "处理"
+    }
+  ],
+  "filters.requestType.recalls": [
+    {
+      "type": 0,
+      "value": "召回"
+    }
+  ],
+  "fulfilmentPreference": [
+    {
+      "type": 0,
+      "value": "請求履行偏好"
+    }
+  ],
+  "holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "预约书架到期日期"
+    }
+  ],
+  "holdShelfExpirationTime": [
+    {
+      "type": 0,
+      "value": "holdShelfExpirationTime"
+    }
+  ],
+  "instance.contributorNames": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "instance.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "instance.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "Enter HRID or UUID"
+    }
+  ],
+  "instance.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "instance.value": [
+    {
+      "type": 0,
+      "value": "Instance HRID or UUID"
+    }
+  ],
+  "item.barcode": [
+    {
+      "type": 0,
+      "value": "單件條碼"
+    }
+  ],
+  "item.callNumber": [
+    {
+      "type": 0,
+      "value": "有效的索書號字串"
+    }
+  ],
+  "item.callNumberComponents.callNumber": [
+    {
+      "type": 0,
+      "value": "有效的索書號"
+    }
+  ],
+  "item.callNumberComponents.prefix": [
+    {
+      "type": 0,
+      "value": "有效的索书号前缀"
+    }
+  ],
+  "item.callNumberComponents.suffix": [
+    {
+      "type": 0,
+      "value": "有效的索书号后缀"
+    }
+  ],
+  "item.chronology": [
+    {
+      "type": 0,
+      "value": "年表"
+    }
+  ],
+  "item.contributorNames": [
+    {
+      "type": 0,
+      "value": "作者"
+    }
+  ],
+  "item.copyNumber": [
+    {
+      "type": 0,
+      "value": "單件複本號"
+    }
+  ],
+  "item.copyNumbers": [
+    {
+      "type": 0,
+      "value": "複本號"
+    }
+  ],
+  "item.dueDate": [
+    {
+      "type": 0,
+      "value": "目前到期日"
+    }
+  ],
+  "item.effectiveLocation": [
+    {
+      "type": 0,
+      "value": "有效的館藏地"
+    }
+  ],
+  "item.enumeration": [
+    {
+      "type": 0,
+      "value": "期數"
+    }
+  ],
+  "item.id": [
+    {
+      "type": 0,
+      "value": "單件 ID"
+    }
+  ],
+  "item.information": [
+    {
+      "type": 0,
+      "value": "單件資訊"
+    }
+  ],
+  "item.location.code": [
+    {
+      "type": 0,
+      "value": "有效的館藏地代碼"
+    }
+  ],
+  "item.location.libraryName": [
+    {
+      "type": 0,
+      "value": "圖書館"
+    }
+  ],
+  "item.location.name": [
+    {
+      "type": 0,
+      "value": "有效的館藏地名稱"
+    }
+  ],
+  "item.noInformation": [
+    {
+      "type": 0,
+      "value": "There is no item information for this request."
+    }
+  ],
+  "item.numRequests": [
+    {
+      "type": 0,
+      "value": "預約"
+    }
+  ],
+  "item.requestsOnItem": [
+    {
+      "type": 0,
+      "value": "單件的預約數量"
+    }
+  ],
+  "item.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "掃描或輸入單件條碼"
+    }
+  ],
+  "item.status": [
+    {
+      "type": 0,
+      "value": "單件狀態"
+    }
+  ],
+  "item.title": [
+    {
+      "type": 0,
+      "value": "題名"
+    }
+  ],
+  "item.volume": [
+    {
+      "type": 0,
+      "value": "卷"
+    }
+  ],
+  "itemLevel": [
+    {
+      "type": 0,
+      "value": "Item"
+    }
+  ],
+  "items": [
+    {
+      "type": 1,
+      "value": "number"
+    },
+    {
+      "type": 0,
+      "value": " items"
+    }
+  ],
+  "items.instanceItems": [
+    {
+      "type": 0,
+      "value": "Other items in "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    }
+  ],
+  "items.instanceItems.notFound": [
+    {
+      "type": 0,
+      "value": "No items found"
+    }
+  ],
+  "items.selectItem": [
+    {
+      "type": 0,
+      "value": "Select item"
+    }
+  ],
+  "loan.dueDate": [
+    {
+      "type": 0,
+      "value": "当前到期日"
+    }
+  ],
+  "loanType": [
+    {
+      "type": 0,
+      "value": "借閱類型"
+    }
+  ],
+  "location": [
+    {
+      "type": 0,
+      "value": "館藏地"
+    }
+  ],
+  "materialType": [
+    {
+      "type": 0,
+      "value": "資料類型"
+    }
+  ],
+  "meta.title": [
+    {
+      "type": 0,
+      "value": "預約"
+    }
+  ],
+  "moveRequest.chooseRequestMessage": [
+    {
+      "type": 0,
+      "value": "請選擇允許的類型"
+    }
+  ],
+  "moveRequest.confirm": [
+    {
+      "type": 0,
+      "value": "確認"
+    }
+  ],
+  "moveRequest.requestTypeChangeHeading": [
+    {
+      "type": 0,
+      "value": "所选单件不允许使用当前请求类型"
+    }
+  ],
+  "moveRequest.requestTypeChangeMessage": [
+    {
+      "type": 0,
+      "value": "请求将转换为"
+    },
+    {
+      "children": [
+        {
+          "type": 0,
+          "value": " "
+        },
+        {
+          "type": 1,
+          "value": "requestType"
+        },
+        {
+          "type": 0,
+          "value": " "
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": " 。"
+    }
+  ],
+  "moveRequest.secondPositionMessage": [
+    {
+      "type": 0,
+      "value": "即使尚未开始执行，也无法将请求移至处理请求之上。此请求将移至请求队列中的位置2。"
+    }
+  ],
+  "moveRequest.secondPositionTitle": [
+    {
+      "type": 0,
+      "value": "預約已移到排隊順序的第 2 位"
+    }
+  ],
+  "moveRequest.success": [
+    {
+      "type": 0,
+      "value": "移動預約成功"
+    }
+  ],
+  "noRequestTypesAvailable": [
+    {
+      "type": 0,
+      "value": "没有适用于所选单件的请求类型"
+    }
+  ],
+  "noServicePoint.errorMessage": [
+    {
+      "type": 0,
+      "value": "您必須先登錄工作區才能訪問預約保留架的清理報告。請在「使用者」App 中為您的使用者記錄新增一個或多個工作區。如果無法在記錄中新增工作區，請與管理員聯繫。"
+    }
+  ],
+  "noServicePoint.label": [
+    {
+      "type": 0,
+      "value": "未選擇工作區"
+    }
+  ],
+  "notes.assigned.for": [
+    {
+      "type": 0,
+      "value": "对于： "
+    },
+    {
+      "type": 1,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " （ "
+    },
+    {
+      "type": 1,
+      "value": "itemLink"
+    },
+    {
+      "type": 0,
+      "value": " ）"
+    }
+  ],
+  "notes.assigned.requestDate": [
+    {
+      "type": 0,
+      "value": "请求日期： "
+    },
+    {
+      "type": 1,
+      "value": "requestCreateDate"
+    }
+  ],
+  "notes.assigned.requester": [
+    {
+      "type": 0,
+      "value": "请求者： "
+    },
+    {
+      "type": 1,
+      "value": "requesterName"
+    }
+  ],
+  "notes.entityType.request": [
+    {
+      "type": 0,
+      "value": "请求"
+    }
+  ],
+  "notes.entityType.request.pluralized": [
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "请求"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "请求"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "notes.newStaffNote": [
+    {
+      "type": 0,
+      "value": "新建员工附注"
+    }
+  ],
+  "notes.staffNotes": [
+    {
+      "type": 0,
+      "value": "员工附注"
+    }
+  ],
+  "override": [
+    {
+      "type": 0,
+      "value": "越权"
+    }
+  ],
+  "patronComments": [
+    {
+      "type": 0,
+      "value": "读者备注"
+    }
+  ],
+  "permission.all": [
+    {
+      "type": 0,
+      "value": "请求：所有权限"
+    }
+  ],
+  "permission.create": [
+    {
+      "type": 0,
+      "value": "请求：查看、创建"
+    }
+  ],
+  "permission.edit": [
+    {
+      "type": 0,
+      "value": "请求：查看、编辑、取消"
+    }
+  ],
+  "permission.moveRequest": [
+    {
+      "type": 0,
+      "value": "请求：移至新单件，重新排序队列"
+    }
+  ],
+  "permission.reorderQueue": [
+    {
+      "type": 0,
+      "value": "请求：重新排序队列"
+    }
+  ],
+  "permission.view": [
+    {
+      "type": 0,
+      "value": "请求：查看"
+    }
+  ],
+  "pickSlipsLoading": [
+    {
+      "type": 0,
+      "value": "选取单正在加载，请稍候"
+    }
+  ],
+  "pickupServicePoint.name": [
+    {
+      "type": 0,
+      "value": "取書工作區"
+    }
+  ],
+  "position": [
+    {
+      "type": 0,
+      "value": "队列中的位置"
+    }
+  ],
+  "printInProgress": [
+    {
+      "type": 0,
+      "value": "正在加载打印选项。可能需要几秒钟，请耐心等待。"
+    }
+  ],
+  "printPickSlips": [
+    {
+      "type": 0,
+      "value": "打印"
+    },
+    {
+      "type": 1,
+      "value": "sp"
+    },
+    {
+      "type": 0,
+      "value": "选取单"
+    }
+  ],
+  "proxy.barcode": [
+    {
+      "type": 0,
+      "value": "请求者的代理条码"
+    }
+  ],
+  "proxy.name": [
+    {
+      "type": 0,
+      "value": "请求者的代理名称"
+    }
+  ],
+  "requestDate": [
+    {
+      "type": 0,
+      "value": "requestDate"
+    }
+  ],
+  "requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "預約到期日"
+    }
+  ],
+  "requestLevel": [
+    {
+      "type": 0,
+      "value": "Request level"
+    }
+  ],
+  "requestMeta.detailLabel": [
+    {
+      "type": 0,
+      "value": "預約詳細資料"
+    }
+  ],
+  "requestMeta.expirationDate": [
+    {
+      "type": 0,
+      "value": "預約到期日"
+    }
+  ],
+  "requestMeta.fulfilment.delivery": [
+    {
+      "type": 0,
+      "value": "送货"
+    }
+  ],
+  "requestMeta.fulfilment.holdShelf": [
+    {
+      "type": 0,
+      "value": "預約書架"
+    }
+  ],
+  "requestMeta.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "保留在架到期日"
+    }
+  ],
+  "requestMeta.information": [
+    {
+      "type": 0,
+      "value": "預約資料"
+    }
+  ],
+  "requestMeta.queuePosition": [
+    {
+      "type": 0,
+      "value": "排隊順序"
+    }
+  ],
+  "requestMeta.status": [
+    {
+      "type": 0,
+      "value": "預約狀態"
+    }
+  ],
+  "requestMeta.tags": [
+    {
+      "type": 0,
+      "value": "标签"
+    }
+  ],
+  "requestMeta.type": [
+    {
+      "type": 0,
+      "value": "預約類型"
+    }
+  ],
+  "requestMeta.type.hold": [
+    {
+      "type": 0,
+      "value": "預約"
+    }
+  ],
+  "requestMeta.type.holds": [
+    {
+      "type": 0,
+      "value": "預約"
+    }
+  ],
+  "requestMeta.type.page": [
+    {
+      "type": 0,
+      "value": "处理"
+    }
+  ],
+  "requestMeta.type.pages": [
+    {
+      "type": 0,
+      "value": "处理"
+    }
+  ],
+  "requestMeta.type.recall": [
+    {
+      "type": 0,
+      "value": "催還"
+    }
+  ],
+  "requestMeta.type.recalls": [
+    {
+      "type": 0,
+      "value": "催還"
+    }
+  ],
+  "requestNotAllowed": [
+    {
+      "type": 0,
+      "value": "預約不被允許"
+    }
+  ],
+  "requestQueue": [
+    {
+      "type": 0,
+      "value": "預約排隊順序"
+    }
+  ],
+  "requestQueue.chronology": [
+    {
+      "type": 0,
+      "value": "Chronology"
+    }
+  ],
+  "requestQueue.confirmReorder.cancel": [
+    {
+      "type": 0,
+      "value": "留在当前位置"
+    }
+  ],
+  "requestQueue.confirmReorder.confirm": [
+    {
+      "type": 0,
+      "value": "移至位置2"
+    }
+  ],
+  "requestQueue.confirmReorder.message1": [
+    {
+      "type": 0,
+      "value": "开始执行后，无法将请求从位置1移开。"
+    }
+  ],
+  "requestQueue.confirmReorder.message2": [
+    {
+      "type": 0,
+      "value": "即使尚未开始执行，也无法将请求移到处理请求之前。"
+    }
+  ],
+  "requestQueue.confirmReorder.title": [
+    {
+      "type": 0,
+      "value": "请求已移至队列的第2位"
+    }
+  ],
+  "requestQueue.deliveryType": [
+    {
+      "type": 0,
+      "value": "交付： "
+    },
+    {
+      "type": 1,
+      "value": "type"
+    }
+  ],
+  "requestQueue.description": [
+    {
+      "type": 0,
+      "value": "Instance: "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "title"
+        },
+        {
+          "type": 0,
+          "value": " /"
+        },
+        {
+          "type": 1,
+          "value": "author"
+        },
+        {
+          "type": 0,
+          "value": "."
+        }
+      ],
+      "type": 8,
+      "value": "instanceLink"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "publisher"
+        },
+        {
+          "type": 0,
+          "value": ", "
+        },
+        {
+          "type": 1,
+          "value": "publicationDate"
+        }
+      ],
+      "type": 8,
+      "value": "i"
+    }
+  ],
+  "requestQueue.enumeration": [
+    {
+      "type": 0,
+      "value": "Enumeration"
+    }
+  ],
+  "requestQueue.fulfillmentInProgressSectionTitle": [
+    {
+      "type": 0,
+      "value": "Fulfillment in progress"
+    }
+  ],
+  "requestQueue.fulfillmentStatus": [
+    {
+      "type": 0,
+      "value": "Status"
+    }
+  ],
+  "requestQueue.heading": [
+    {
+      "type": 0,
+      "value": "Request queue on instance • "
+    },
+    {
+      "type": 1,
+      "value": "title"
+    },
+    {
+      "type": 0,
+      "value": " /"
+    },
+    {
+      "type": 1,
+      "value": "author"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
+  "requestQueue.holdShelfExpirationDate": [
+    {
+      "type": 0,
+      "value": "預約書架到期"
+    }
+  ],
+  "requestQueue.itemBarcode": [
+    {
+      "type": 0,
+      "value": "Item barcode"
+    }
+  ],
+  "requestQueue.noDataForFulfillment": [
+    {
+      "type": 0,
+      "value": "There are no requests in fulfillment."
+    }
+  ],
+  "requestQueue.notYetFilledRequests.noData": [
+    {
+      "type": 0,
+      "value": "No requests found"
+    }
+  ],
+  "requestQueue.notYetFilledSectionTitle": [
+    {
+      "type": 0,
+      "value": "Open - Not yet filled"
+    }
+  ],
+  "requestQueue.order": [
+    {
+      "type": 0,
+      "value": "Order"
+    }
+  ],
+  "requestQueue.patronComments": [
+    {
+      "type": 0,
+      "value": "Patron comments"
+    }
+  ],
+  "requestQueue.patronGroup": [
+    {
+      "type": 0,
+      "value": "讀者群組"
+    }
+  ],
+  "requestQueue.pickup": [
+    {
+      "type": 0,
+      "value": "取件/交付"
+    }
+  ],
+  "requestQueue.refresh": [
+    {
+      "type": 0,
+      "value": "Refresh queue"
+    }
+  ],
+  "requestQueue.reorderSuccess": [
+    {
+      "type": 0,
+      "value": "队列更新成功"
+    }
+  ],
+  "requestQueue.requestDate": [
+    {
+      "type": 0,
+      "value": "请求日期"
+    }
+  ],
+  "requestQueue.requestExpirationDate": [
+    {
+      "type": 0,
+      "value": "请求过期"
+    }
+  ],
+  "requestQueue.requestInProgress": [
+    {
+      "type": 0,
+      "value": "In progress"
+    }
+  ],
+  "requestQueue.requestType": [
+    {
+      "type": 0,
+      "value": "类型"
+    }
+  ],
+  "requestQueue.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "请求者条码"
+    }
+  ],
+  "requestQueue.requesterName": [
+    {
+      "type": 0,
+      "value": "请求者"
+    }
+  ],
+  "requestQueue.status": [
+    {
+      "type": 0,
+      "value": "Request status"
+    }
+  ],
+  "requestQueue.volume": [
+    {
+      "type": 0,
+      "value": "Volume"
+    }
+  ],
+  "requestType": [
+    {
+      "type": 0,
+      "value": "預約類型"
+    }
+  ],
+  "requestType.message": [
+    {
+      "type": 0,
+      "value": "选择单件以查看可用的请求类型"
+    }
+  ],
+  "requester.barcode": [
+    {
+      "type": 0,
+      "value": "預約者條碼"
+    }
+  ],
+  "requester.findUserPluginLabel": [
+    {
+      "type": 0,
+      "value": "查詢預約者"
+    }
+  ],
+  "requester.firstName": [
+    {
+      "type": 0,
+      "value": "預約者名字"
+    }
+  ],
+  "requester.fulfilmentPref": [
+    {
+      "type": 0,
+      "value": "取件偏好設定"
+    }
+  ],
+  "requester.information": [
+    {
+      "type": 0,
+      "value": "預約者詳細資訊"
+    }
+  ],
+  "requester.name": [
+    {
+      "type": 0,
+      "value": "預約者名稱"
+    }
+  ],
+  "requester.patronGroup.group": [
+    {
+      "type": 0,
+      "value": "預約者讀者群組"
+    }
+  ],
+  "requester.pickupLocation": [
+    {
+      "type": 0,
+      "value": "取書館藏地"
+    }
+  ],
+  "requester.proxy": [
+    {
+      "type": 0,
+      "value": "預約者的代理人"
+    }
+  ],
+  "requester.requester": [
+    {
+      "type": 0,
+      "value": "預約者"
+    }
+  ],
+  "requester.scanOrEnterBarcode": [
+    {
+      "type": 0,
+      "value": "掃描或輸入預約者條碼"
+    }
+  ],
+  "requester.username": [
+    {
+      "type": 0,
+      "value": "使用者名稱"
+    }
+  ],
+  "requests.createTitleLevelRequest": [
+    {
+      "type": 0,
+      "value": "Create title level request"
+    }
+  ],
+  "requests.itemBarcode": [
+    {
+      "type": 0,
+      "value": "單件條碼"
+    }
+  ],
+  "requests.proxy": [
+    {
+      "type": 0,
+      "value": "代理"
+    }
+  ],
+  "requests.queuePosition": [
+    {
+      "type": 0,
+      "value": "Queue position"
+    }
+  ],
+  "requests.requestDate": [
+    {
+      "type": 0,
+      "value": "預約日期"
+    }
+  ],
+  "requests.requester": [
+    {
+      "type": 0,
+      "value": "預約者"
+    }
+  ],
+  "requests.requesterBarcode": [
+    {
+      "type": 0,
+      "value": "預約者條碼"
+    }
+  ],
+  "requests.status": [
+    {
+      "type": 0,
+      "value": "預約狀態"
+    }
+  ],
+  "requests.title": [
+    {
+      "type": 0,
+      "value": "題名"
+    }
+  ],
+  "requests.type": [
+    {
+      "type": 0,
+      "value": "類型"
+    }
+  ],
+  "requests.year": [
+    {
+      "type": 0,
+      "value": "Year"
+    }
+  ],
+  "resultCount": [
+    {
+      "type": 0,
+      "value": "找到 "
+    },
+    {
+      "style": null,
+      "type": 2,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "筆紀錄"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 0,
+              "value": "筆紀錄"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    }
+  ],
+  "routingError": [
+    {
+      "type": 0,
+      "value": "你是怎么到"
+    },
+    {
+      "type": 1,
+      "value": "pathname"
+    },
+    {
+      "type": 0,
+      "value": " 的？"
+    }
+  ],
+  "routingErrorOops": [
+    {
+      "type": 0,
+      "value": "哦哦！"
+    }
+  ],
+  "showTags": [
+    {
+      "type": 0,
+      "value": "顯示標籤"
+    }
+  ],
+  "status": [
+    {
+      "type": 0,
+      "value": "預約狀態"
+    }
+  ],
+  "tags.tagList": [
+    {
+      "type": 0,
+      "value": "標籤"
+    }
+  ],
+  "title.information": [
+    {
+      "type": 0,
+      "value": "Title information"
+    }
+  ],
+  "titleInformation.contributors": [
+    {
+      "type": 0,
+      "value": "Contributor"
+    }
+  ],
+  "titleInformation.editions": [
+    {
+      "type": 0,
+      "value": "Edition"
+    }
+  ],
+  "titleInformation.identifiers": [
+    {
+      "type": 0,
+      "value": "ISBN(s)"
+    }
+  ],
+  "titleInformation.publicationsDate": [
+    {
+      "type": 0,
+      "value": "Publication date"
+    }
+  ],
+  "titleInformation.title": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ],
+  "titleInformation.titleLevelRequests": [
+    {
+      "type": 0,
+      "value": "Title level requests"
+    }
+  ],
+  "titleLevel": [
+    {
+      "type": 0,
+      "value": "Title"
+    }
+  ]
+}

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -4,6 +4,7 @@
 
   "items": "{number} items",
   "meta.title": "Requests",
+  "appMenu.keyboardShortcuts": "Keyboard shortcuts",
   "resultCount": "{count, number} {count, plural, one {Record found} other {Records found}}",
   "barcode": "Barcode",
   "requestQueue": "Request queue",


### PR DESCRIPTION
UIREQ-588:

## Purpose
Each FOLIO app should support these baseline shortcut keys (when applicable).

Added support shortcuts include, a.) create, b.) edit, c.) duplicate, and save a request. 
As well as collapse, expand accordions, and open Accordions Modal.

## Approach
Used Commander components from stripes.

## Refs
[UIREQ-588](https://issues.folio.org/browse/UIREQ-588)
