### PR TITLE
UIREQ-751: fix the issue when pickup location was not preserved on request duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add success toast to Requests. Refs UIREQ-722.
 * Add success toast to duplicated Requests. Refs UIREQ-747.
 * Change queue position message from "items" to "requests". Refs UIREQ-755.
+* When duplicating a request, the pickup location is not preserved. Refs UIREQ-751.
 
 ## [7.0.0](https://github.com/folio-org/ui-requests/tree/v7.0.0) (2022-02-25)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v6.0.2...v7.0.0)

--- a/src/utils.js
+++ b/src/utils.js
@@ -120,7 +120,6 @@ export function duplicateRequest(request) {
     'proxyUserId',
     'requestCount',
     'requester',
-    'requesterId',
     'status',
   ]);
 }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -108,7 +108,6 @@ describe('duplicateRequest', () => {
       'proxyUserId',
       'requestCount',
       'requester',
-      'requesterId',
       'status',
     ];
 


### PR DESCRIPTION
## Purpose
When duplicating a request, the pickup location is not preserved

## Approach
According to code in the `duplicateRequest` function, we omit `requesterId` field, and than in `RequestForm.js` we trying to compare it and it's equal to `undefined`:
`
if (requesterId !== selectedUser?.id || this.props?.query?.mode !== createModes.DUPLICATE) {
        change('pickupServicePointId', defaultServicePointId);
}
`

## Refs
https://issues.folio.org/browse/UIREQ-751