### PR TITLE
UIREQ-767: add `move` action for title-level requests with attached item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix the issue when user can't select request type when item have status 'Restricted'. Refs UIREQ-772.
 * Sort queue-position numerically. Refs UIREQ-750.
 * Remove react-hot-loader. Refs UIREQ-758.
+* Add Move request to Action list when item is attached to title level request for fulfillment. Refs UIREQ-767.
 
 ## [7.0.2](https://github.com/folio-org/ui-requests/tree/v7.0.2) (2022-04-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.1...v7.0.2)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -37,7 +37,7 @@ const ItemDetail = ({
   const title = request?.instance.title || item.title || <NoValue />;
   const contributor = request?.instance.contributorNames?.[0]?.name || item.contributorNames?.[0]?.name || <NoValue />;
   const count = request?.itemRequestCount || requestCount || DEFAULT_COUNT_VALUE;
-  const status = item.status.name || item.status || <NoValue />;
+  const status = item.status?.name || item.status || <NoValue />;
   const effectiveLocationName = item.effectiveLocation?.name || item.location?.name || <NoValue />;
   const dueDate = loan?.dueDate ? <FormattedDate value={loan.dueDate} /> : <NoValue />;
 

--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -14,7 +14,7 @@ import {
   Checkbox,
   TextField,
   CommandList,
-  defaultKeyboardShortcuts
+  defaultKeyboardShortcuts,
 } from '@folio/stripes/components';
 
 import RequestForm from './RequestForm';
@@ -78,7 +78,7 @@ describe('RequestForm', () => {
       change: mockedChangeFunction,
       handleSubmit: jest.fn(),
       asyncValidate: jest.fn(),
-      findResource: jest.fn(() => new Promise((resolve) => resolve({}))),
+      findResource: jest.fn(() => new Promise((resolve) => resolve())),
       request: mockedRequest || {},
       initialValues: {},
       location: {

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -514,7 +514,7 @@ class ViewRequest extends React.Component {
               </Icon>
             </Button>
           </IfPermission>
-          {requestLevel === REQUEST_LEVEL_TYPES.ITEM && isRequestNotFilled &&
+          {item && isRequestNotFilled &&
             <IfPermission perm="ui-requests.moveRequest">
               <Button
                 id="move-request"

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -72,6 +72,10 @@ describe('RequestsRoute', () => {
       currentServicePoint: {
         update: jest.fn(),
       },
+      expiredHolds: {
+        GET: jest.fn(() => ({})),
+        reset: jest.fn(),
+      },
       proxy: {
         reset: jest.fn(),
         GET: jest.fn(),


### PR DESCRIPTION
## Purpose
Add Move request to Action list when item is attached to title level request for fulfillment.

## Approach
Instead of request level, we should check item presence and then show or hide `move` button.
Fixed jest tests because they didn't run locally.

## Refs
https://issues.folio.org/browse/UIREQ-767