### PR TITLE
UIREQ-913: Reassign limit variable from hardcoded value to MAX_RECORDS constant for ItemsDialog.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Made code improvements related to TLR. Refs UIREQ-871.
 * UI tests replacement with RTL/Jest for urls. Refs UIREQ-896.
+* Reassign limit variable from hardcoded value to MAX_RECORDS constant for `ItemsDialog.js`. Refs UIREQ-913.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/ItemsDialog.js
+++ b/src/ItemsDialog.js
@@ -27,6 +27,7 @@ import {
   itemStatuses,
   itemStatusesTranslations,
   requestableItemStatuses,
+  MAX_RECORDS,
 } from './constants';
 import { Loading } from './components';
 
@@ -93,7 +94,7 @@ const ItemsDialog = ({
     const query = holdings.map(h => `holdingsRecordId==${h.id}`).join(' or ');
     mutator.items.reset();
 
-    return mutator.items.GET({ params: { query, limit: 1000 } });
+    return mutator.items.GET({ params: { query, limit: MAX_RECORDS } });
   };
 
   const fetchRequests = async (itemsList) => {
@@ -111,7 +112,7 @@ const ItemsDialog = ({
 
       mutator.requests.reset();
       // eslint-disable-next-line no-await-in-loop
-      const result = await mutator.requests.GET({ params: { query, limit: 1000 } });
+      const result = await mutator.requests.GET({ params: { query, limit: MAX_RECORDS } });
 
       data.push(...result);
     }


### PR DESCRIPTION
## Purpose
Reassign limit variable from hardcoded value to MAX_RECORDS constant for ItemsDialog.js

## Refs
https://issues.folio.org/browse/UIREQ-913