### PR TITLE
UIREQ-837: Cannot submit a request with fulfillment preference = Delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Requests: Implement App context menu and keyboard shortcuts modal. refs UIREQ-817.
 * Make title level request box selected when duplicating title level request. Refs UIREQ-827.
 * Prevent request to get instance if there is no `instanceId`. Refs UIREQ-826.
+* Make Fulfillment preference and Delivery address selectable. Refs UIREQ-837. 
 
 ## [7.1.3](https://github.com/folio-org/ui-requests/tree/v7.1.3) (2022-08-11)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.1.2...v7.1.3)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -371,7 +371,6 @@ class RequestForm extends React.Component {
     const selectedAddressTypeId = this.getSelectedAddressTypeId(deliverySelected, defaultDeliveryAddressTypeId);
 
     form.change('fulfilmentPreference', selectedFullfillmentPreference);
-
     this.setState({
       deliverySelected,
       selectedAddressTypeId,
@@ -384,10 +383,10 @@ class RequestForm extends React.Component {
     const { form } = this.props;
     const selectedAddressTypeId = e.target.value;
 
+    form.change('deliveryAddressTypeId', selectedAddressTypeId);
     this.setState({
       selectedAddressTypeId,
     });
-    form.change('deliveryAddressTypeId', selectedAddressTypeId);
   }
 
   // This function is called from the "search and select user" widget when

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -364,9 +364,9 @@ class RequestForm extends React.Component {
   }
 
   onChangeFulfilment(e) {
-    const selectedFullfillmentPreference = e.target.value;
-    const { defaultDeliveryAddressTypeId } = this.state;
     const { form } = this.props;
+    const { defaultDeliveryAddressTypeId } = this.state;
+    const selectedFullfillmentPreference = e.target.value;
     const deliverySelected = this.isDeliverySelected(selectedFullfillmentPreference);
     const selectedAddressTypeId = this.getSelectedAddressTypeId(deliverySelected, defaultDeliveryAddressTypeId);
 

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -366,9 +366,11 @@ class RequestForm extends React.Component {
   onChangeFulfilment(e) {
     const selectedFullfillmentPreference = e.target.value;
     const { defaultDeliveryAddressTypeId } = this.state;
-
+    const { form } = this.props;
     const deliverySelected = this.isDeliverySelected(selectedFullfillmentPreference);
     const selectedAddressTypeId = this.getSelectedAddressTypeId(deliverySelected, defaultDeliveryAddressTypeId);
+
+    form.change('fulfilmentPreference', selectedFullfillmentPreference);
 
     this.setState({
       deliverySelected,
@@ -379,9 +381,13 @@ class RequestForm extends React.Component {
   }
 
   onChangeAddress(e) {
+    const { form } = this.props;
+    const selectedAddressTypeId = e.target.value;
+
     this.setState({
-      selectedAddressTypeId: e.target.value,
+      selectedAddressTypeId,
     });
+    form.change('deliveryAddressTypeId', selectedAddressTypeId);
   }
 
   // This function is called from the "search and select user" widget when

--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -415,6 +415,9 @@ describe('RequestForm', () => {
       mockedTlrSettings = {
         titleLevelRequestsFeatureEnabled: false,
       };
+    });
+
+    beforeEach(() => {
       renderComponent();
     });
 

--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -44,11 +44,32 @@ jest.mock('./components/TitleInformation', () => jest.fn(() => null));
 jest.mock('./ItemDetail', () => jest.fn(() => null));
 jest.mock('./ItemsDialog', () => jest.fn(() => null));
 jest.mock('./PositionLink', () => jest.fn(() => null));
+jest.mock('./UserForm', () => jest.fn(({
+  onChangeAddress,
+  onChangeFulfilment,
+}) => (
+  <>
+    <input
+      data-testid="fulfillmentInput"
+      onChange={onChangeFulfilment}
+    />
+    <input
+      data-testid="addressInput"
+      onChange={onChangeAddress}
+    />
+  </>
+)));
 
 describe('RequestForm', () => {
   const testIds = {
     tlrCheckbox: 'tlrCheckbox',
     instanceInfoSection: 'instanceInfoSection',
+    fulfillmentInput: 'fulfillmentInput',
+    addressInput: 'addressInput'
+  };
+  const formFieldNames = {
+    fulfilmentPreference: 'fulfilmentPreference',
+    deliveryAddressTypeId: 'deliveryAddressTypeId',
   };
   const labelIds = {
     tlrCheckbox: 'ui-requests.requests.createTitleLevelRequest',
@@ -74,7 +95,7 @@ describe('RequestForm', () => {
       history = createMemoryHistory(),
       values = valuesMock,
       selectedItem,
-      selectedUser,
+      selectedUser = { id: 'id' },
       selectedInstance,
       isPatronBlocksOverridden = false,
       isErrorModalOpen = false,
@@ -386,6 +407,45 @@ describe('RequestForm', () => {
       );
 
       expect(mockedChangeFunction).toHaveBeenCalledWith('createTitleLevelRequest', false);
+    });
+  });
+
+  describe('User information', () => {
+    beforeAll(() => {
+      mockedTlrSettings = {
+        titleLevelRequestsFeatureEnabled: false,
+      };
+      renderComponent();
+    });
+
+    describe('Fulfillment preference', () => {
+      it('should trigger `form.change` with correct arguments', () => {
+        const value = 'test';
+        const event = {
+          target: {
+            value,
+          },
+        };
+
+        fireEvent.change(screen.getByTestId(testIds.fulfillmentInput), event);
+
+        expect(mockedChangeFunction).toHaveBeenCalledWith(formFieldNames.fulfilmentPreference, value);
+      });
+    });
+
+    describe('Delivery address', () => {
+      it('should trigger `form.change` with correct arguments', () => {
+        const value = 'test';
+        const event = {
+          target: {
+            value,
+          },
+        };
+
+        fireEvent.change(screen.getByTestId(testIds.addressInput), event);
+
+        expect(mockedChangeFunction).toHaveBeenCalledWith(formFieldNames.deliveryAddressTypeId, value);
+      });
     });
   });
 });


### PR DESCRIPTION
## Purpose
User is not able to select Fulfillment preference correctly due to incorrect migration from Redux Form to React Final Form. 
Also, the same issue with Delivery address selector.

## Refs
[UIREQ-837](https://issues.folio.org/browse/UIREQ-837)