### PR TITLE
UIREQ-863: Update versions of interfaces request-storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 * Increased the limit for Service points in Request. Refs UIREQ-850.
 * Cannot search for requests with tags ( or [. Fix UIREQ-846.
+* Change "request-storage" interface version to 5.0. Refs - UIREQ-863.
 
 ## [7.2.4](https://github.com/folio-org/ui-requests/tree/v7.2.4) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.3...v7.2.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## IN PROGRESS
 * Increased the limit for Service points in Request. Refs UIREQ-850.
 * Cannot search for requests with tags ( or [. Fix UIREQ-846.
-* Change "request-storage" interface version to 5.0. Refs - UIREQ-863.
+* BREAKING: Change "request-storage" interface version to 5.0. Refs - UIREQ-863.
 
 ## [7.2.4](https://github.com/folio-org/ui-requests/tree/v7.2.4) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.3...v7.2.4)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/requests",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "Requests manager",
   "repository": "folio-org/ui-requests",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "cancellation-reason-storage": "1.1",
       "circulation": "13.0",
       "inventory": "10.0 11.0 12.0",
-      "request-storage": "4.0",
+      "request-storage": "5.0",
       "pick-slips": "0.1",
       "automated-patron-blocks": "0.1"
     },


### PR DESCRIPTION
## Purpose
Update `request-storage` interface version due to braking changes in `mod-circulation-storage`

## Refs
[UIREQ-863](https://issues.folio.org/browse/UIREQ-863)