### PR TITLE
UIREQ-760: fix modal appearing for `Restricted` item status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Change queue position message from "items" to "requests". Refs UIREQ-755.
 * Fix defect with first name of success toast to Requests. Refs UIREQ-753.
 * Ensure Request details # (# requests) shows correct data. Refs UIREQ-757.
+* Fix modal appearing for `Restricted` item status. Refs UIREQ-760.
 
 ## [7.0.1](https://github.com/folio-org/ui-requests/tree/v7.0.1) (2022-03-31)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.0...v7.0.1)

--- a/src/constants.js
+++ b/src/constants.js
@@ -83,6 +83,7 @@ export const itemStatuses = {
   UNAVAILABLE: 'Unavailable',
   UNKNOWN: 'Unknown',
   WITHDRAWN: 'Withdrawn',
+  RESTRICTED: 'Restricted',
 };
 
 export const requestTypesMap = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -151,6 +151,7 @@ export function hasNonRequestableStatus(item) {
     itemStatuses.UNAVAILABLE,
     itemStatuses.UNKNOWN,
     itemStatuses.WITHDRAWN,
+    itemStatuses.RESTRICTED,
   ], item?.status?.name);
 }
 

--- a/test/bigtest/tests/new-request-test.js
+++ b/test/bigtest/tests/new-request-test.js
@@ -29,6 +29,7 @@ const nonRequestableItemStatuses = [
   'Unavailable',
   'Unknown',
   'Withdrawn',
+  'Restricted',
 ];
 
 const patronComment = 'I really need this in the next three days';
@@ -179,7 +180,7 @@ describe('New Request page', () => {
       });
     });
 
-    describe('creating new request for item with status "Restricted"', () => {
+    describe('creating new request for item with status "Available"', () => {
       beforeEach(async function () {
         this.server.create('item', {
           barcode: '9676761472500',
@@ -187,7 +188,7 @@ describe('New Request page', () => {
           materialType: {
             name: 'book',
           },
-          status: { name: 'Restricted' },
+          status: { name: 'Available' },
         });
 
         const user = this.server.create('user', { barcode: '9676761472501' });


### PR DESCRIPTION
## Purpose
We should show "Request not allowed" modal when creating a request for an item in "Restricted" status.

## Approach
`hasNonRequestableStatus` didn't contain corresponding status.

## Refs
https://issues.folio.org/browse/UIREQ-760