### PR TITLE
UIREQ-922: Unexpected ugly UI error when placing request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Made code improvements related to TLR. Refs UIREQ-871.
 * Fix error with proxyUserId when it is not cleared. Refs UIREQ-919.
+* Fix incorrect formatting of request date. Refs UIREQ-922.
 
 ## [8.0.0](https://github.com/folio-org/ui-requests/tree/v8.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v7.2.4...v8.0.0)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -738,7 +738,7 @@ class RequestsRoute extends React.Component {
 
   massageNewRecord = (requestData) => {
     const { intl: { timeZone } } = this.props;
-    const isoDate = moment.tz(timeZone).format();
+    const isoDate = moment.tz(timeZone).toISOString();
     Object.assign(requestData, { requestDate: isoDate });
   };
 


### PR DESCRIPTION
## Purpose
Replace moment.format() with moment.toISOString() because the
former does not guarantee the numbering system will be Latn (0-9,
Arabic numbers). 

## Refs
[UIREQ-922](https://issues.folio.org/browse/UIREQ-922)