### PR TITLE
UIREQ-929: Requests for Items on Instances with more than 10 holdings  do not allow a user to move a request to all requestable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Populate the token "requester.departments" in the pick slip, with the data provided by the backend in the ui-requests module. Refs UIREQ-814.
 * UI tests replacement with RTL/Jest for src/PositionLink.js. Refs UIREQ-879.
 * Populate the token "currentDateTime" in the pick slip, with the data provided by the backend in the ui-requests module. Refs UIREQ-807.
+* Requests for Items on Instances with more than 10 holdings do not allow a user to move a request to all requestable items. Refs UIREQ-929.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/ItemsDialog.test.js
+++ b/src/ItemsDialog.test.js
@@ -412,4 +412,85 @@ describe('ItemsDialog', () => {
       }
     });
   });
+
+  describe('formatter', () => {
+    const item = {
+      status: {
+        name: 'Aged to lost',
+      },
+      effectiveLocation: {
+        name: 'effective location name',
+      },
+      materialType: {
+        name: 'material type name',
+      },
+      temporaryLoanType: {
+        name: 'temporary loan type name',
+      },
+      permanentLoanType: {
+        name: 'permanent loan type name',
+      },
+    };
+
+    describe('itemStatus', () => {
+      it('should return formatted message', () => {
+        expect(formatter.itemStatus(item).props.id).toEqual('ui-requests.item.status.agedToLost');
+      });
+    });
+
+    describe('location', () => {
+      it('should return effective location name', () => {
+        expect(formatter.location(item)).toEqual('effective location name');
+      });
+
+      it('should return default value for effective location name', () => {
+        expect(formatter.location({
+          ...item,
+          effectiveLocation: {},
+        })).toEqual('');
+      });
+    });
+
+    describe('materialType', () => {
+      it('should return material type', () => {
+        expect(formatter.materialType(item)).toEqual('material type name');
+      });
+    });
+
+    describe('loanType', () => {
+      describe('with temporaryLoanType', () => {
+        it('should return temporary loan type name', () => {
+          expect(formatter.loanType(item)).toEqual('temporary loan type name');
+        });
+
+        it('should return default value for temporary loan type name', () => {
+          expect(formatter.loanType({
+            ...item,
+            temporaryLoanType: {
+              other: '',
+            },
+          })).toEqual('');
+        });
+      });
+
+      describe('without temporaryLoanType', () => {
+        it('should return permanent loan type name', () => {
+          expect(formatter.loanType({
+            ...item,
+            temporaryLoanType: false,
+          })).toEqual('permanent loan type name');
+        });
+
+        it('should return default value for permanent loan type name', () => {
+          expect(formatter.loanType({
+            ...item,
+            temporaryLoanType: false,
+            permanentLoanType: {
+              other: '',
+            },
+          })).toEqual('');
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Purpose
Requests for Items on Instances with more than 10 holdings  do not allow a user to move a request to all requestable items

## Approach
1. We add `limit: MAX_RECORDS` for get all data without this limit work BE limit. 
2. We use `for` for get all data because we use GET request
3. Increase code coverage.

## Refs
https://issues.folio.org/browse/UIREQ-929