### PR TITLE
UIREQ-792: Components are incorrectly imported directly from stripes-* packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix modal loop when move item on request fails due to policy. Refs UIREQ-662.
 * Сannot add tags to record in the Requests app. Refs UIREQ-794.
 * Retrieve up to `MAX_RECORDS` cancellation-reasons. Refs UIREQ-795.
+* Correctly import components from @folio/stripes/* packages. Refs UIREQ-792.
 
 ## [7.1.0](https://github.com/folio-org/ui-requests/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.0.2...v7.1.0)

--- a/src/PositionLink.js
+++ b/src/PositionLink.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 
-import { NoValue } from '@folio/stripes-components';
+import { NoValue } from '@folio/stripes/components';
 
 import { openRequestStatusFilters } from './utils';
 

--- a/src/components/RequestFormShortcutsWrapper/RequestsFormShortcutsWrapper.test.js
+++ b/src/components/RequestFormShortcutsWrapper/RequestsFormShortcutsWrapper.test.js
@@ -6,9 +6,14 @@ import '../../../test/jest/__mock__';
 import {
   CommandList,
   defaultKeyboardShortcuts,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import RequestsFormShortcutsWrapper from './RequestFormShortcutsWrapper';
-import { cancelShortcut, saveShortcut, collapseSectionsShortcut, expandSectionsShortcut } from '../../../test/jest/helpers/shortcuts';
+import {
+  cancelShortcut,
+  saveShortcut,
+  collapseSectionsShortcut,
+  expandSectionsShortcut,
+} from '../../../test/jest/helpers/shortcuts';
 
 const mockOnSubmit = jest.fn();
 const mockOnCanel = jest.fn();

--- a/src/components/RequestsRouteShortcutsWrapper/RequestsRouteShortcutsWrapper.test.js
+++ b/src/components/RequestsRouteShortcutsWrapper/RequestsRouteShortcutsWrapper.test.js
@@ -5,11 +5,14 @@ import '../../../test/jest/__mock__';
 
 import {
   CommandList,
-  defaultKeyboardShortcuts
-} from '@folio/stripes-components';
+  defaultKeyboardShortcuts,
+} from '@folio/stripes/components';
 import RequestsRouteShortcutsWrapper from './RequestsRouteShortcutsWrapper';
 import { buildStripes } from '../../../test/jest/helpers';
-import { openNewRecordShortcut, focusSearchFieldShortcut } from '../../../test/jest/helpers/shortcuts';
+import {
+  openNewRecordShortcut,
+  focusSearchFieldShortcut,
+} from '../../../test/jest/helpers/shortcuts';
 
 const history = {
   push: jest.fn(),

--- a/src/components/ViewRequestShortcutsWrapper/ViewRequestShortcutsWrapper.test.js
+++ b/src/components/ViewRequestShortcutsWrapper/ViewRequestShortcutsWrapper.test.js
@@ -6,9 +6,14 @@ import '../../../test/jest/__mock__';
 import {
   CommandList,
   defaultKeyboardShortcuts,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import ViewRequestShortcutsWrapper from './ViewRequestShortcutsWrapper';
-import { duplicateRecordShortcut, collapseSectionsShortcut, expandSectionsShortcut, editRecordShortcut } from '../../../test/jest/helpers/shortcuts';
+import {
+  duplicateRecordShortcut,
+  collapseSectionsShortcut,
+  expandSectionsShortcut,
+  editRecordShortcut,
+} from '../../../test/jest/helpers/shortcuts';
 
 const mockOnEdit = jest.fn();
 const mockOnDuplicate = jest.fn();
@@ -50,7 +55,10 @@ const renderViewRequestShortcuts = ({ isDuplicatingDisabled, isEditingDisabled }
 };
 
 describe('ViewRequestShortcutsWrapper component', () => {
-  const notDisbaled = { isDuplicatingDisabled: false, isEditingDisabled: false };
+  const notDisbaled = {
+    isDuplicatingDisabled: false,
+    isEditingDisabled: false,
+  };
 
   afterEach(() => {
     mockOnEdit.mockClear();


### PR DESCRIPTION
## Purpose
Components are incorrectly imported directly from stripes-* packages

## Refs
https://issues.folio.org/browse/UIREQ-792

## Screenshots
We have imports "@folio/stripes-" but all of them associated with tests
![UIREQ-792](https://user-images.githubusercontent.com/24813219/179730792-36ada529-09a5-4b12-bc0a-1cb18b96b56a.JPG)