### PR TITLE
UIREQ-955: TLR: "Create title level request" checkbox not preselected on "New request" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Cover `src/components/Loading/Loading.js` file by RTL/Jest tests. Refs UIREQ-885.
 * Leverage cookie-based authentication in all API requests. Refs UIREQ-861.
 * Update `circulation` okapi interface to `14.0` version. Refs UIREQ-954.
+* TLR: "Create title level request" checkbox not preselected on "New request" page. Refs UIREQ-955.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -1018,6 +1018,7 @@ class RequestForm extends React.Component {
     const fulfillmentTypeOptions = getFulfillmentTypeOptions(hasDelivery, optionLists?.fulfillmentTypes || []);
     const selectedProxy = getProxy(request, proxy);
     const isSubmittingDisabled = isSubmittingButtonDisabled(pristine, submitting);
+    const isTitleLevelRequest = createTitleLevelRequest || request?.requestLevel === REQUEST_LEVEL_TYPES.TITLE;
     const getPatronBlockModalOpenStatus = () => {
       if (isAwaitingForProxySelection) {
         return false;
@@ -1108,6 +1109,7 @@ class RequestForm extends React.Component {
                         type="checkbox"
                         label={formatMessage({ id: 'ui-requests.requests.createTitleLevelRequest' })}
                         component={Checkbox}
+                        checked={isTitleLevelRequest}
                         disabled={!this.state.titleLevelRequestsFeatureEnabled || isItemOrInstanceLoading}
                         onChange={this.handleTlrCheckboxChange}
                       />
@@ -1118,7 +1120,7 @@ class RequestForm extends React.Component {
               <AccordionStatus ref={this.accordionStatusRef}>
                 <AccordionSet>
                   {
-                    createTitleLevelRequest || (request?.requestLevel === REQUEST_LEVEL_TYPES.TITLE)
+                    isTitleLevelRequest
                       ? (
                         <Accordion
                           id="new-instance-info"


### PR DESCRIPTION
## Purpose
By some reason React Final Form incorrectly handles functionality of <Field /> component with type "checkbox". Sometimes when user opens request form at the first time "Create title level request" checkbox is not checked even if the form value of "createTitleLevelRequest" field is true. 
After some investigation, I found out that there are a few reports about this issue.
I found 2 solutions:
1. Add `checked` property directly
2. Use <Field /> with children
In my opinion, the first approach is better and I decided to use it.

## Approach
Use `checked` property that will be directly passed to `Checkbox` component.

## Refs
[UIREQ-955](https://issues.folio.org/browse/UIREQ-955)