### PR TITLE
UIREQ-899,UIREQ-900: Requests: Include call number and service point in Action menu list of fields to display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Reassign limit variable from hardcoded value to MAX_RECORDS constant for `RequestsRoute.js`. Refs UIREQ-914.
 * Include "Effective call number string" in display of result list. Refs UIREQ-898.
 * Include call number in Action menu list of fields to display. Refs UIREQ-899.
+* Include pickup service point in Action menu list of fields to display. Refs UIREQ-901.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reassign limit variable from hardcoded value to MAX_RECORDS constant for `ItemsDialog.js`. Refs UIREQ-913.
 * Reassign limit variable from hardcoded value to MAX_RECORDS constant for `RequestsRoute.js`. Refs UIREQ-914.
 * Include "Effective call number string" in display of result list. Refs UIREQ-898.
+* Include call number in Action menu list of fields to display. Refs UIREQ-899.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -1110,6 +1110,18 @@ class RequestsRoute extends React.Component {
 
     const columnManagerProps = {
       excludeKeys: ['title'],
+      visibleColumns: [
+        'title',
+        'requestDate',
+        'year',
+        'itemBarcode',
+        'type',
+        'requestStatus',
+        'position',
+        'requester',
+        'requesterBarcode',
+        'proxy',
+      ],
     };
 
     return (


### PR DESCRIPTION
## Purpose
Include call number (unselected by default) in Action menu.
Include service point name (unselected by default) in Action menu.

## Refs
[UIREQ-899](https://issues.folio.org/browse/UIREQ-899)
[UIREQ-901](https://issues.folio.org/browse/UIREQ-901)

## NOTES
After merging this PR to UIREQ-898 branch, UIREQ-898 will be merged to master.