### PR TITLE
UIREQ-794: Сannot add tags to record in the Requests app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Fix modal loop when move item on request fails due to policy. Refs UIREQ-662.
+* Сannot add tags to record in the Requests app. Refs UIREQ-794.
 
 ## [7.1.0](https://github.com/folio-org/ui-requests/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.2...v7.1.0)

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -409,7 +409,8 @@ class ViewRequest extends React.Component {
     const tags = ((request && request.tags) || {}).tagList || [];
 
     const requestStatus = get(request, ['status'], '-');
-    const isRequestClosed = requestStatus.startsWith('Closed');
+    const closedStatuses = [requestStatuses.CANCELLED, requestStatuses.FILLED, requestStatuses.PICKUP_EXPIRED, requestStatuses.UNFILLED];
+    const isRequestClosed = closedStatuses.includes(requestStatus);
 
     return (
       <PaneMenu>

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -408,6 +408,9 @@ class ViewRequest extends React.Component {
 
     const tags = ((request && request.tags) || {}).tagList || [];
 
+    const requestStatus = get(request, ['status'], '-');
+    const isRequestClosed = requestStatus.startsWith('Closed');
+
     return (
       <PaneMenu>
         {
@@ -420,6 +423,7 @@ class ViewRequest extends React.Component {
                 onClick={tagsToggle}
                 badgeCount={tags.length}
                 ariaLabel={ariaLabel}
+                disabled={isRequestClosed}
               />
             )}
           </FormattedMessage>


### PR DESCRIPTION

<!--
  You have added reviewers to the pull request.
  Required reviewers this is a personal that responsible for current repository
  in according with https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix
-->

## Purpose
A closed Request should not be edited. Hence disable the tags Icon Button on closed request.
Issue: https://issues.folio.org/browse/UIREQ-794
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIREQ-746
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->
Closed Request - Tags Icon Button disabled
![image](https://user-images.githubusercontent.com/104053200/178914578-f684cdb5-9b1d-4259-b146-b29dd3ad96cf.png)

Open Request - Tags Icon Button remain enabled
![image](https://user-images.githubusercontent.com/104053200/178915059-93b96c98-3239-45a8-b257-867efdb2e5a8.png)


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
