### PR TITLE
UIREQ-849: Cannot submit a request with a user without barcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change history for ui-requests
 
 ## IN PROGRESS
+* Add the possibility to submit a request if there is no user barcode. Refs UIREQ-849.
 
 ## [7.2.3](https://github.com/folio-org/ui-requests/tree/v7.2.3) (2022-11-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.2...v7.2.3)
 * Make title info loading when request created from Instance record at the first time. Refs UIREQ-834.
-* Add the possibility to submit a request if there is no user barcode. Refs UIREQ-849.
 
 ## [7.2.2](https://github.com/folio-org/ui-requests/tree/v7.2.2) (2022-11-21)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.1...v7.2.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 * Make title info loading when request created from Instance record at the first time. Refs UIREQ-834.
+* Add the possibility to submit a request if there is no user barcode. Refs UIREQ-849.
 
 ## [7.2.2](https://github.com/folio-org/ui-requests/tree/v7.2.2) (2022-11-21)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.1...v7.2.2)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -538,6 +538,11 @@ class RequestForm extends React.Component {
             form.change('requesterId', selectedUser.id);
             form.change('requester', selectedUser);
             onSetSelectedUser(selectedUser);
+
+            if (fieldName === 'id') {
+              this.triggerUserBarcodeValidation();
+            }
+
             this.findRequestPreferences(selectedUser.id);
 
             if ((blocks.length && blocks[0].userId === selectedUser.id) || (!isEmpty(automatedPatronBlocks) && !isAutomatedPatronBlocksRequestInPendingState)) {
@@ -994,6 +999,10 @@ class RequestForm extends React.Component {
     const {
       shouldValidateUserBarcode,
     } = this.state;
+
+    if (selectedUser?.id && !barcode) {
+      return undefined;
+    }
 
     if (!barcode || (!barcode && !selectedUser?.id)) {
       return <FormattedMessage id="ui-requests.errors.selectUser" />;
@@ -1843,7 +1852,7 @@ class RequestForm extends React.Component {
                                         validateFields={[]}
                                       >
                                         {({ input, meta }) => {
-                                          const selectUserError = meta.touched && meta.error;
+                                          const selectUserError = meta.touched && !selectedUser?.id && meta.error;
                                           const userDoesntExistError = (isUserBarcodeClicked || isUserBarcodeBlur) && meta.error;
                                           const error = selectUserError || userDoesntExistError || null;
 

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -96,6 +96,10 @@ import css from './requests.css';
 
 const INSTANCE_SEGMENT_FOR_PLUGIN = 'instances';
 const ENTER_EVENT_KEY = 'Enter';
+const RESOURCE_KEYS = {
+  id: 'id',
+  barcode: 'barcode',
+};
 
 class RequestForm extends React.Component {
   static propTypes = {
@@ -226,15 +230,15 @@ class RequestForm extends React.Component {
 
   componentDidMount() {
     if (this.props.query.userBarcode) {
-      this.findUser('barcode', this.props.query.userBarcode);
+      this.findUser(RESOURCE_KEYS.barcode, this.props.query.userBarcode);
     }
 
     if (this.props.query.itemBarcode) {
-      this.findItem('barcode', this.props.query.itemBarcode);
+      this.findItem(RESOURCE_KEYS.barcode, this.props.query.itemBarcode);
     }
 
     if (this.props.query.itemId) {
-      this.findItem('id', this.props.query.itemId);
+      this.findItem(RESOURCE_KEYS.id, this.props.query.itemId);
     }
 
     if (this.props.query.instanceId && !this.props.query.itemBarcode && !this.props.query.itemId) {
@@ -302,15 +306,15 @@ class RequestForm extends React.Component {
     }
 
     if (prevQuery.userBarcode !== query.userBarcode) {
-      this.findUser('barcode', query.userBarcode);
+      this.findUser(RESOURCE_KEYS.barcode, query.userBarcode);
     }
 
     if (prevQuery.itemBarcode !== query.itemBarcode) {
-      this.findItem('barcode', query.itemBarcode);
+      this.findItem(RESOURCE_KEYS.barcode, query.itemBarcode);
     }
 
     if (prevQuery.itemId !== query.itemId) {
-      this.findItem('id', query.itemId);
+      this.findItem(RESOURCE_KEYS.id, query.itemId);
     }
 
     if (prevQuery.instanceId !== query.instanceId) {
@@ -412,9 +416,9 @@ class RequestForm extends React.Component {
 
     onSetSelectedUser(null);
     if (barcode) {
-      this.findUser('barcode', barcode);
+      this.findUser(RESOURCE_KEYS.barcode, barcode);
     } else {
-      this.findUser('id', id);
+      this.findUser(RESOURCE_KEYS.id, id);
     }
   }
 
@@ -460,7 +464,7 @@ class RequestForm extends React.Component {
       this.setState({
         isUserBarcodeClicked: true,
       });
-      this.findUser('barcode', barcode);
+      this.findUser(RESOURCE_KEYS.barcode, barcode);
 
       if (eventKey === ENTER_EVENT_KEY) {
         this.setState({
@@ -539,7 +543,7 @@ class RequestForm extends React.Component {
             form.change('requester', selectedUser);
             onSetSelectedUser(selectedUser);
 
-            if (fieldName === 'id') {
+            if (fieldName === RESOURCE_KEYS.id) {
               this.triggerUserBarcodeValidation();
             }
 
@@ -710,11 +714,11 @@ class RequestForm extends React.Component {
 
       return findResource(RESOURCE_TYPES.ITEM, value, key)
         .then((result) => {
-          if (key === 'id' && !isBarcodeRequired) {
+          if (key === RESOURCE_KEYS.id && !isBarcodeRequired) {
             this.setState({
               isItemIdRequest: true,
             });
-          } else if (key === 'barcode' && isItemIdRequest) {
+          } else if (key === RESOURCE_KEYS.barcode && isItemIdRequest) {
             this.setState({
               isItemIdRequest: false,
             });
@@ -888,7 +892,7 @@ class RequestForm extends React.Component {
       this.setState(({
         isItemBarcodeClicked: true,
       }));
-      this.findItem('barcode', barcode);
+      this.findItem(RESOURCE_KEYS.barcode, barcode);
 
       if (eventKey === ENTER_EVENT_KEY) {
         this.setState({
@@ -983,7 +987,7 @@ class RequestForm extends React.Component {
     if (barcode && shouldValidateItemBarcode) {
       this.setState({ shouldValidateItemBarcode: false });
 
-      const item = await this.findItem('barcode', barcode, true);
+      const item = await this.findItem(RESOURCE_KEYS.barcode, barcode, true);
 
       return !item
         ? <FormattedMessage id="ui-requests.errors.itemBarcodeDoesNotExist" />
@@ -1010,7 +1014,7 @@ class RequestForm extends React.Component {
     if (barcode && shouldValidateUserBarcode) {
       this.setState({ shouldValidateUserBarcode: false });
 
-      const user = await this.findUser('barcode', barcode, true);
+      const user = await this.findUser(RESOURCE_KEYS.barcode, barcode, true);
 
       return !user
         ? <FormattedMessage id="ui-requests.errors.userBarcodeDoesNotExist" />
@@ -1273,7 +1277,7 @@ class RequestForm extends React.Component {
       });
     }
 
-    this.findItem('id', item.id, false, isBarcodeRequired);
+    this.findItem(RESOURCE_KEYS.id, item.id, false, isBarcodeRequired);
   }
 
   handleCloseProxy = () => {

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -497,6 +497,10 @@ class RequestForm extends React.Component {
     return user;
   }
 
+  shouldSetBlocked = (blocks, selectedUser) => {
+    return blocks.length && blocks[0].userId === selectedUser.id;
+  }
+
   findUser(fieldName, value, isValidation = false) {
     const {
       form,
@@ -549,7 +553,7 @@ class RequestForm extends React.Component {
 
             this.findRequestPreferences(selectedUser.id);
 
-            if ((blocks.length && blocks[0].userId === selectedUser.id) || (!isEmpty(automatedPatronBlocks) && !isAutomatedPatronBlocksRequestInPendingState)) {
+            if (this.shouldSetBlocked(blocks, selectedUser) || (!isEmpty(automatedPatronBlocks) && !isAutomatedPatronBlocksRequestInPendingState)) {
               onSetBlocked(true);
               onSetIsPatronBlocksOverridden(false);
             }


### PR DESCRIPTION
## Purpose
After migration from Redux Form to React Final Form we were not able to create requests if a user doesn't have a barcode. 

## Approach
I changed the validation which should let us create a request if the user was selected and a user barcode field is empty or/and a user doesn't have a barcode.
We have the same behavior on Morning Glory.
Also, removed magic strings 😇 

## Refs
[UIREQ-849](https://issues.folio.org/browse/UIREQ-849)