### PR TITLE
UIREQ-784: disable item and instance links in request detail when hardcoded UUID is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Update NodeJS to v16 in GitHub Actions. Refs UIREQ-780.
 * Fix HTTP request duplication when making request. Refs UIREQ-779.
 * Disable request detail action menu when hardcoded UID is present. Refs UIREQ-783.
+* Disable item and instance links in request detail when hardcoded UID is present. Refs UIREQ-784.
  
 ## [7.0.2](https://github.com/folio-org/ui-requests/tree/v7.0.2) (2022-04-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.1...v7.0.2)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -15,7 +15,10 @@ import {
   ClipCopy,
 } from '@folio/stripes/smart-components';
 
-import { openRequestStatusFilters } from './utils';
+import {
+  isValidRequest,
+  openRequestStatusFilters,
+} from './utils';
 import { itemStatusesTranslations } from './constants';
 
 const DEFAULT_COUNT_VALUE = 0;
@@ -44,7 +47,6 @@ const ItemDetail = ({
   const dueDate = loan?.dueDate ? <FormattedDate value={loan.dueDate} /> : <NoValue />;
 
   const effectiveCallNumberString = effectiveCallNumber(item);
-  const recordLink = itemId ? <Link to={`/inventory/view/${instanceId}/${holdingsRecordId}/${itemId}`}>{item.barcode || itemId}</Link> : <NoValue />;
   const positionLink = count
     ? (
       <Link to={`/requests?filters=${openRequestStatusFilters}&query=${itemId}&sort=Request Date`}>
@@ -53,13 +55,26 @@ const ItemDetail = ({
     )
     : count;
   const itemLabel = item.barcode ? 'ui-requests.item.barcode' : 'ui-requests.item.id';
+  const isRequestValid = isValidRequest({ instanceId, holdingsRecordId });
+  const recordLink = () => {
+    if (itemId) {
+      return isRequestValid
+        ? <Link to={`/inventory/view/${instanceId}/${holdingsRecordId}/${itemId}`}>{item.barcode || itemId}</Link>
+        : (item.barcode || itemId);
+    }
+
+    return <NoValue />;
+  };
 
   return (
     <>
       <Row>
         <Col xs={4}>
-          <KeyValue label={<FormattedMessage id={itemLabel} />}>
-            {recordLink}
+          <KeyValue
+            data-testid="itemBarcodeLink"
+            label={<FormattedMessage id={itemLabel} />}
+          >
+            {recordLink()}
             {
               Boolean(item.barcode) && (
                 <ClipCopy text={item.barcode} />

--- a/src/ItemDetail.test.js
+++ b/src/ItemDetail.test.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+
+import '../test/jest/__mock__';
+
+import ItemDetail from './ItemDetail';
+import { INVALID_REQUEST_HARDCODED_ID } from './constants';
+
+jest.mock('react-router-dom', () => ({
+  Link: jest.fn(({ to, children }) => <a href={to}>{children}</a>),
+}));
+
+describe('ItemDetail', () => {
+  const testIds = {
+    itemBarcodeLink: 'itemBarcodeLink',
+  };
+  const defaultRequest = {
+    itemId: 'testItemId',
+    instance: {
+      title: 'testTitle',
+    },
+  };
+  const item = {
+    barcode: 'testItemBarcode',
+  };
+  const defaultProps = {
+    item,
+  };
+
+  describe('with valid request', () => {
+    const validRequest = {
+      ...defaultRequest,
+      instanceId: 'testInstanceId',
+      holdingsRecordId: 'testHoldingRecordId',
+    };
+
+    beforeEach(() => {
+      render(
+        <ItemDetail
+          {...defaultProps}
+          request={validRequest}
+        />
+      );
+    });
+
+    it('should render "item barcode" as a link', () => {
+      const keyValueWithLink = screen.getByTestId(testIds.itemBarcodeLink);
+      const link = within(keyValueWithLink).getByRole('link');
+
+      expect(within(link).getByText(item.barcode)).toBeInTheDocument();
+    });
+  });
+
+  describe('with invalid request', () => {
+    const invalidRequest = {
+      ...defaultRequest,
+      instanceId: INVALID_REQUEST_HARDCODED_ID,
+      holdingsRecordId: INVALID_REQUEST_HARDCODED_ID,
+    };
+
+    beforeEach(() => {
+      render(
+        <ItemDetail
+          {...defaultProps}
+          request={invalidRequest}
+        />
+      );
+    });
+
+    it('should render "item barcode" without link', () => {
+      const keyValueWithLink = screen.getByTestId(testIds.itemBarcodeLink);
+      const link = within(keyValueWithLink).queryByRole('link');
+
+      expect(link).not.toBeInTheDocument();
+      expect(within(keyValueWithLink).getByText(item.barcode)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/TitleInformation/TitleInformation.js
+++ b/src/components/TitleInformation/TitleInformation.js
@@ -15,7 +15,10 @@ import {
   REQUEST_DATE,
   REQUEST_LEVEL_TYPES,
 } from '../../constants';
-import { openRequestStatusFilters } from '../../utils';
+import {
+  isValidRequest,
+  openRequestStatusFilters,
+} from '../../utils';
 
 export const TEXT_SEPARATOR = ', ';
 export const CONTRIBUTOR_SEPARATOR = '; ';
@@ -41,6 +44,8 @@ const TitleInformation = (props) => {
       formatMessage,
     },
   } = props;
+  const titleLevelRequestsCountValue = titleLevelRequestsLink ? getURL(instanceId, titleLevelRequestsCount) : titleLevelRequestsCount;
+  const titleValue = isValidRequest({ instanceId }) ? getTitleURL(instanceId, title) : title;
 
   return (
     <>
@@ -48,16 +53,13 @@ const TitleInformation = (props) => {
         <Col xs={4}>
           <KeyValue
             label={formatMessage({ id: 'ui-requests.titleInformation.titleLevelRequests' })}
-            value={titleLevelRequestsLink
-              ? getURL(instanceId, titleLevelRequestsCount)
-              : titleLevelRequestsCount
-            }
+            value={titleLevelRequestsCountValue}
           />
         </Col>
         <Col xs={4}>
           <KeyValue
             label={formatMessage({ id: 'ui-requests.titleInformation.title' })}
-            value={getTitleURL(instanceId, title)}
+            value={titleValue}
           />
         </Col>
         <Col xs={4}>

--- a/src/components/TitleInformation/TitleInformation.test.js
+++ b/src/components/TitleInformation/TitleInformation.test.js
@@ -17,6 +17,7 @@ import TitleInformation, {
   getEditions,
   getIdentifiers,
 } from './TitleInformation';
+import { INVALID_REQUEST_HARDCODED_ID } from '../../constants';
 
 KeyValue.mockImplementation(jest.fn(() => null));
 
@@ -167,6 +168,29 @@ describe('TitleInformation', () => {
       expect(KeyValue).toHaveBeenNthCalledWith(
         orderOfKeyValueCall.titleLevelRequests,
         expectedProps,
+        {}
+      );
+    });
+  });
+
+  describe('when request is not valid', () => {
+    beforeEach(() => {
+      render(
+        <TitleInformation
+          {...defaultProps}
+          instanceId={INVALID_REQUEST_HARDCODED_ID}
+        />
+      );
+    });
+
+    it('should render "instanceId" not as a link', () => {
+      const expectedProps = {
+        value: title,
+      };
+
+      expect(KeyValue).toHaveBeenNthCalledWith(
+        orderOfKeyValueCall.title,
+        expect.objectContaining(expectedProps),
         {}
       );
     });

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -90,8 +90,9 @@ jest.mock('@folio/stripes/components', () => ({
     label,
     children,
     value,
+    'data-testid': testId,
   }) => (
-    <div>
+    <div data-testid={testId}>
       <div>
         {label}
       </div>

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/smart-components', () => ({
+  ClipCopy: jest.fn(() => null),
   makeQueryFunction: jest.fn((value) => value),
   CheckboxFilter: jest.fn(() => null),
   NotesSmartAccordion: jest.fn(() => null),


### PR DESCRIPTION
## Purpose
Disable item and instance links in request detail when hardcoded UID is present.

## Approach
This is a continuation of issue described in [this PR](https://github.com/folio-org/ui-requests/pull/928).

## Refs
https://issues.folio.org/browse/UIREQ-784