### PR TITLE
UIREQ-757: changes requests filter logic to  shows correct number in `# requests`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add success toast to duplicated Requests. Refs UIREQ-747.
 * Change queue position message from "items" to "requests". Refs UIREQ-755.
 * Fix defect with first name of success toast to Requests. Refs UIREQ-753.
+* Ensure Request details # (# requests) shows correct data. Refs UIREQ-757.
 
 ## [7.0.1](https://github.com/folio-org/ui-requests/tree/v7.0.1) (2022-03-31)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.0...v7.0.1)

--- a/src/PositionLink.js
+++ b/src/PositionLink.js
@@ -26,7 +26,7 @@ export default function PositionLink({
     ? (
       <div>
         <span>
-          {`${queuePosition} (${formatMessage({ id: 'ui-requests.requests' }, { number: request.numberOfNotYetFilledRequests })})`}
+          {`${queuePosition} (${formatMessage({ id: 'ui-requests.requests' }, { number: request.numberOfReorderableRequests })})`}
           &nbsp;
         </span>
         <Link to={openRequestsPath}>

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -1003,7 +1003,7 @@ class RequestForm extends React.Component {
     unset(requestData, 'itemRequestCount');
     unset(requestData, 'titleRequestCount');
     unset(requestData, 'createTitleLevelRequest');
-    unset(requestData, 'numberOfNotYetFilledRequests');
+    unset(requestData, 'numberOfReorderableRequests');
     unset(requestData, RESOURCE_TYPES.INSTANCE);
 
     return this.props.onSubmit(requestData);

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -216,7 +216,7 @@ class ViewRequest extends React.Component {
     delete updatedRecord.itemStatus;
     delete updatedRecord.titleRequestCount;
     delete updatedRecord.itemRequestCount;
-    delete updatedRecord.numberOfNotYetFilledRequests;
+    delete updatedRecord.numberOfReorderableRequests;
     delete updatedRecord.holdShelfExpirationTime;
 
     this.props.mutator.selectedRequest.PUT(updatedRecord).then(() => {

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -43,7 +43,6 @@ import {
   requestTypesTranslations,
   REQUEST_LEVEL_TYPES,
   DEFAULT_DISPLAYED_YEARS_AMOUNT,
-  requestStatuses,
   MAX_RECORDS,
 } from '../constants';
 import {
@@ -68,7 +67,10 @@ import {
   RequestsFilters,
   RequestsFiltersConfig,
 } from '../components/RequestsFilters';
-import { getFormattedYears } from './utils';
+import {
+  getFormattedYears,
+  isReorderableRequest,
+} from './utils';
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
@@ -652,9 +654,9 @@ class RequestsRoute extends React.Component {
       const requester = get(users, 'users[0]', null);
       const titleRequestCount = get(titleRequests, 'totalRecords', 0);
       const dynamicProperties = {};
-      const requestsForFilter = titleLevelRequestsFeatureEnabled ? titleRequests : itemRequests;
+      const requestsForFilter = titleLevelRequestsFeatureEnabled ? titleRequests.requests : itemRequests.requests;
 
-      dynamicProperties.numberOfNotYetFilledRequests = requestsForFilter.requests.filter(currentRequest => currentRequest.status === requestStatuses.NOT_YET_FILLED).length;
+      dynamicProperties.numberOfReorderableRequests = requestsForFilter.filter(currentRequest => isReorderableRequest(currentRequest)).length;
 
       if (itemId) {
         dynamicProperties.itemRequestCount = get(itemRequests, 'totalRecords', 0);

--- a/src/routes/utils.js
+++ b/src/routes/utils.js
@@ -32,9 +32,5 @@ export const getFormattedContributors = (contributors) => (
 );
 
 export const isReorderableRequest = request => {
-  if (request.status === requestStatuses.NOT_YET_FILLED && request.requestType !== requestTypesMap.PAGE) {
-    return true;
-  }
-
-  return false;
+  return request.status === requestStatuses.NOT_YET_FILLED && request.requestType !== requestTypesMap.PAGE;
 };

--- a/src/routes/utils.js
+++ b/src/routes/utils.js
@@ -1,3 +1,8 @@
+import {
+  requestStatuses,
+  requestTypesMap,
+} from '../constants';
+
 const YEAR_SEPARATOR = ', ';
 const YEAR_REGEX = /^([1-9][0-9]{0,3})$/;
 
@@ -25,3 +30,11 @@ export const getFormattedPublishers = (publications) => (
 export const getFormattedContributors = (contributors) => (
   contributors?.find(({ name }) => !!name)?.name ?? ''
 );
+
+export const isReorderableRequest = request => {
+  if (request.status === requestStatuses.NOT_YET_FILLED && request.requestType !== requestTypesMap.PAGE) {
+    return true;
+  }
+
+  return false;
+};

--- a/src/routes/utils.test.js
+++ b/src/routes/utils.test.js
@@ -1,7 +1,12 @@
 import {
+  requestStatuses,
+  requestTypesMap,
+} from '../constants';
+import {
   getFormattedYears,
   getFormattedPublishers,
   getFormattedContributors,
+  isReorderableRequest,
 } from './utils';
 
 describe('utils', () => {
@@ -102,6 +107,35 @@ describe('utils', () => {
       }, {
         name: 'Alina',
       }])).toBe('Pavel');
+    });
+  });
+
+  describe('isReorderableRequest', () => {
+    it('should return false if requestType is "Page"', () => {
+      const request = {
+        requestType: requestTypesMap.PAGE,
+        status: requestStatuses.NOT_YET_FILLED,
+      };
+
+      expect(isReorderableRequest(request)).toBe(false);
+    });
+
+    it('should return false if status is not "Open - Not yet filled"', () => {
+      const request = {
+        requestType: requestTypesMap.HOLD,
+        status: requestStatuses.AWAITING_PICKUP,
+      };
+
+      expect(isReorderableRequest(request)).toBe(false);
+    });
+
+    it('should return true if requestType is not "Page" and status is "Open - Not yet filled"', () => {
+      const request = {
+        requestType: requestTypesMap.HOLD,
+        status: requestStatuses.NOT_YET_FILLED,
+      };
+
+      expect(isReorderableRequest(request)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Purpose
Ensure Request details # (# requests) shows correct data.

## Approach
After changes that was made in [UIREQ-728](https://issues.folio.org/browse/UIREQ-728) all `Page` requests situated in non-reorderable accordion. As discussed with PO, our `# reuqests` should represent number of reorderable requests.
I added coresponding filter and also renamed `numberOfNotYetFilledRequests` to `numberOfReorderableRequests` because it's no more match with what exact this number mean.

## Refs
https://issues.folio.org/browse/UIREQ-757