### PR TITLE
UIREQ-787: filter the items list on `move request` action from items with non-requestable statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
 * Fix "Timeout of 2000ms exceeded. For async tests and hooks, ensure “done()” is called" big tests errors. Refs UIREQ-785.
 * Fix big tests errors related to interactors small default timeout. Refs UIREQ-786.
 * Create/Edit Request: required is not read. Refs UIREQ-775.
- 
+* Filter the items list on "move request" action from items with non-requestable statuses. Refs UIREQ-787.
+
 ## [7.0.2](https://github.com/folio-org/ui-requests/tree/v7.0.2) (2022-04-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.1...v7.0.2)
 

--- a/src/ItemsDialog.js
+++ b/src/ItemsDialog.js
@@ -26,6 +26,7 @@ import { stripesConnect } from '@folio/stripes/core';
 import {
   itemStatuses,
   itemStatusesTranslations,
+  requestableItemStatuses,
 } from './constants';
 import { Loading } from './components';
 
@@ -124,6 +125,11 @@ const ItemsDialog = ({
 
       const holdings = await fetchHoldings();
       let itemsList = await fetchItems(holdings);
+
+      if (skippedItemId) {
+        itemsList = itemsList.filter(item => requestableItemStatuses.includes(item.status?.name));
+      }
+
       const requests = await fetchRequests(itemsList);
       const requestMap = countBy(requests, 'itemId');
 
@@ -163,7 +169,7 @@ const ItemsDialog = ({
       status: {
         ...item.status,
         name: formatMessage({ id: itemStatusesTranslations[item.status.name] }),
-      }
+      },
     }));
   }, [items, skippedItemId, formatMessage]);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -151,6 +151,8 @@ export const requestTypesByItemStatus = {
   [itemStatuses.RESTRICTED]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
 };
 
+export const requestableItemStatuses = Object.keys(requestTypesByItemStatus);
+
 export const reportHeaders = [
   'requestType',
   'status',


### PR DESCRIPTION
## Purpose
Filter the items list on "move request" action from items with non-requestable statuses.

## Approach
When we have `skippedItemId` it means that we in `move request` process, so we should filter our list from items with non-requestable statuses. 

## Refs
https://issues.folio.org/browse/UIREQ-787