### PR TITLE
UIREQ-897 correctly depend on babel-plugin-module-resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Correctly handle move-request in non-English locales. Refs UIREQ-870.
 * Bump major versions of several @folio/stripes-* packages. Refs UIREQ-874.
 * Populate the token "requester.patronGroup" in the pick slip, with the data provided by the backend in the ui-requests module. Refs - UIREQ-804.
+* Move and upgrade `babel-plugin-module-resolver` to dev-deps, v5. Refs UIREQ-897.
 
 ## [7.2.4](https://github.com/folio-org/ui-requests/tree/v7.2.4) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.3...v7.2.4)

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.1.10",
     "babel-jest": "^26.6.3",
+    "babel-plugin-module-resolver": "^5.0.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.4",
     "eslint": "^7",
@@ -189,7 +190,6 @@
     "sinon": "^7.2.0"
   },
   "dependencies": {
-    "babel-plugin-module-resolver": "^4.1.0",
     "final-form": "^4.20.7",
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Correctly locate `babel-plugin-module-resolver` in dev-deps since it is not a runtime dependency, and update it to v5 in order to avoid CVE-2022-46175.

Refs [UIREQ-897](https://issues.folio.org/browse/UIREQ-897)
