### PR TITLE
UIREQ-694: The message "Item with this barcode does not exist" should appear whenever the user tries to enter a invalid item barcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Disable item and instance links in request detail when hardcoded UID is present. Refs UIREQ-784.
 * Fix "Timeout of 2000ms exceeded. For async tests and hooks, ensure “done()” is called" big tests errors. Refs UIREQ-785.
 * Fix big tests errors related to interactors small default timeout. Refs UIREQ-786.
+* Fix validation of item barcode field. Refs UIREQ-694.
  
 ## [7.0.2](https://github.com/folio-org/ui-requests/tree/v7.0.2) (2022-04-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.1...v7.0.2)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -853,8 +853,10 @@ class RequestForm extends React.Component {
     return undefined;
   }
 
-  requireEnterItem = () => {
-    if (this.state.selectedItem === undefined) {
+  requireEnterItem = (value) => {
+    const values = this.getCurrentFormValues();
+
+    if (!value && !values?.itemId) {
       return <FormattedMessage id="ui-requests.errors.selectItemRequired" />;
     }
 


### PR DESCRIPTION
## Purpose
Fix validation issue of item barcode field

## Refs
[UIREQ-694](https://issues.folio.org/browse/UIREQ-694)

## Screenshots

**BEFORE**
![image](https://user-images.githubusercontent.com/42437614/173573481-49e75c78-c61a-4a6c-8ea2-606a62c95952.png)


**AFTER**
![image](https://user-images.githubusercontent.com/42437614/173573324-e34aca87-82c0-43d1-b4c6-8bef5eb62b9f.png)

