### PR TITLE
UIREQ-906: Use camel case notation for all data-testid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Move and upgrade `babel-plugin-module-resolver` to dev-deps, v5. Refs UIREQ-897.
 * UI tests replacement with RTL/Jest for ErrorModal. Refs UIREQ-883.
 * Change filtering by tag rules in `RequestsFiltersConfig`. Refs UIREQ-904.
+* Use camel case notation for all data-testid. Refs UIREQ-906.
 
 ## [7.2.4](https://github.com/folio-org/ui-requests/tree/v7.2.4) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.3...v7.2.4)

--- a/src/ChooseRequestTypeDialog.test.js
+++ b/src/ChooseRequestTypeDialog.test.js
@@ -23,10 +23,11 @@ jest.mock('./utils', () => ({
   }])),
 }));
 
+const testIds = {
+  loading: 'loading',
+};
+
 describe('ChooseRequestTypeDialog', () => {
-  const testIds = {
-    loading: 'loading',
-  };
   const buttonCallOrder = {
     confirm: 1,
     cancel: 2,

--- a/src/ItemsDialog.test.js
+++ b/src/ItemsDialog.test.js
@@ -32,13 +32,17 @@ jest.mock('./components', () => ({
   )),
 }));
 
+const testIds = {
+  loading: 'loading',
+};
+const labelIds = {
+  selectItem: 'ui-requests.items.selectItem',
+  instanceItems: 'ui-requests.items.instanceItems',
+  resultCount: 'ui-requests.resultCount',
+  instanceItemsNotFound: 'ui-requests.items.instanceItems.notFound',
+};
+
 describe('ItemsDialog', () => {
-  const labelIds = {
-    selectItem: 'ui-requests.items.selectItem',
-    instanceItems: 'ui-requests.items.instanceItems',
-    resultCount: 'ui-requests.resultCount',
-    instanceItemsNotFound: 'ui-requests.items.instanceItems.notFound',
-  };
   const onClose = jest.fn();
   const onRowClick = jest.fn();
   const testTitle = 'testTitle';
@@ -211,7 +215,7 @@ describe('ItemsDialog', () => {
     });
 
     it('should render Loading when data is being loaded', () => {
-      const loading = screen.queryByTestId('loading');
+      const loading = screen.queryByTestId(testIds.loading);
 
       expect(loading).toBeInTheDocument();
     });
@@ -222,7 +226,7 @@ describe('ItemsDialog', () => {
       });
 
       it('should hide Loading when data is loaded', () => {
-        const loading = screen.queryByTestId('loading');
+        const loading = screen.queryByTestId(testIds.loading);
 
         expect(loading).not.toBeInTheDocument();
       });

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -18,7 +18,7 @@ const ErrorModal = ({
       <Button
         data-test-error-modal-close-button
         onClick={onClose}
-        data-testid="footer-close-button"
+        data-testid="footerCloseButton"
       >
         <FormattedMessage id="ui-requests.close" />
       </Button>
@@ -37,7 +37,7 @@ const ErrorModal = ({
     >
       <div
         data-test-error-modal-content
-        data-testid="error-modal"
+        data-testid="errorModal"
       >
         {errorMessage}
       </div>

--- a/src/components/ErrorModal/ErrorModal.test.js
+++ b/src/components/ErrorModal/ErrorModal.test.js
@@ -12,8 +12,8 @@ import ErrorModal from './ErrorModal';
 describe('ErrorModal', () => {
   const closeModal = jest.fn();
   const testIds = {
-    errorModal: 'error-modal',
-    footerCloseButton: 'footer-close-button',
+    errorModal: 'errorModal',
+    footerCloseButton: 'footerCloseButton',
   };
   const labelIds = {
     footerMessageId: 'ui-requests.close',

--- a/src/components/RequestFormShortcutsWrapper/RequestsFormShortcutsWrapper.test.js
+++ b/src/components/RequestFormShortcutsWrapper/RequestsFormShortcutsWrapper.test.js
@@ -28,8 +28,12 @@ mockAccordionStatusRef.current = {
   setStatus: jest.fn(),
 };
 
+const testIds = {
+  childElement: 'childElement',
+};
+
 const renderRequestsFormShortcuts = (isSubmittingDisabled) => {
-  const childElement = <input data-testid="childElement" id="input-request-search" />;
+  const childElement = <input data-testid={testIds.childElement} id="input-request-search" />;
 
   const component = () => (
     <CommandList commands={defaultKeyboardShortcuts}>
@@ -57,7 +61,7 @@ describe('RequestsFormShortcutsWrapper component', () => {
   it('should render children correctly', () => {
     const { getByTestId } = renderRequestsFormShortcuts(true);
 
-    expect(getByTestId('childElement')).toBeInTheDocument();
+    expect(getByTestId(testIds.childElement)).toBeInTheDocument();
   });
   describe('when isSubmittingDisabled is true', () => {
     it('Save shortcut should not work', () => {

--- a/src/components/RequestsFilters/RequestLevelFilter/RequestLevelFilter.test.js
+++ b/src/components/RequestsFilters/RequestLevelFilter/RequestLevelFilter.test.js
@@ -18,10 +18,17 @@ import {
   requestLevelFilters,
 } from '../../../constants';
 
+const testIds = {
+  accordion: 'accordion',
+};
+const labelIds = {
+  requestLevel: 'ui-requests.requestLevel',
+};
+
 Accordion.mockImplementation(({ onClearFilter, children }) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
   <div
-    data-testid="accordion"
+    data-testid={testIds.accordion}
     onClick={onClearFilter}
   >
     {children}
@@ -29,10 +36,6 @@ Accordion.mockImplementation(({ onClearFilter, children }) => (
 ));
 
 describe('RequestLevelFilter', () => {
-  const labelIds = {
-    requestLevel: 'ui-requests.requestLevel',
-  };
-
   const testOnClearCallback = jest.fn();
   const testOnChangeCallback = () => {};
   const defaultTestActiveValues = [];
@@ -70,7 +73,7 @@ describe('RequestLevelFilter', () => {
     it('should handle clear filters', () => {
       expect(testOnClearCallback).not.toHaveBeenCalled();
 
-      fireEvent.click(screen.getByTestId('accordion'));
+      fireEvent.click(screen.getByTestId(testIds.accordion));
 
       expect(testOnClearCallback).toHaveBeenCalledWith(requestFilterTypes.REQUEST_LEVELS);
     });

--- a/src/components/RequestsRouteShortcutsWrapper/RequestsRouteShortcutsWrapper.test.js
+++ b/src/components/RequestsRouteShortcutsWrapper/RequestsRouteShortcutsWrapper.test.js
@@ -26,8 +26,12 @@ const mockButtonClick = jest.fn();
 
 stripes.hasPerm = jest.fn(() => true);
 
+const testIds = {
+  childElement: 'childElement',
+};
+
 describe('RequestsRouteShortcutsWrapper component', () => {
-  let childElement = <input data-testid="childElement" id="input-request-search" />;
+  let childElement = <input data-testid={testIds.childElement} id="input-request-search" />;
   const renderRequestsRouteShortcutsWrapper = () => {
     const component = () => (
       <CommandList commands={defaultKeyboardShortcuts}>
@@ -53,7 +57,7 @@ describe('RequestsRouteShortcutsWrapper component', () => {
   it('should render children correctly', () => {
     const { getByTestId } = renderRequestsRouteShortcutsWrapper();
 
-    expect(getByTestId('childElement')).toBeInTheDocument();
+    expect(getByTestId(testIds.childElement)).toBeInTheDocument();
   });
 
   describe('when openNewRecord shortcut is pressed', () => {
@@ -69,7 +73,7 @@ describe('RequestsRouteShortcutsWrapper component', () => {
     it('focusSearchField is pressed, search field should be focused', () => {
       const { getByTestId } = renderRequestsRouteShortcutsWrapper();
       focusSearchFieldShortcut(document.body);
-      expect(getByTestId('childElement')).toHaveFocus();
+      expect(getByTestId(testIds.childElement)).toHaveFocus();
     });
   });
 

--- a/src/components/ViewRequestShortcutsWrapper/ViewRequestShortcutsWrapper.test.js
+++ b/src/components/ViewRequestShortcutsWrapper/ViewRequestShortcutsWrapper.test.js
@@ -33,8 +33,12 @@ mockAccordionStatusRef.current = {
   setStatus: jest.fn(),
 };
 
+const testIds = {
+  childElement: 'childElement',
+};
+
 const renderViewRequestShortcuts = ({ isDuplicatingDisabled, isEditingDisabled }) => {
-  const childElement = <input data-testid="childElement" id="input-request-search" />;
+  const childElement = <input data-testid={testIds.childElement} id="input-request-search" />;
 
   const component = () => (
     <CommandList commands={defaultKeyboardShortcuts}>
@@ -70,7 +74,7 @@ describe('ViewRequestShortcutsWrapper component', () => {
   it('should render children correctly', () => {
     const { getByTestId } = renderViewRequestShortcuts(notDisbaled);
 
-    expect(getByTestId('childElement')).toBeInTheDocument();
+    expect(getByTestId(testIds.childElement)).toBeInTheDocument();
   });
 
   describe('when isEditingDisabled is true', () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -11,6 +11,12 @@ jest.mock('./routes/index', () => ({
   RequestsRoute: () => <h1>RequestsRoute</h1>,
 }));
 
+const labelIds = {
+  navigation: 'ui-requests.navigation.app',
+  keyboardShortcuts: 'ui-requests.appMenu.keyboardShortcuts',
+  shortcutMvodalLabel: 'stripes-components.shortcut.modalLabel',
+};
+
 describe('UI Requests', () => {
   const renderRequest = () => {
     const component = (
@@ -39,29 +45,29 @@ describe('UI Requests', () => {
     window.history.pushState({}, '', '/requests');
 
     renderRequest();
-    expect(screen.getByText('ui-requests.navigation.app')).toBeInTheDocument();
+    expect(screen.getByText(labelIds.navigation)).toBeInTheDocument();
   });
 
   it('should render "Keyboard shortcuts" nav item', () => {
     window.history.pushState({}, '', '/requests');
 
     renderRequest();
-    expect(screen.getByText('ui-requests.appMenu.keyboardShortcuts')).toBeInTheDocument();
+    expect(screen.getByText(labelIds.keyboardShortcuts)).toBeInTheDocument();
   });
 
   it('should render keyboard shortcuts modal', () => {
     window.history.pushState({}, '', '/requests');
 
     renderRequest();
-    fireEvent.click(screen.getByText('ui-requests.appMenu.keyboardShortcuts'));
-    expect(screen.getByText('stripes-components.shortcut.modalLabel')).toBeInTheDocument();
+    fireEvent.click(screen.getByText(labelIds.keyboardShortcuts));
+    expect(screen.getByText(labelIds.shortcutMvodalLabel)).toBeInTheDocument();
   });
 
   it('should close keyboard shortcuts modal on clicking close button', () => {
     window.history.pushState({}, '', '/requests');
 
     renderRequest();
-    fireEvent.click(screen.getByText('ui-requests.appMenu.keyboardShortcuts'));
+    fireEvent.click(screen.getByText(labelIds.keyboardShortcuts));
     const button = screen.getByRole('button', { name: /stripes-components.dismissModal/i });
     fireEvent.click(button);
     expect(screen.queryByText('stripes-components.shortcut.modalLabel')).not.toBeInTheDocument();

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -39,13 +39,17 @@ jest.mock('../components', () => ({
   LoadingButton: jest.fn(() => null),
 }));
 
+const testIds = {
+  searchAndSort: 'searchAndSort',
+};
+
 SearchAndSort.mockImplementation(jest.fn(({
   parentResources: { records: { records } },
   detailProps: { onDuplicate },
 }) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
   <div
-    data-testid="searchAndSort"
+    data-testid={testIds.searchAndSort}
     onClick={() => onDuplicate(records[0])}
   />
 )));
@@ -189,7 +193,7 @@ describe('RequestsRoute', () => {
 
       renderComponent(defaultProps);
 
-      fireEvent.click(screen.getByTestId('searchAndSort'));
+      fireEvent.click(screen.getByTestId(testIds.searchAndSort));
 
       expect(duplicateRequest).toHaveBeenCalledWith(mockedRequest);
       expect(mockedUpdateFunc).toHaveBeenCalledWith(expectedResultForUpdate);
@@ -200,7 +204,7 @@ describe('RequestsRoute', () => {
 
       renderComponent(defaultProps);
 
-      fireEvent.click(screen.getByTestId('searchAndSort'));
+      fireEvent.click(screen.getByTestId(testIds.searchAndSort));
 
       expect(duplicateRequest).toHaveBeenCalledWith(mockedRequest);
       expect(mockedUpdateFunc).toHaveBeenCalledWith(defaultExpectedResultForUpdate);


### PR DESCRIPTION
## Purpose
- Use camel case notation for all data-testid
- Remove magic strings for testIds and labelIds

## Refs
https://issues.folio.org/browse/UIREQ-906