### PR TITLE
UIREQ-951: Cover RequestInformation by jest/RTL tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Create Jest/RTL test for PickupServicePointFilter.js. Refs UIREQ-939.
 * Jest/RTL tests cleanup. Refs UIREQ-988.
 * Jest/RTL tests cleanup of RequestsRoute.js file. Refs UIREQ-991.
+* Cover RequestInformation by jest/RTL tests. Refs UIREQ-951.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/components/RequestInformation/RequestInformation.test.js
+++ b/src/components/RequestInformation/RequestInformation.test.js
@@ -39,8 +39,8 @@ const labelIds = {
   requestStatus: 'ui-requests.status',
   patronComment: 'ui-requests.patronComments',
   requestPosition: 'ui-requests.position',
-  noRequestTypesAvailable: 'ui-requests.noRequestTypesAvailable',
   holdShelfExpirationDate: 'ui-requests.holdShelfExpirationDate',
+  noRequestTypesAvailable: 'ui-requests.noRequestTypesAvailable',
 };
 const testIds = {
   requestTypeDropDown: 'requestTypeDropDown',


### PR DESCRIPTION
## Purpose
Improve code coverage of RequestInformation.js file

## Refs
[UIREQ-951](https://issues.folio.org/browse/UIREQ-951)