### PR TITLE
UIREQ-750 sort queue position numerically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Ensure Request details # (# requests) shows correct data. Refs UIREQ-757.
 * Notes Accordion is Not Closed After Deleting a Note. Refs UIREQ-759.
 * Implement baseline shortcut keys. Refs UIREQ-588.
+* Sort queue-position numerically. Refs UIREQ-750.
 
 ## [7.0.2](https://github.com/folio-org/ui-requests/tree/v7.0.2) (2022-04-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.1...v7.0.2)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -179,7 +179,7 @@ class RequestsRoute extends React.Component {
               'requestStatus': 'status',
               'requesterBarcode': 'requester.barcode',
               'requestDate': 'requestDate',
-              'position': 'position',
+              'position': 'position/number',
               'proxy': 'proxy',
             },
             RequestsFiltersConfig,


### PR DESCRIPTION
The `position` field is numeric, so that needs to be configured in the
`sortMap` argument passed to `makeQueryParam`.

Refs [UIREQ-750](https://issues.folio.org/browse/UIREQ-750)
