### PR TITLE
UIREQ-795 retrieve up to MAX_RECORDS cancellation-reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix modal loop when move item on request fails due to policy. Refs UIREQ-662.
 * Сannot add tags to record in the Requests app. Refs UIREQ-794.
+* Retrieve up to `MAX_RECORDS` cancellation-reasons. Refs UIREQ-795.
 
 ## [7.1.0](https://github.com/folio-org/ui-requests/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.2...v7.1.0)

--- a/src/CancelRequestDialog.js
+++ b/src/CancelRequestDialog.js
@@ -10,12 +10,17 @@ import {
   Button,
 } from '@folio/stripes/components';
 
+import { MAX_RECORDS } from './constants';
 class CancelRequestDialog extends React.Component {
   static manifest = {
     cancellationReasons: {
       type: 'okapi',
       path: 'cancellation-reason-storage/cancellation-reasons',
       records: 'cancellationReasons',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: MAX_RECORDS,
+      },
     },
   }
 

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -153,6 +153,10 @@ class RequestsRoute extends React.Component {
       type: 'okapi',
       path: 'addresstypes',
       records: 'addressTypes',
+      params: {
+        query: 'cql.allRecords=1 sortby addressType',
+        limit: MAX_RECORDS,
+      },
     },
     query: {
       initialValue: { sort: 'requestDate' },
@@ -211,7 +215,11 @@ class RequestsRoute extends React.Component {
     servicePoints: {
       type: 'okapi',
       records: 'servicepoints',
-      path: 'service-points?query=(pickupLocation==true) sortby name&limit=100',
+      path: 'service-points',
+      params: {
+        query: 'query=(pickupLocation==true) sortby name',
+        limit: '100',
+      },
     },
     itemUniquenessValidator: {
       type: 'okapi',
@@ -258,11 +266,20 @@ class RequestsRoute extends React.Component {
       type: 'okapi',
       path: 'cancellation-reason-storage/cancellation-reasons',
       records: 'cancellationReasons',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: MAX_RECORDS,
+      },
     },
     staffSlips: {
       type: 'okapi',
       records: 'staffSlips',
-      path: 'staff-slips-storage/staff-slips?limit=100',
+      path: 'staff-slips-storage/staff-slips',
+      params: {
+        query: 'cql.allRecords=1 sortby name',
+        limit: '100',
+      },
+
       throwErrors: false,
     },
     pickSlips: {
@@ -279,7 +296,7 @@ class RequestsRoute extends React.Component {
       path: 'tags',
       params: {
         query: 'cql.allRecords=1 sortby label',
-        limit: '10000',
+        limit: MAX_RECORDS,
       },
       records: 'tags',
     },


### PR DESCRIPTION
The `cancellation-reasons` request lacked a `limit` clause, applying a
de facto limit of only ten entries. Providing an explicit `limit`
retrieves up to 10000.

Refs [UIREQ-795](https://issues.folio.org/browse/UIREQ-795)