### PR TITLE
UIREQ-972: Remove redundant ariaLabel prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Cover ItemInformation by jest/RTL tests. Refs UIREQ-949.
 * Cover InstanceInformation by jest/RTL tests. Refs UIREQ-950.
 * Fix inconsistency in RTL/Jest tests. Refs UIREQ-979.
+* Remove redundant ariaLabel prop. Refs UIREQ-972.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/ItemsDialog.js
+++ b/src/ItemsDialog.js
@@ -212,7 +212,6 @@ const ItemsDialog = ({
             : <MultiColumnList
                 id="instance-items-list"
                 interactive
-                ariaLabel={formatMessage({ id: 'ui-requests.items.instanceItems' })}
                 contentData={contentData}
                 visibleColumns={COLUMN_NAMES}
                 columnMapping={COLUMN_MAP}

--- a/src/ItemsDialog.test.js
+++ b/src/ItemsDialog.test.js
@@ -177,7 +177,6 @@ describe('ItemsDialog', () => {
         expect.objectContaining({
           id: 'instance-items-list',
           interactive: true,
-          ariaLabel: labelIds.instanceItems,
           contentData: [],
           visibleColumns: COLUMN_NAMES,
           columnMapping: COLUMN_MAP,
@@ -236,7 +235,6 @@ describe('ItemsDialog', () => {
           {
             id: 'instance-items-list',
             interactive: true,
-            ariaLabel: labelIds.instanceItems,
             contentData: [{
               id: '2',
               status: {
@@ -397,7 +395,6 @@ describe('ItemsDialog', () => {
             {
               id: 'instance-items-list',
               interactive: true,
-              ariaLabel: labelIds.instanceItems,
               contentData: [],
               visibleColumns: COLUMN_NAMES,
               columnMapping: COLUMN_MAP,


### PR DESCRIPTION
## Purpose
When a user opens the request form to create or edit a request we can see a console error related to the missing param for `formatMessage`.
In our case, we had an unnecessary `ariaLabel` attribute which contains the result of execution of `formatMessage`.
Currently `MultiColumnList` component does not support `ariaLabel` property.

## Approach
I have removed `ariaLabel` attribute which is unnecessary for `MultiColumnList` component and as a result I removed `formatMessage({ id: 'ui-requests.items.instanceItems' })` that does not contain the required `title` param.

## Refs
[UIREQ-972](https://issues.folio.org/browse/UIREQ-972)