### PR TITLE
UIREQ-745: restore skipped tests

### DIFF
--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -41,7 +41,7 @@ jest.mock('./ItemDetail', () => jest.fn(() => null));
 jest.mock('./ItemsDialog', () => jest.fn(() => null));
 jest.mock('./PositionLink', () => jest.fn(() => null));
 
-describe.skip('RequestForm', () => {
+describe('RequestForm', () => {
   const testIds = {
     tlrCheckbox: 'tlrCheckbox',
     instanceInfoSection: 'instanceInfoSection',

--- a/src/ViewRequest.test.js
+++ b/src/ViewRequest.test.js
@@ -130,7 +130,7 @@ describe('ViewRequest', () => {
           ...mockedRequest,
         },
       };
-      screen.debug();
+
       expect(RequestForm).toHaveBeenCalledWith(expect.objectContaining(expectedResult), {});
     });
   });

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -50,7 +50,7 @@ SearchAndSort.mockImplementation(jest.fn(({
 jest.mock('../ViewRequest', () => jest.fn());
 jest.mock('../RequestForm', () => jest.fn());
 
-describe.skip('RequestsRoute', () => {
+describe('RequestsRoute', () => {
   const mockedUpdateFunc = jest.fn();
   const mockedRequest = {
     requestLevel: REQUEST_LEVEL_TYPES.ITEM,

--- a/test/bigtest/network/factories/request.js
+++ b/test/bigtest/network/factories/request.js
@@ -41,8 +41,6 @@ export default Factory.extend({
       itemId: item.id,
       requesterId: user.id,
       requester: {
-        lastName: user.personal.lastName,
-        firstName: user.personal.firstName,
         barcode: user.barcode,
         patronGroup: {
           id: user.patronGroup,
@@ -50,6 +48,10 @@ export default Factory.extend({
           desc: 'test',
         },
         patronGroupId: user.patronGroup,
+        personal: {
+          lastName: user.personal.lastName,
+          firstName: user.personal.firstName,
+        },
       },
       metadata: {
         createdDate: '2020-07-07T03:56:29.238+0000',
@@ -82,13 +84,15 @@ export default Factory.extend({
         itemId: item.id,
         requesterId: user.id,
         requester: {
-          lastName: user.personal.lastName,
-          firstName: user.personal.firstName,
           barcode: user.barcode,
           patronGroup: {
             id: user.patronGroup,
             group: 'test',
             desc: 'test',
+          },
+          personal: {
+            lastName: user.personal.lastName,
+            firstName: user.personal.firstName,
           },
           patronGroupId: user.patronGroup,
         },

--- a/test/bigtest/tests/edit-request-test.js
+++ b/test/bigtest/tests/edit-request-test.js
@@ -55,7 +55,7 @@ describe('Edit Request page', () => {
     });
   });
 
-  xdescribe('updating existing request', function () {
+  describe('updating existing request', function () {
     beforeEach(async function () {
       await EditRequestInteractor.chooseServicePoint('Circ Desk 2');
       await EditRequestInteractor.clickUpdate();


### PR DESCRIPTION
## Purpose
Previously we skipped few Jest/RTL test suits, and also one bigtest. This PR aimed to resolve issues with tests.

## Approach
Looks like problems with Jest/RTL was temporary and now they are not reproducible. As for bigtest: I just moved `personal` user data to the correct place in the mocks, the same where it locate in real responces.

I am not sure should we add something to changelog in this PR.

## Refs
https://issues.folio.org/browse/UIREQ-745