### PR TITLE
UIREQ-344: deleting already-deleted request causes ungraceful error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Create/Edit Request: required is not read. Refs UIREQ-775.
 * Filter the items list on "move request" action from items with non-requestable statuses. Refs UIREQ-787.
 * Fix validation issue of item barcode field. Refs UIREQ-694.
+* Deleting already-deleted request causes ungraceful error. Refs UIREQ-344.
 
 ## [7.0.2](https://github.com/folio-org/ui-requests/tree/v7.0.2) (2022-04-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.1...v7.0.2)

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -55,6 +55,7 @@ import {
   REQUEST_LEVEL_TYPES,
   requestTypesTranslations,
   requestStatusesTranslations,
+  errorMessageLabels,
 } from './constants';
 import {
   toUserAddress,
@@ -85,6 +86,7 @@ class ViewRequest extends React.Component {
 
         return refresh || (path && path.match(/link/));
       },
+      throwErrors: false,
     },
   };
 
@@ -251,6 +253,9 @@ class ViewRequest extends React.Component {
       mutator,
       onCloseEdit,
       buildRecordsForHoldsShelfReport,
+      intl: {
+        formatMessage,
+      },
     } = this.props;
 
     // Get the initial request data, mix in the cancellation info, PUT,
@@ -261,11 +266,24 @@ class ViewRequest extends React.Component {
       ...cancellationInfo,
     };
 
-    mutator.selectedRequest.PUT(cancelledRequest).then(() => {
-      this.setState({ isCancellingRequest: false });
-      onCloseEdit();
-      buildRecordsForHoldsShelfReport();
-    });
+
+    mutator.selectedRequest.PUT(cancelledRequest)
+      .catch(resp => {
+        resp.json()
+          .then(res => {
+            res.errors.forEach(error => {
+              this.callout.current.sendCallout({
+                message: errorMessageLabels[error.message] ? formatMessage({ id: errorMessageLabels[error.message] }) : error.message,
+                type: 'error',
+              });
+            });
+          });
+      })
+      .finally(() => {
+        this.setState({ isCancellingRequest: false });
+        onCloseEdit();
+        buildRecordsForHoldsShelfReport();
+      });
   }
 
   onMove = async (request) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -251,6 +251,11 @@ export const createModes = {
 
 export const errorMessages = {
   REORDER_SYNC_ERROR: 'There is inconsistency between provided reordered queue and item queue.',
+  DELETE_REQUEST_ERROR: 'The Request has already been closed',
+};
+
+export const errorMessageLabels = {
+  [errorMessages.DELETE_REQUEST_ERROR]: 'ui-requests.errors.closingAlreadyClosedRequest',
 };
 
 export const errorCodes = {

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -76,6 +76,7 @@
   "errors.sync.requestQueueBody": "This request queue has been updated by another person or process and may be out of synch.",
   "errors.unknown.requestQueueLabel": "Request queue error",
   "errors.unknown.requestQueueBody": "Request queue reorder failed",
+  "errors.closingAlreadyClosedRequest": "Error: The Request has already been closed.",
 
   "actions.label": "Actions",
   "actions.edit": "Edit",


### PR DESCRIPTION
## Note
We already created [tech debt](https://issues.folio.org/browse/UIREQ-789) about localization for errors within request closing.

## Purpose
Improve of error handling on closing already closed request.

## Refs
https://issues.folio.org/browse/UIREQ-344

## Screenshots
before:
![image](https://user-images.githubusercontent.com/88130496/173319763-ff19ec96-219c-4583-8db1-11ecaebad444.png)

after:
![image](https://user-images.githubusercontent.com/88130496/173319948-439a6453-6f95-487f-aad3-e706fc410501.png)