### PR TITLE
UIREQ-963: Update request-storage okapi interface to 6.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Cover `src/components/Loading/Loading.js` file by RTL/Jest tests. Refs UIREQ-885.
 * Leverage cookie-based authentication in all API requests. Refs UIREQ-861.
 * Update `circulation` okapi interface to `14.0` version. Refs UIREQ-954.
+* Update `request-storage` okapi interface to `6.0` version. Refs UIREQ-963.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "cancellation-reason-storage": "1.1",
       "circulation": "14.0",
       "inventory": "10.0 11.0 12.0 13.0",
-      "request-storage": "5.0",
+      "request-storage": "6.0",
       "pick-slips": "0.1",
       "automated-patron-blocks": "0.1"
     },


### PR DESCRIPTION
## Purpose
Update request-storage okapi interface to 6.0 version

## Refs
https://issues.folio.org/browse/UIREQ-963