### PR TITLE
UIREQ-840: Cannot save item request from On Order item, because need a barcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 * Make Fulfillment preference and Delivery address selectable. Refs UIREQ-837.
+* Add the possibility to save item request if there is no item barcode. Refs UIREQ-840.
 
 ## [7.2.1](https://github.com/folio-org/ui-requests/tree/v7.2.1) (2022-11-14)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.0...v7.2.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -670,7 +670,7 @@ class RequestForm extends React.Component {
     });
   }
 
-  findItem(key, value, isValidation = false, disableValidation = true) {
+  findItem(key, value, isValidation = false, isBarcodeRequired = true) {
     const {
       findResource,
       form,
@@ -700,7 +700,7 @@ class RequestForm extends React.Component {
 
       return findResource(RESOURCE_TYPES.ITEM, value, key)
         .then((result) => {
-          if (key === 'id' && disableValidation) {
+          if (key === 'id' && isBarcodeRequired) {
             this.setState({
               isItemIdRequest: true,
             });

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -208,6 +208,7 @@ class RequestForm extends React.Component {
       shouldValidateInstanceId: false,
       isInstanceIdBlur: false,
       validatedInstanceId: null,
+      isItemIdRequest: Boolean(this.props.query.itemId),
     };
 
     this.connectedCancelRequestDialog = props.stripes.connect(CancelRequestDialog);
@@ -669,13 +670,16 @@ class RequestForm extends React.Component {
     });
   }
 
-  findItem(key, value, isValidation = false) {
+  findItem(key, value, isValidation = false, disableValidation = true) {
     const {
       findResource,
       form,
       onSetSelectedItem,
       onShowErrorModal,
     } = this.props;
+    const {
+      isItemIdRequest,
+    } = this.state;
 
     this.setState({
       isItemOrInstanceLoading: true,
@@ -696,6 +700,16 @@ class RequestForm extends React.Component {
 
       return findResource(RESOURCE_TYPES.ITEM, value, key)
         .then((result) => {
+          if (key === 'id' && disableValidation) {
+            this.setState({
+              isItemIdRequest: true,
+            });
+          } else if (key === 'barcode' && isItemIdRequest) {
+            this.setState({
+              isItemIdRequest: false,
+            });
+          }
+
           if (!result || result.totalRecords === 0) {
             this.setState({
               isItemOrInstanceLoading: false,
@@ -945,7 +959,12 @@ class RequestForm extends React.Component {
     } = this.props;
     const {
       shouldValidateItemBarcode,
+      isItemIdRequest,
     } = this.state;
+
+    if (isItemIdRequest && !barcode) {
+      return undefined;
+    }
 
     if (!barcode || (!barcode && !selectedItem?.id)) {
       return <FormattedMessage id="ui-requests.errors.selectItemRequired" />;
@@ -1217,13 +1236,15 @@ class RequestForm extends React.Component {
     this.setState({
       isItemsDialogOpen: false,
       requestTypeOptions: [],
-    });
+      isItemIdRequest: false,
+    }, this.triggerItemBarcodeValidation);
   }
 
   handleInstanceItemClick = (event, item) => {
     const {
       onSetSelectedInstance,
     } = this.props;
+    let shouldDisableValidation = true;
 
     onSetSelectedInstance(undefined);
     this.setState({
@@ -1231,7 +1252,14 @@ class RequestForm extends React.Component {
       requestTypeOptions: [],
     });
 
-    this.findItem('id', item.id);
+    if (item?.barcode) {
+      shouldDisableValidation = false;
+      this.setState({
+        isItemIdRequest: false,
+      });
+    }
+
+    this.findItem('id', item.id, false, shouldDisableValidation);
   }
 
   handleCloseProxy = () => {

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -208,7 +208,7 @@ class RequestForm extends React.Component {
       shouldValidateInstanceId: false,
       isInstanceIdBlur: false,
       validatedInstanceId: null,
-      isItemIdRequest: Boolean(this.props.query.itemId),
+      isItemIdRequest: Boolean(this.props.query?.itemId),
     };
 
     this.connectedCancelRequestDialog = props.stripes.connect(CancelRequestDialog);

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -670,7 +670,7 @@ class RequestForm extends React.Component {
     });
   }
 
-  findItem(key, value, isValidation = false, isBarcodeRequired = true) {
+  findItem(key, value, isValidation = false, isBarcodeRequired = false) {
     const {
       findResource,
       form,
@@ -700,7 +700,7 @@ class RequestForm extends React.Component {
 
       return findResource(RESOURCE_TYPES.ITEM, value, key)
         .then((result) => {
-          if (key === 'id' && isBarcodeRequired) {
+          if (key === 'id' && !isBarcodeRequired) {
             this.setState({
               isItemIdRequest: true,
             });
@@ -1244,7 +1244,7 @@ class RequestForm extends React.Component {
     const {
       onSetSelectedInstance,
     } = this.props;
-    let shouldDisableValidation = true;
+    let isBarcodeRequired = false;
 
     onSetSelectedInstance(undefined);
     this.setState({
@@ -1253,13 +1253,13 @@ class RequestForm extends React.Component {
     });
 
     if (item?.barcode) {
-      shouldDisableValidation = false;
+      isBarcodeRequired = true;
       this.setState({
         isItemIdRequest: false,
       });
     }
 
-    this.findItem('id', item.id, false, shouldDisableValidation);
+    this.findItem('id', item.id, false, isBarcodeRequired);
   }
 
   handleCloseProxy = () => {


### PR DESCRIPTION
## Purpose
When the user tries to create a request with `itemId` but **without** `item.barcode` we have a validation error for `item barcode` field which says that the field is empty. But we should not have that error. 
The issue appeared after migration from Redux Form to React Final Form.

## Approach
I have disabled validation of `item barcode` field if it is empty and `itemId` is presented (the same functionality as on Morning Glory).

## Refs
[UIREQ-840](https://issues.folio.org/browse/UIREQ-840)