### PR TITLE
UIREQ-754: fix request details `# items` to show correct number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add success toast to Requests. Refs UIREQ-722.
 * Add success toast to duplicated Requests. Refs UIREQ-747.
 * Change queue position message from "items" to "requests". Refs UIREQ-755.
+* Request details `# items` showing incorrect number. Refs UIREQ-754.
 
 ## [7.0.0](https://github.com/folio-org/ui-requests/tree/v7.0.0) (2022-02-25)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v6.0.2...v7.0.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -240,3 +240,5 @@ export const REQUEST_TYPES = {
 export const MISSING_VALUE_SYMBOL = '-';
 
 export const DEFAULT_DISPLAYED_YEARS_AMOUNT = 3;
+
+export const MAX_RECORDS = '10000';

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -44,6 +44,7 @@ import {
   REQUEST_LEVEL_TYPES,
   DEFAULT_DISPLAYED_YEARS_AMOUNT,
   requestStatuses,
+  MAX_RECORDS,
 } from '../constants';
 import {
   buildUrl,
@@ -98,11 +99,18 @@ const urls = {
     return `circulation/loans?${query}`;
   },
   requestsForItem: (value) => {
-    const query = stringify({ query: `(itemId=="${value}" and status=Open)` });
+    const query = stringify({
+      query: `(itemId=="${value}" and status=Open)`,
+      limit: MAX_RECORDS,
+    });
+
     return `circulation/requests?${query}`;
   },
   requestsForInstance: (value) => {
-    const query = stringify({ query: `(instanceId=="${value}" and status=Open)` });
+    const query = stringify({
+      query: `(instanceId=="${value}" and status=Open)`,
+      limit: MAX_RECORDS,
+    });
 
     return `circulation/requests?${query}`;
   },


### PR DESCRIPTION
## Purpose
There was mismatching between number of requests on `request detail` page and reorderable accordion on the `reorder queue` page.

## Approach
Again we can see here the problem with query limits witch is `10` by default. 

## Refs
https://issues.folio.org/browse/UIREQ-754