### PR TITLE
UIREQ-818: Render search results as normal and show dash for empty st…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix modal loop when move item on request fails due to policy. Refs UIREQ-662.
 * Correctly import components from @folio/stripes/* packages. Refs UIREQ-792.
+* Render search results as normal and show dash for empty status. Refs UIREQ-818.
 
 ## [7.1.3](https://github.com/folio-org/ui-requests/tree/v7.1.3) (2022-08-11)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.1.2...v7.1.3)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -49,6 +49,7 @@ import {
   Timepicker,
   Checkbox,
   AccordionStatus,
+  NoValue,
 } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';
 
@@ -1475,7 +1476,9 @@ class RequestForm extends React.Component {
                             {isEditForm &&
                               <KeyValue
                                 label={<FormattedMessage id="ui-requests.status" />}
-                                value={<FormattedMessage id={requestStatusesTranslations[request.status]} />}
+                                value={(requestStatusesTranslations[request.status]
+                                  ? <FormattedMessage id={requestStatusesTranslations[request.status]} />
+                                  : <NoValue />)}
                               />}
                           </Col>
                           <Col xs={2}>

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -25,6 +25,7 @@ import {
   MenuSection,
   TextLink,
   DefaultMCLRowFormatter,
+  NoValue,
 } from '@folio/stripes/components';
 import {
   deparseFilters,
@@ -1001,7 +1002,9 @@ class RequestsRoute extends React.Component {
       ),
       'requester': rq => (rq.requester ? `${rq.requester.lastName}, ${rq.requester.firstName}` : ''),
       'requesterBarcode': rq => (rq.requester ? rq.requester.barcode : ''),
-      'requestStatus': rq => <FormattedMessage id={requestStatusesTranslations[rq.status]} />,
+      'requestStatus': rq => (requestStatusesTranslations[rq.status]
+        ? <FormattedMessage id={requestStatusesTranslations[rq.status]} />
+        : <NoValue />),
       'type': rq => <FormattedMessage id={requestTypesTranslations[rq.requestType]} />,
       'title': rq => <TextLink to={this.getRowURL(rq.id)} onClick={() => this.setURL(rq.id)}>{(rq.instance ? rq.instance.title : '')}</TextLink>,
       'year': rq => getFormattedYears(rq.instance?.publication, DEFAULT_DISPLAYED_YEARS_AMOUNT),


### PR DESCRIPTION
## Purpose
Render search results as normal and show dash for empty status

## Refs
https://issues.folio.org/browse/UIREQ-818

## Screenshots
On screen shot we can see difference between current behavior and future behavior after fix
![UIREQ-818](https://user-images.githubusercontent.com/24813219/185928425-de7d449c-3347-4b3e-82c5-925e6ac75ca7.JPG)
![UIREQ-818_2](https://user-images.githubusercontent.com/24813219/185928433-c64db09a-d9e7-4b2a-a4a7-60b7c94384c5.JPG)

