### PR TITLE
UIREQ-826: TLR: when changing from title request to item request, form can't "save & close"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Refactor forms to use final-form. Refs UIREQ-419.
 * Requests: Implement App context menu and keyboard shortcuts modal. refs UIREQ-817.
 * Make title level request box selected when duplicating title level request. Refs UIREQ-827.
+* Prevent request to get instance if there is no `instanceId`. Refs UIREQ-826.
 
 ## [7.1.3](https://github.com/folio-org/ui-requests/tree/v7.1.3) (2022-08-11)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.1.2...v7.1.3)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -943,7 +943,7 @@ class RequestForm extends React.Component {
       selectedInstance,
     } = this.props;
 
-    if (isUndefined(selectedInstance)) {
+    if (isUndefined(selectedInstance) || isNil(instanceId)) {
       return <FormattedMessage id="ui-requests.errors.selectInstanceRequired" />;
     }
 

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -20,6 +20,7 @@ import {
   isBoolean,
   isUndefined,
   isNil,
+  isNull,
 } from 'lodash';
 
 import { Pluggable } from '@folio/stripes/core';
@@ -946,7 +947,8 @@ class RequestForm extends React.Component {
     if (isUndefined(selectedInstance)) {
       return <FormattedMessage id="ui-requests.errors.selectInstanceRequired" />;
     }
-    if (isNil(instanceId)) {
+
+    if (isNull(instanceId)) {
       return undefined;
     }
 

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -943,8 +943,11 @@ class RequestForm extends React.Component {
       selectedInstance,
     } = this.props;
 
-    if (isUndefined(selectedInstance) || isNil(instanceId)) {
+    if (isUndefined(selectedInstance)) {
       return <FormattedMessage id="ui-requests.errors.selectInstanceRequired" />;
+    }
+    if (isNil(instanceId)) {
+      return undefined;
     }
 
     const instance = await this.findInstance(instanceId);


### PR DESCRIPTION
## Purpose
When a user deselects the "Create title level request" checkbox and then clicks the "Save and close" button we had an error.

## Approach
The issue happened because we have a redundant API call without "instanceId" value. 
In this case, we will not do the server request because it is not necessary.

## Refs 
https://issues.folio.org/browse/UIREQ-826