### PR TITLE
UIREQ-785: Fix "Timeout of 2000ms exceeded. For async tests and hooks…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix HTTP request duplication when making request. Refs UIREQ-779.
 * Disable request detail action menu when hardcoded UID is present. Refs UIREQ-783.
 * Disable item and instance links in request detail when hardcoded UID is present. Refs UIREQ-784.
+* Fix "Timeout of 2000ms exceeded. For async tests and hooks, ensure “done()” is called" big tests errors. Refs UIREQ-785.
  
 ## [7.0.2](https://github.com/folio-org/ui-requests/tree/v7.0.2) (2022-04-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.1...v7.0.2)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,2 +1,13 @@
+const { DEFAULT_TIMEOUT } = require('./test/bigtest/constants');
+
 /** @param {import('karma').Config} config */
-module.exports = config => config.set({ client: { captureConsole: false } });
+module.exports = config => {
+  config.set({
+    client: {
+      captureConsole: false,
+      mocha: {
+        timeout : DEFAULT_TIMEOUT,
+      },
+    },
+  });
+};

--- a/test/bigtest/constants.js
+++ b/test/bigtest/constants.js
@@ -1,0 +1,3 @@
+const DEFAULT_TIMEOUT = 10000;
+
+module.exports = { DEFAULT_TIMEOUT };

--- a/test/bigtest/tests/all-requests-test.js
+++ b/test/bigtest/tests/all-requests-test.js
@@ -13,8 +13,6 @@ const servicePoint = {
 };
 
 describe('Requests', function () {
-  this.timeout(5000);
-
   setupApplication({
     currentUser: {
       servicePoints: [servicePoint],


### PR DESCRIPTION
## Purpose
Fix "Timeout of 2000ms exceeded. For async tests and hooks, ensure “done()” is called" big tests errors

## Refs
https://issues.folio.org/browse/UIREQ-785