### PR TITLE
UIREQ-914: Reassign limit variable from hardcoded value to MAX_RECORDS constant for RequestsRoute.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Made code improvements related to TLR. Refs UIREQ-871.
 * UI tests replacement with RTL/Jest for urls. Refs UIREQ-896.
 * Reassign limit variable from hardcoded value to MAX_RECORDS constant for `ItemsDialog.js`. Refs UIREQ-913.
+* Reassign limit variable from hardcoded value to MAX_RECORDS constant for `RequestsRoute.js`. Refs UIREQ-914.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -212,7 +212,7 @@ class RequestsRoute extends React.Component {
       path: 'groups',
       params: {
         query: 'cql.allRecords=1 sortby group',
-        limit: '200',
+        limit: MAX_RECORDS,
       },
       records: 'usergroups',
     },
@@ -281,7 +281,7 @@ class RequestsRoute extends React.Component {
       path: 'staff-slips-storage/staff-slips',
       params: {
         query: 'cql.allRecords=1 sortby name',
-        limit: '100',
+        limit: MAX_RECORDS,
       },
 
       throwErrors: false,


### PR DESCRIPTION
## Purpose
Reassign limit variable from hardcoded value to MAX_RECORDS constant for RequestsRoute.js

## Refs
https://issues.folio.org/browse/UIREQ-914