### PR TITLE
UIREQ-819: Support inventory 12.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## IN PROGRESS
 
 * Fix modal loop when move item on request fails due to policy. Refs UIREQ-662.
-* Correctly import components from @folio/stripes/* packages. Refs UIREQ-792.
+* Correctly import components from `@folio/stripes/*` packages. Refs UIREQ-792.
 * Render search results as normal and show dash for empty status. Refs UIREQ-818.
+* Support inventory 12.0 in okapiInterfaces. Refs UIREQ-819.
 
 ## [7.1.3](https://github.com/folio-org/ui-requests/tree/v7.1.3) (2022-08-11)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.1.2...v7.1.3)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "okapiInterfaces": {
       "cancellation-reason-storage": "1.1",
       "circulation": "13.0",
-      "inventory": "10.0 11.0",
+      "inventory": "10.0 11.0 12.0",
       "request-storage": "4.0",
       "pick-slips": "0.1",
       "automated-patron-blocks": "0.1"


### PR DESCRIPTION
Add version `12.0` to the list of supported `inventory` interface versions.

`DELETE /inventory/instances` and `DELETE /inventory/items` have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

ui-requests doesn't use these two `DELETE` APIs therefore no code change is needed.