### PR TITLE
UIREQ-904: Change filtering by tags rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Support `inventory` `13.0` interface version. Refs UIREQ-867.
 * Move and upgrade `babel-plugin-module-resolver` to dev-deps, v5. Refs UIREQ-897.
 * UI tests replacement with RTL/Jest for ErrorModal. Refs UIREQ-883.
+* Change filtering by tag rules in `RequestsFiltersConfig`. Refs UIREQ-904.
 
 ## [7.2.4](https://github.com/folio-org/ui-requests/tree/v7.2.4) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.3...v7.2.4)

--- a/src/components/RequestsFilters/RequestsFiltersConfig.js
+++ b/src/components/RequestsFilters/RequestsFiltersConfig.js
@@ -29,9 +29,9 @@ export default [
     operator: '==',
     parse: (value) => {
       if (Array.isArray(value)) {
-        return `tags.tagList==(${value.map(v => `"*${v}*"`)
+        return `tags.tagList==(${value.map(v => `*"*${v}*"*`)
           .join(' or ')})`;
-      } else return `tags.tagList=="*${value}*"`;
+      } else return `tags.tagList==*"*${value}*"*`;
     }
   },
   {


### PR DESCRIPTION
## Purpose
Change filtering by tags rules to allow for proper filter by tags behavior

## Approach
Change filtering by tags rules from "\*EXPRESSION\*" to \*"EXPRESSION"\*

## Refs
https://issues.folio.org/browse/UIREQ-904