### PR TITLE
UIREQ-977: Ensure Only Available Service Points Display When Placing a New Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * Remove bigtest tests and associated dependencies. Refs UIREQ-999.
 * Update Node.js to v18 in GitHub Actions. Refs UIREQ-1000.
 * Implementation of receiving available request types. Refs UIREQ-971.
+* Ensure Only Available Service Points Display When Placing a New Request. Refs UIREQ-977.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "subPermissions": [
           "circulation.requests.queue.collection.get",
           "circulation.requests.queue.reorder.collection.post",
+          "circulation.requests.allowed-service-points.get",
           "circulation.rules.request-policy.get"
         ]
       },
@@ -113,6 +114,7 @@
           "ui-requests.view",
           "automated-patron-blocks.collection.get",
           "circulation.requests.item.post",
+          "circulation.requests.allowed-service-points.get",
           "circulation-storage.requests.item.post",
           "circulation-storage.request-preferences.collection.get",
           "circulation.pick-slips.get",
@@ -126,6 +128,7 @@
         "subPermissions": [
           "ui-requests.view",
           "circulation.requests.item.put",
+          "circulation.requests.allowed-service-points.get",
           "circulation-storage.requests.collection.delete",
           "circulation-storage.requests.item.put",
           "circulation-storage.requests.item.delete",

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -46,6 +46,7 @@ import {
   InstanceInformation,
   RequestInformation,
   RequesterInformation,
+  FulfilmentPreference,
 } from './components';
 import ItemsDialog from './ItemsDialog';
 import {
@@ -58,6 +59,7 @@ import {
   REQUEST_FORM_FIELD_NAMES,
   DEFAULT_REQUEST_TYPE_VALUE,
   requestTypeOptionMap,
+  REQUEST_LAYERS,
 } from './constants';
 import {
   handleKeyCommand,
@@ -74,7 +76,7 @@ import {
   getProxy,
   isSubmittingButtonDisabled,
   isFormEditing,
-  resetRequestTypeState,
+  resetFieldState,
 } from './utils';
 
 import css from './requests.css';
@@ -83,11 +85,10 @@ export const ID_TYPE_MAP = {
   ITEM_ID: 'itemId',
   INSTANCE_ID: 'instanceId',
 };
-
 export const getResourceTypeId = (isTitleLevelRequest) => (isTitleLevelRequest ? ID_TYPE_MAP.INSTANCE_ID : ID_TYPE_MAP.ITEM_ID);
-
+export const isTLR = (createTitleLevelRequest, requestLevel) => (createTitleLevelRequest || requestLevel === REQUEST_LEVEL_TYPES.TITLE);
 export const getRequestInformation = (values, selectedInstance, selectedItem, request) => {
-  const isTitleLevelRequest = values.createTitleLevelRequest || request?.requestLevel === REQUEST_LEVEL_TYPES.TITLE;
+  const isTitleLevelRequest = isTLR(values.createTitleLevelRequest, request?.requestLevel);
   const selectedResource = isTitleLevelRequest ? selectedInstance : selectedItem;
 
   return {
@@ -192,10 +193,11 @@ class RequestForm extends React.Component {
       isItemOrInstanceLoading: false,
       isItemsDialogOpen: false,
       isItemIdRequest: this.isItemIdProvided(),
-      requestTypeOptions: [],
+      requestTypes: {},
       isRequestTypesReceived: false,
       isRequestTypeLoading: false,
       isRequestTypesForDuplicate: false,
+      isRequestTypesForEditing: false,
     };
 
     this.connectedCancelRequestDialog = props.stripes.connect(CancelRequestDialog);
@@ -232,10 +234,12 @@ class RequestForm extends React.Component {
   componentDidUpdate(prevProps) {
     const {
       isRequestTypesForDuplicate,
+      isRequestTypesForEditing,
     } = this.state;
     const {
       initialValues,
       request,
+      values,
       parentResources,
       query,
       selectedItem,
@@ -295,6 +299,20 @@ class RequestForm extends React.Component {
         isRequestTypesForDuplicate: true,
       });
       this.getAvailableRequestTypes(selectedUser);
+    }
+
+    if (query?.layer === REQUEST_LAYERS.EDIT &&
+      !isRequestTypesForEditing
+    ) {
+      this.setState({
+        isRequestTypesForEditing: true,
+      });
+
+      const isTitleLevelRequest = isTLR(values.createTitleLevelRequest, request.requestLevel);
+      const resourceTypeId = getResourceTypeId(isTitleLevelRequest);
+      const resourceId = isTitleLevelRequest ? request.instanceId : request.itemId;
+
+      this.findRequestTypes(resourceId, request.requester.id || request.requesterId, resourceTypeId);
     }
 
     if (prevQuery.userBarcode !== query.userBarcode) {
@@ -411,7 +429,7 @@ class RequestForm extends React.Component {
     if (selectedResource?.id && user?.id) {
       const resourceTypeId = getResourceTypeId(isTitleLevelRequest);
 
-      this.findRequestTypes(selectedResource, user, resourceTypeId);
+      this.findRequestTypes(selectedResource.id, user.id, resourceTypeId);
     }
   }
 
@@ -434,7 +452,7 @@ class RequestForm extends React.Component {
       onSetSelectedUser(selectedUser);
       this.setState({
         proxy,
-        requestTypeOptions: [],
+        requestTypes: {},
         isRequestTypesReceived: false,
       });
       form.change(REQUEST_FORM_FIELD_NAMES.REQUESTER_ID, proxy.id);
@@ -501,7 +519,7 @@ class RequestForm extends React.Component {
     } else {
       this.setState({
         proxy: null,
-        requestTypeOptions: [],
+        requestTypes: {},
         isRequestTypesReceived: false,
       });
       form.change(REQUEST_FORM_FIELD_NAMES.PICKUP_SERVICE_POINT_ID, undefined);
@@ -640,33 +658,30 @@ class RequestForm extends React.Component {
     }
   }
 
-  findRequestTypes = (resource, requester, resourceType) => {
+  findRequestTypes = (resourceId, requesterId, resourceType) => {
     const {
       findResource,
       form,
+      request,
     } = this.props;
+    const isEditForm = isFormEditing(request);
+
+    if (!isEditForm) {
+      form.change(REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE, DEFAULT_REQUEST_TYPE_VALUE);
+    }
 
     this.setState({
       isRequestTypeLoading: true,
     });
 
     findResource(RESOURCE_TYPES.REQUEST_TYPES, {
-      [resourceType]: resource.id,
-      requesterId: requester.id,
+      [resourceType]: resourceId,
+      requesterId: requesterId,
     })
       .then(requestTypes => {
         if (!isEmpty(requestTypes)) {
-          form.change(REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE, DEFAULT_REQUEST_TYPE_VALUE);
-
-          const requestTypeOptions = Object.keys(requestTypes).map(requestType => {
-            return {
-              id: requestTypeOptionMap[requestType],
-              value: requestType,
-            };
-          });
-
           this.setState({
-            requestTypeOptions,
+            requestTypes,
             isRequestTypesReceived: true,
           }, this.triggerRequestTypeValidation);
         } else {
@@ -674,8 +689,6 @@ class RequestForm extends React.Component {
             isRequestTypesReceived: true,
           }, this.triggerRequestTypeValidation);
         }
-
-        return resource;
       })
       .finally(() => {
         this.setState({
@@ -748,7 +761,7 @@ class RequestForm extends React.Component {
         });
     } else {
       this.setState({
-        requestTypeOptions: [],
+        requestTypes: {},
         isRequestTypesReceived: false,
       });
 
@@ -768,7 +781,7 @@ class RequestForm extends React.Component {
 
           form.change(REQUEST_FORM_FIELD_NAMES.ITEM_ID, item.id);
           form.change(REQUEST_FORM_FIELD_NAMES.ITEM_BARCODE, item.barcode);
-          resetRequestTypeState(form);
+          resetFieldState(form, REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE);
 
           // Setting state here is redundant with what follows, but it lets us
           // display the matched item as quickly as possible, without waiting for
@@ -782,7 +795,7 @@ class RequestForm extends React.Component {
         })
         .then(item => {
           if (item && selectedUser?.id) {
-            this.findRequestTypes(item, selectedUser, ID_TYPE_MAP.ITEM_ID);
+            this.findRequestTypes(item.id, selectedUser.id, ID_TYPE_MAP.ITEM_ID);
           }
 
           return item;
@@ -834,7 +847,7 @@ class RequestForm extends React.Component {
         });
     } else {
       this.setState({
-        requestTypeOptions: [],
+        requestTypes: {},
         isRequestTypesReceived: false,
       });
 
@@ -852,7 +865,7 @@ class RequestForm extends React.Component {
 
           form.change(REQUEST_FORM_FIELD_NAMES.INSTANCE_ID, instance.id);
           form.change(REQUEST_FORM_FIELD_NAMES.INSTANCE_HRID, instance.hrid);
-          resetRequestTypeState(form);
+          resetFieldState(form, REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE);
 
           onSetSelectedInstance(instance);
           this.setState({
@@ -863,7 +876,7 @@ class RequestForm extends React.Component {
         })
         .then(instance => {
           if (instance && selectedUser?.id) {
-            this.findRequestTypes(instance, selectedUser, ID_TYPE_MAP.INSTANCE_ID);
+            this.findRequestTypes(instance.id, selectedUser.id, ID_TYPE_MAP.INSTANCE_ID);
           }
 
           return instance;
@@ -976,7 +989,7 @@ class RequestForm extends React.Component {
     if (isCreateTlr) {
       onSetSelectedItem(undefined);
       this.setState({
-        requestTypeOptions: [],
+        requestTypes: {},
         isRequestTypesReceived: false,
       });
 
@@ -985,14 +998,14 @@ class RequestForm extends React.Component {
       }
     } else if (selectedInstance) {
       form.change(REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE, DEFAULT_REQUEST_TYPE_VALUE);
-      resetRequestTypeState(form);
+      resetFieldState(form, REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE);
       this.setState({
         isItemsDialogOpen: true,
       });
     } else {
       onSetSelectedInstance(undefined);
       this.setState({
-        requestTypeOptions: [],
+        requestTypes: {},
         isRequestTypesReceived: false,
       });
     }
@@ -1006,7 +1019,7 @@ class RequestForm extends React.Component {
     onSetSelectedInstance(undefined);
     this.setState({
       isItemsDialogOpen: false,
-      requestTypeOptions: [],
+      requestTypes: {},
       isRequestTypesReceived: false,
       isItemIdRequest: false,
     }, this.triggerItemBarcodeValidation);
@@ -1021,7 +1034,7 @@ class RequestForm extends React.Component {
     onSetSelectedInstance(undefined);
     this.setState({
       isItemsDialogOpen: false,
-      requestTypeOptions: [],
+      requestTypes: {},
     });
 
     if (item?.barcode) {
@@ -1090,7 +1103,7 @@ class RequestForm extends React.Component {
       isAwaitingForProxySelection,
       isItemsDialogOpen,
       proxy,
-      requestTypeOptions,
+      requestTypes,
       hasDelivery,
       defaultDeliveryAddressTypeId,
       isItemIdRequest,
@@ -1144,6 +1157,13 @@ class RequestForm extends React.Component {
       else if (keepEditBtn) keepEditBtn.click();
       else onCancel();
     };
+    const isFulfilmentPreferenceVisible = (values.requestType || isEditForm) && !isRequestTypeLoading && isRequestTypesReceived;
+    const requestTypeOptions = Object.keys(requestTypes).map(requestType => {
+      return {
+        id: requestTypeOptionMap[requestType],
+        value: requestType,
+      };
+    });
 
     return (
       <Paneset isRoot>
@@ -1284,16 +1304,9 @@ class RequestForm extends React.Component {
                     <div id="section-requester-info">
                       <RequesterInformation
                         {...this.props}
-                        defaultDeliveryAddressTypeId={defaultDeliveryAddressTypeId}
                         patronGroup={patronGroup}
-                        deliverySelected={deliverySelected}
-                        addressDetail={addressDetail}
-                        deliveryLocations={deliveryLocations}
-                        fulfillmentTypeOptions={fulfillmentTypeOptions}
                         selectedProxy={selectedProxy}
                         isLoading={isUserLoading}
-                        changeDeliveryAddress={this.changeDeliveryAddress}
-                        onChangeAddress={this.onChangeAddress}
                         onSelectProxy={this.onSelectProxy}
                         handleCloseProxy={this.handleCloseProxy}
                         findUser={this.findUser}
@@ -1317,7 +1330,24 @@ class RequestForm extends React.Component {
                       isSelectedItem={Boolean(selectedItem?.id)}
                       isSelectedUser={Boolean(selectedUser?.id)}
                       values={values}
+                      form={form}
                     />
+                    {isFulfilmentPreferenceVisible &&
+                      <FulfilmentPreference
+                        isEditForm={isEditForm}
+                        requestTypes={requestTypes}
+                        deliverySelected={deliverySelected}
+                        deliveryAddress={addressDetail}
+                        onChangeAddress={this.onChangeAddress}
+                        changeDeliveryAddress={this.changeDeliveryAddress}
+                        deliveryLocations={deliveryLocations}
+                        fulfillmentTypeOptions={fulfillmentTypeOptions}
+                        defaultDeliveryAddressTypeId={defaultDeliveryAddressTypeId}
+                        request={request}
+                        form={form}
+                        values={values}
+                      />
+                    }
                   </Accordion>
                 </AccordionSet>
               </AccordionStatus>

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -676,7 +676,7 @@ class RequestForm extends React.Component {
 
     findResource(RESOURCE_TYPES.REQUEST_TYPES, {
       [resourceType]: resourceId,
-      requesterId: requesterId,
+      requesterId,
     })
       .then(requestTypes => {
         if (!isEmpty(requestTypes)) {

--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -521,7 +521,7 @@ describe('RequestForm', () => {
       );
     });
 
-    it('should trigger "FulfilmentPreference" with correct arguments', () => {
+    it('should trigger "FulfilmentPreference"', () => {
       expect(FulfilmentPreference).toHaveBeenCalled();
     });
 

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -3,15 +3,11 @@ import PropTypes from 'prop-types';
 import {
   FormattedMessage,
 } from 'react-intl';
-import {
-  Field,
-} from 'react-final-form';
 
 import {
   Col,
   KeyValue,
   Row,
-  Select,
 } from '@folio/stripes/components';
 import { ProxyManager } from '@folio/stripes/smart-components';
 
@@ -19,44 +15,21 @@ import {
   getFullName,
   userHighlightBox,
 } from './utils';
-import {
-  REQUEST_FORM_FIELD_NAMES,
-  requestStatuses,
-} from './constants';
-
-const {
-  AWAITING_DELIVERY,
-  AWAITING_PICKUP,
-} = requestStatuses;
 
 class UserForm extends React.Component {
   static propTypes = {
-    deliveryAddress: PropTypes.node,
-    deliveryLocations: PropTypes.arrayOf(PropTypes.object),
-    fulfillmentTypeOptions: PropTypes.arrayOf(PropTypes.object),
-    fulfillmentPreference: PropTypes.string,
-    onChangeAddress: PropTypes.func,
-    onChangeFulfillment: PropTypes.func,
     onCloseProxy: PropTypes.func.isRequired,
     onSelectProxy: PropTypes.func.isRequired,
     patronGroup: PropTypes.string,
     proxy: PropTypes.object,
     stripes: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,
-    deliverySelected: PropTypes.bool,
-    servicePoints: PropTypes.arrayOf(PropTypes.object),
     request: PropTypes.object,
   };
 
   static defaultProps = {
-    deliveryAddress: '',
-    deliveryLocations: [],
-    fulfillmentTypeOptions: [],
-    onChangeAddress: () => {},
-    onChangeFulfillment: () => {},
     patronGroup: '',
     proxy: {},
-    deliverySelected: false,
   };
 
   constructor(props) {
@@ -64,63 +37,11 @@ class UserForm extends React.Component {
     this.connectedProxyManager = props.stripes.connect(ProxyManager);
   }
 
-  requireServicePoint = value => (value ? undefined : <FormattedMessage id="ui-requests.errors.selectItem" />);
-  requireDeliveryAddress = value => (value ? undefined : <FormattedMessage id="ui-requests.errors.selectItem" />);
-
-  renderDeliveryAddressSelect() {
-    const {
-      onChangeAddress,
-      deliveryLocations,
-    } = this.props;
-
-    return (
-      <Field
-        name="deliveryAddressTypeId"
-        label={<FormattedMessage id="ui-requests.deliveryAddress" />}
-        component={Select}
-        fullWidth
-        onChange={onChangeAddress}
-        required
-        validate={this.requireDeliveryAddress}
-      >
-        {deliveryLocations.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
-      </Field>
-    );
-  }
-
-  renderPickupServicePointSelect() {
-    const {
-      servicePoints,
-    } = this.props;
-
-    return (
-      <Field
-        name="pickupServicePointId"
-        label={<FormattedMessage id="ui-requests.pickupServicePoint.name" />}
-        component={Select}
-        fullWidth
-        required
-        validate={this.requireServicePoint}
-      >
-        <FormattedMessage id="ui-requests.actions.selectPickupSp">
-          {optionLabel => <option value="">{optionLabel}</option>}
-        </FormattedMessage>
-        {servicePoints.map(({ id, name }) => <option key={id} value={id}>{name}</option>)}
-      </Field>
-    );
-  }
-
   render() {
     const {
       user,
       proxy,
       patronGroup,
-      deliveryAddress,
-      deliveryLocations,
-      deliverySelected,
-      fulfillmentPreference,
-      fulfillmentTypeOptions,
-      onChangeFulfillment,
       request,
     } = this.props;
 
@@ -128,7 +49,6 @@ class UserForm extends React.Component {
     const name = getFullName(user);
     const barcode = user.barcode;
     const isEditable = !!request;
-    const shouldDisableFulfillmentPreferenceField = isEditable && (request.status === AWAITING_PICKUP || request.status === AWAITING_DELIVERY);
 
     let proxyName;
     let proxyBarcode;
@@ -154,42 +74,7 @@ class UserForm extends React.Component {
           <Col xs={4}>
             <KeyValue label={<FormattedMessage id="ui-requests.requester.patronGroup.group" />} value={patronGroup || '-'} />
           </Col>
-          <Col xs={4}>
-            <Field
-              name={REQUEST_FORM_FIELD_NAMES.FULFILLMENT_PREFERENCE}
-              label={<FormattedMessage id="ui-requests.requester.fulfillmentPref" />}
-              component={Select}
-              fullWidth
-              value={fulfillmentPreference}
-              onChange={onChangeFulfillment}
-              disabled={shouldDisableFulfillmentPreferenceField}
-              data-test-fulfillment-preference-filed
-            >
-              {fulfillmentTypeOptions.map(({ labelTranslationPath, value }) => (
-                <FormattedMessage key={value} id={labelTranslationPath}>
-                  {translatedLabel => (
-                    <option value={value}>
-                      {translatedLabel}
-                    </option>
-                  )}
-                </FormattedMessage>
-              ))}
-            </Field>
-          </Col>
-          <Col xs={4}>
-            {
-              (!deliverySelected && this.renderPickupServicePointSelect()) ||
-              (deliveryLocations && this.renderDeliveryAddressSelect())
-            }
-          </Col>
         </Row>
-
-        { deliverySelected &&
-          <Row>
-            <Col xs={4} xsOffset={8}>
-              {deliveryAddress}
-            </Col>
-          </Row> }
 
         {proxySection}
 

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -55,6 +55,7 @@ import {
   requestTypesTranslations,
   requestStatusesTranslations,
   errorMessageLabels,
+  REQUEST_LAYERS,
 } from './constants';
 import {
   toUserAddress,
@@ -371,7 +372,7 @@ class ViewRequest extends React.Component {
 
     const query = location.search ? queryString.parse(location.search) : {};
 
-    if (query.layer === 'edit') {
+    if (query.layer === REQUEST_LAYERS.EDIT) {
       // The hold shelf expiration date is stored as a single value (e.g., 20201101T23:59:00-0400),
       // but it's exposed in the UI as separate date- and time-picker components.
       let momentDate;

--- a/src/components/FulfilmentPreference/FulfilmentPreference.js
+++ b/src/components/FulfilmentPreference/FulfilmentPreference.js
@@ -53,7 +53,7 @@ const FulfilmentPreference = ({
         {deliveryLocations.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
       </Field>
     );
-  }
+  };
   const renderPickupServicePoint = () => {
     const selectedRequestType = isEditForm ? request.requestType : values.requestType;
     const allowedServicePoints = requestTypes[selectedRequestType] || [];
@@ -90,7 +90,7 @@ const FulfilmentPreference = ({
         }
       </Field>
     );
-  }
+  };
   const onChangeFulfillment = (e) => {
     const selectedFulfillmentPreference = e.target.value;
     const isDelivery = isDeliverySelected(selectedFulfillmentPreference);
@@ -98,7 +98,7 @@ const FulfilmentPreference = ({
 
     form.change(REQUEST_FORM_FIELD_NAMES.FULFILLMENT_PREFERENCE, selectedFulfillmentPreference);
     changeDeliveryAddress(isDelivery, selectedAddressTypeId);
-  }
+  };
   const isDisabledFulfillmentPreference = !!request && (request.status === AWAITING_PICKUP || request.status === AWAITING_DELIVERY);
 
 

--- a/src/components/FulfilmentPreference/FulfilmentPreference.js
+++ b/src/components/FulfilmentPreference/FulfilmentPreference.js
@@ -1,0 +1,177 @@
+import PropTypes from 'prop-types';
+import { Field } from 'react-final-form';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Col,
+  Row,
+  Select,
+} from '@folio/stripes-components';
+
+import {
+  REQUEST_FORM_FIELD_NAMES,
+  requestStatuses,
+} from '../../constants';
+import {
+  getSelectedAddressTypeId,
+  isDeliverySelected,
+} from '../../utils';
+
+export const validate = value => (value ? undefined : <FormattedMessage id="ui-requests.errors.selectItem" />);
+
+const {
+  AWAITING_DELIVERY,
+  AWAITING_PICKUP,
+} = requestStatuses;
+
+const FulfilmentPreference = ({
+  isEditForm,
+  deliverySelected,
+  deliveryAddress,
+  onChangeAddress,
+  deliveryLocations,
+  fulfillmentTypeOptions,
+  defaultDeliveryAddressTypeId,
+  changeDeliveryAddress,
+  requestTypes,
+  request,
+  form,
+  values,
+}) => {
+  const { fulfillmentPreference } = request || {};
+  const renderDeliveryAddress = () => {
+    return (
+      <Field
+        name="deliveryAddressTypeId"
+        label={<FormattedMessage id="ui-requests.deliveryAddress" />}
+        component={Select}
+        fullWidth
+        onChange={onChangeAddress}
+        required
+        validate={validate}
+      >
+        {deliveryLocations.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
+      </Field>
+    );
+  }
+  const renderPickupServicePoint = () => {
+    const selectedRequestType = isEditForm ? request.requestType : values.requestType;
+    const allowedServicePoints = requestTypes[selectedRequestType] || [];
+
+    return (
+      <Field
+        data-testid="pickupServicePoint"
+        name="pickupServicePointId"
+        validateFields={[]}
+        validate={validate}
+      >
+        {
+          ({
+            input,
+            meta
+          }) => {
+            const error = meta.touched && meta.error;
+
+            return (
+              <Select
+                {...input}
+                label={<FormattedMessage id="ui-requests.pickupServicePoint.name" />}
+                error={error}
+                fullWidth
+                required
+              >
+                <FormattedMessage id="ui-requests.actions.selectPickupSp">
+                  {optionLabel => <option value="">{optionLabel}</option>}
+                </FormattedMessage>
+                {allowedServicePoints.map(({ id, name }) => <option key={id} value={id}>{name}</option>)}
+              </Select>
+            );
+          }
+        }
+      </Field>
+    );
+  }
+  const onChangeFulfillment = (e) => {
+    const selectedFulfillmentPreference = e.target.value;
+    const isDelivery = isDeliverySelected(selectedFulfillmentPreference);
+    const selectedAddressTypeId = getSelectedAddressTypeId(isDelivery, defaultDeliveryAddressTypeId);
+
+    form.change(REQUEST_FORM_FIELD_NAMES.FULFILLMENT_PREFERENCE, selectedFulfillmentPreference);
+    changeDeliveryAddress(isDelivery, selectedAddressTypeId);
+  }
+  const isDisabledFulfillmentPreference = !!request && (request.status === AWAITING_PICKUP || request.status === AWAITING_DELIVERY);
+
+
+  return (
+    <>
+      <Row>
+        <Col
+          xsOffset={4}
+          xs={4}
+        >
+          <Field
+            data-testid="fulfilmentPreference"
+            name={REQUEST_FORM_FIELD_NAMES.FULFILLMENT_PREFERENCE}
+            label={<FormattedMessage id="ui-requests.requester.fulfillmentPref" />}
+            component={Select}
+            value={fulfillmentPreference}
+            onChange={onChangeFulfillment}
+            disabled={isDisabledFulfillmentPreference}
+            data-test-fulfillment-preference-filed
+            fullWidth
+          >
+            {fulfillmentTypeOptions.map(({ labelTranslationPath, value }) => (
+              <FormattedMessage key={value} id={labelTranslationPath}>
+                {translatedLabel => (
+                  <option value={value}>
+                    {translatedLabel}
+                  </option>
+                )}
+              </FormattedMessage>
+            ))}
+          </Field>
+        </Col>
+        <Col xs={4}>
+          {
+            (!deliverySelected && renderPickupServicePoint()) ||
+            (deliveryLocations && renderDeliveryAddress())
+          }
+        </Col>
+      </Row>
+      {deliverySelected &&
+        <Row>
+          <Col
+            xs={4}
+            xsOffset={8}
+          >
+            {deliveryAddress}
+          </Col>
+        </Row>
+      }
+    </>
+  );
+};
+
+FulfilmentPreference.propTypes = {
+  isEditForm: PropTypes.bool.isRequired,
+  defaultDeliveryAddressTypeId: PropTypes.string.isRequired,
+  changeDeliveryAddress: PropTypes.func.isRequired,
+  requestTypes: PropTypes.object.isRequired,
+  request: PropTypes.object.isRequired,
+  form: PropTypes.object.isRequired,
+  values: PropTypes.object.isRequired,
+  onChangeAddress: PropTypes.func.isRequired,
+  deliveryAddress: PropTypes.node,
+  deliveryLocations: PropTypes.arrayOf(PropTypes.object),
+  fulfillmentTypeOptions: PropTypes.arrayOf(PropTypes.object),
+  deliverySelected: PropTypes.bool,
+};
+
+FulfilmentPreference.defaultProps = {
+  deliveryAddress: '',
+  deliveryLocations: [],
+  fulfillmentTypeOptions: [],
+  deliverySelected: false,
+};
+
+export default FulfilmentPreference;

--- a/src/components/FulfilmentPreference/FulfilmentPreference.js
+++ b/src/components/FulfilmentPreference/FulfilmentPreference.js
@@ -6,7 +6,7 @@ import {
   Col,
   Row,
   Select,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import {
   REQUEST_FORM_FIELD_NAMES,

--- a/src/components/FulfilmentPreference/FulfilmentPreference.test.js
+++ b/src/components/FulfilmentPreference/FulfilmentPreference.test.js
@@ -1,0 +1,222 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { FormattedMessage } from 'react-intl';
+
+import FulfilmentPreference, {
+  validate,
+} from './FulfilmentPreference';
+
+jest.mock('../../utils', () => ({
+  getSelectedAddressTypeId: jest.fn(),
+  isDeliverySelected: jest.fn(),
+}));
+
+const basicProps = {
+  isEditForm: false,
+  deliverySelected: false,
+  deliveryAddress: 'deliveryAddress',
+  onChangeAddress: jest.fn(),
+  deliveryLocations: [],
+  fulfillmentTypeOptions: [
+    {
+      labelTranslationPath: 'labelTranslationPath',
+      value: 'value',
+    }
+  ],
+  defaultDeliveryAddressTypeId: 'defaultId',
+  changeDeliveryAddress: jest.fn(),
+  requestTypes: {
+    Hold: [
+      {
+        id: 'spId',
+        name: 'spName',
+      }
+    ],
+  },
+  request: {},
+  values: {
+    requestType: 'Hold',
+  },
+  form: {
+    change: jest.fn(),
+  },
+};
+const labelIds = {
+  fulfilmentPreference: 'ui-requests.requester.fulfillmentPref',
+  deliveryAddress: 'ui-requests.deliveryAddress',
+  pickupServicePoint: 'ui-requests.pickupServicePoint.name',
+  selectItemError: 'ui-requests.errors.selectItem',
+};
+const testIds = {
+  fulfilmentPreference: 'fulfilmentPreference',
+  pickupServicePoint: 'pickupServicePoint',
+};
+
+describe('FulfilmentPreference', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    cleanup();
+  });
+
+  describe('when "deliverySelected" is false', () => {
+    beforeEach(() => {
+      render(
+        <FulfilmentPreference
+          {...basicProps}
+        />
+      );
+    });
+
+    it('should render fulfilment preference label', () => {
+      const fulfilmentPreferenceLabel = screen.getByText(labelIds.fulfilmentPreference);
+
+      expect(fulfilmentPreferenceLabel).toBeInTheDocument();
+    });
+
+    it('should render pickup service point label', () => {
+      const pickupServicePointLabel = screen.getByText(labelIds.pickupServicePoint);
+
+      expect(pickupServicePointLabel).toBeInTheDocument();
+    });
+
+    it('should not render delivery address label', () => {
+      const deliveryAddressLabel = screen.queryByText(labelIds.deliveryAddress);
+
+      expect(deliveryAddressLabel).not.toBeInTheDocument();
+    });
+
+    it('should not render delivery address', () => {
+      const deliveryAddress = screen.queryByText(basicProps.deliveryAddress);
+
+      expect(deliveryAddress).not.toBeInTheDocument();
+    });
+
+    describe('fulfilment preference changing', () => {
+      beforeEach(() => {
+        const event = {
+          target: {
+            value: 'test',
+          },
+        };
+        const fulfilmentPreferenceSelect = screen.getByTestId(testIds.fulfilmentPreference);
+
+        fireEvent.change(fulfilmentPreferenceSelect, event);
+      });
+
+      it('should trigger "form.change"', () => {
+        expect(basicProps.form.change).toHaveBeenCalled();
+      });
+
+      it('should trigger "changeDeliveryAddress"', () => {
+        expect(basicProps.changeDeliveryAddress).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when "deliverySelected" is true', () => {
+    const props = {
+      ...basicProps,
+      deliverySelected: true,
+      deliveryLocations: [
+        {
+          value: 'Home',
+          label: 'Home',
+        }
+      ],
+    };
+
+    beforeEach(() => {
+      render(
+        <FulfilmentPreference
+          {...props}
+        />
+      );
+    });
+
+    it('should render delivery address', () => {
+      const deliveryAddress = screen.getByText(props.deliveryAddress);
+
+      expect(deliveryAddress).toBeVisible();
+    });
+
+    it('should render delivery address label', () => {
+      const deliveryAddressLabel = screen.getByText(labelIds.deliveryAddress);
+
+      expect(deliveryAddressLabel).toBeInTheDocument();
+    });
+
+    it('should not render pickup service point label', () => {
+      const pickupServicePointLabel = screen.queryByText(labelIds.pickupServicePoint);
+
+      expect(pickupServicePointLabel).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when "isEditForm" is false', () => {
+    it('should render request types for edit form', () => {
+      render(
+        <FulfilmentPreference
+          {...basicProps}
+        />
+      );
+
+      const servicePointName = screen.getByText(basicProps.requestTypes.Hold[0].name);
+
+      expect(servicePointName).toBeInTheDocument();
+    });
+  });
+
+  describe('when "isEditForm" is true', () => {
+    it('should render request types for edit form', () => {
+      const props = {
+        ...basicProps,
+        isEditForm: true,
+        values: {},
+        request: {
+          requestType: 'Recall',
+        },
+        requestTypes: {
+          Recall: [
+            {
+              id: 'testId',
+              name: 'testName',
+            }
+          ],
+        },
+      };
+
+      render(
+        <FulfilmentPreference
+          {...props}
+        />
+      );
+
+      const servicePointName = screen.getByText(props.requestTypes.Recall[0].name);
+
+      expect(servicePointName).toBeInTheDocument();
+    });
+  });
+
+  describe('validate', () => {
+    it('should return undefined', () => {
+      expect(validate('test')).toBeUndefined();
+    });
+
+    it('should trigger "FormattedMessage" with correct props', () => {
+      const expectedProps = {
+        id: labelIds.selectItemError,
+      };
+
+      render(validate(''));
+
+      expect(FormattedMessage).toHaveBeenCalledWith(expectedProps, {});
+    });
+  });
+});

--- a/src/components/FulfilmentPreference/index.js
+++ b/src/components/FulfilmentPreference/index.js
@@ -1,0 +1,1 @@
+export { default } from './FulfilmentPreference';

--- a/src/components/RequestInformation/RequestInformation.js
+++ b/src/components/RequestInformation/RequestInformation.js
@@ -25,7 +25,10 @@ import {
   REQUEST_TYPE_ERRORS,
 } from '../../constants';
 import PositionLink from '../../PositionLink';
-import { isFormEditing } from '../../utils';
+import {
+  isFormEditing,
+  resetFieldState,
+} from '../../utils';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -47,6 +50,7 @@ const RequestInformation = ({
   isRequestTypesReceived,
   isRequestTypeLoading,
   values,
+  form,
 }) => {
   const isEditForm = isFormEditing(request);
   const holdShelfExpireDate = get(request, ['status'], '') === requestStatuses.AWAITING_PICKUP
@@ -70,6 +74,11 @@ const RequestInformation = ({
 
     return undefined;
   }, [isItemOrTitleSelected, isSelectedUser, requestTypeOptions, isTitleLevelRequest, isRequestTypesReceived]);
+  const changeRequestType = (input) => (e) => {
+    form.change(REQUEST_FORM_FIELD_NAMES.PICKUP_SERVICE_POINT_ID, undefined);
+    resetFieldState(form, REQUEST_FORM_FIELD_NAMES.PICKUP_SERVICE_POINT_ID);
+    input.onChange(e);
+  };
 
   return (
     <>
@@ -111,6 +120,7 @@ const RequestInformation = ({
                         label={<FormattedMessage id="ui-requests.requestType" />}
                         disabled={isRequestTypeDisabled}
                         error={error}
+                        onChange={changeRequestType(input)}
                         fullWidth
                         required
                       >
@@ -243,9 +253,10 @@ RequestInformation.propTypes = {
   isSelectedUser: PropTypes.bool.isRequired,
   isRequestTypesReceived: PropTypes.bool.isRequired,
   isRequestTypeLoading: PropTypes.bool.isRequired,
+  request: PropTypes.object.isRequired,
+  values: PropTypes.object.isRequired,
+  form: PropTypes.object.isRequired,
   requestTypeOptions: PropTypes.arrayOf(PropTypes.object),
-  request: PropTypes.object,
-  values: PropTypes.object,
 };
 
 export default RequestInformation;

--- a/src/components/RequesterInformation/RequesterInformation.js
+++ b/src/components/RequesterInformation/RequesterInformation.js
@@ -18,8 +18,6 @@ import {
 
 import UserForm from '../../UserForm';
 import {
-  getSelectedAddressTypeId,
-  isDeliverySelected,
   isFormEditing,
   memoizeValidation,
 } from '../../utils';
@@ -49,8 +47,6 @@ class RequesterInformation extends Component {
     submitting: PropTypes.bool.isRequired,
     onSetIsPatronBlocksOverridden: PropTypes.func.isRequired,
     onSetBlocked: PropTypes.func.isRequired,
-    changeDeliveryAddress: PropTypes.func.isRequired,
-    onChangeAddress: PropTypes.func.isRequired,
     onSelectProxy: PropTypes.func.isRequired,
     handleCloseProxy: PropTypes.func.isRequired,
     findUser: PropTypes.func.isRequired,
@@ -61,11 +57,6 @@ class RequesterInformation extends Component {
     optionLists: PropTypes.object,
     selectedProxy: PropTypes.object,
     patronGroup: PropTypes.object,
-    defaultDeliveryAddressTypeId: PropTypes.string,
-    deliverySelected: PropTypes.bool,
-    addressDetail: PropTypes.element,
-    deliveryLocations: PropTypes.arrayOf(PropTypes.object),
-    fulfillmentTypeOptions: PropTypes.arrayOf(PropTypes.object),
   };
 
   constructor(props) {
@@ -77,20 +68,6 @@ class RequesterInformation extends Component {
       isUserBlurred: false,
       validatedBarcode: null,
     };
-  }
-
-  onChangeFulfillment = (e) => {
-    const {
-      form,
-      defaultDeliveryAddressTypeId,
-      changeDeliveryAddress,
-    } = this.props;
-    const selectedFulfillmentPreference = e.target.value;
-    const deliverySelected = isDeliverySelected(selectedFulfillmentPreference);
-    const selectedAddressTypeId = getSelectedAddressTypeId(deliverySelected, defaultDeliveryAddressTypeId);
-
-    form.change(REQUEST_FORM_FIELD_NAMES.FULFILLMENT_PREFERENCE, selectedFulfillmentPreference);
-    changeDeliveryAddress(deliverySelected, selectedAddressTypeId);
   }
 
   validate = memoizeValidation(async (barcode) => {
@@ -229,24 +206,16 @@ class RequesterInformation extends Component {
       submitting,
       stripes,
       patronGroup,
-      deliverySelected,
-      addressDetail,
-      deliveryLocations,
-      fulfillmentTypeOptions,
-      onChangeAddress,
       selectedProxy,
       onSelectProxy,
       handleCloseProxy,
       isLoading,
-      optionLists,
     } = this.props;
     const {
       isUserClicked,
       isUserBlurred,
     } = this.state;
     const isEditForm = isFormEditing(request);
-    const { fulfillmentPreference } = request || {};
-    const isAddressSelected = values?.deliveryAddressTypeId !== undefined || values?.pickupServicePointId !== undefined;
 
     return (
       <Row>
@@ -314,21 +283,13 @@ class RequesterInformation extends Component {
               </Button>
             </Col>
           </Row>}
-          {(selectedUser?.id || request?.requester) && isAddressSelected &&
+          {(selectedUser?.id || isEditForm) &&
             <UserForm
               user={request ? request.requester : selectedUser}
               stripes={stripes}
               request={request}
               patronGroup={patronGroup?.group}
-              deliverySelected={deliverySelected}
-              fulfillmentPreference={fulfillmentPreference}
-              deliveryAddress={addressDetail}
-              deliveryLocations={deliveryLocations}
-              fulfillmentTypeOptions={fulfillmentTypeOptions}
-              onChangeAddress={onChangeAddress}
-              onChangeFulfillment={this.onChangeFulfillment}
               proxy={selectedProxy}
-              servicePoints={optionLists.servicePoints}
               onSelectProxy={onSelectProxy}
               onCloseProxy={handleCloseProxy}
             />

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -10,3 +10,4 @@ export { default as ItemInformation } from './ItemInformation';
 export { default as InstanceInformation } from './InstanceInformation';
 export { default as RequestInformation } from './RequestInformation';
 export { default as RequesterInformation } from './RequesterInformation';
+export { default as FulfilmentPreference } from './FulfilmentPreference';

--- a/src/constants.js
+++ b/src/constants.js
@@ -262,6 +262,10 @@ export const createModes = {
   DUPLICATE: 'duplicate',
 };
 
+export const REQUEST_LAYERS = {
+  EDIT: 'edit',
+};
+
 export const errorMessages = {
   REORDER_SYNC_ERROR: 'There is inconsistency between provided reordered queue and item queue.',
   DELETE_REQUEST_ERROR: 'The Request has already been closed',

--- a/src/utils.js
+++ b/src/utils.js
@@ -430,10 +430,10 @@ export const isFormEditing = (request) => {
   return !!get(request, 'id');
 };
 
-export function resetRequestTypeState(form) {
+export function resetFieldState(form, fieldName) {
   const registeredFields = form.getRegisteredFields();
 
-  if (includes(registeredFields, REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE)) {
-    form.resetFieldState(REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE);
+  if (includes(registeredFields, fieldName)) {
+    form.resetFieldState(fieldName);
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,7 +33,6 @@ import {
   REQUEST_LEVEL_TYPES,
   createModes,
   INVALID_REQUEST_HARDCODED_ID,
-  REQUEST_FORM_FIELD_NAMES,
 } from './constants';
 
 import css from './requests.css';

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -26,7 +26,7 @@ import {
   getProxy,
   isSubmittingButtonDisabled,
   isFormEditing,
-  resetRequestTypeState,
+  resetFieldState,
 } from './utils';
 
 import {
@@ -769,21 +769,22 @@ describe('convertToSlipData', () => {
   });
 });
 
-describe('resetRequestTypeState', () => {
+describe('resetFieldState', () => {
   const form = {
     getRegisteredFields: jest.fn(),
     resetFieldState: jest.fn(),
   };
+  const fieldName = 'test';
 
   afterEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
-  describe('when request type field exists', () => {
+  describe('when field exists', () => {
     beforeEach(() => {
-      form.getRegisteredFields.mockReturnValue([REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE]);
-      resetRequestTypeState(form);
+      form.getRegisteredFields.mockReturnValue([fieldName]);
+      resetFieldState(form, fieldName);
     });
 
     it('should trigger "getRegisteredFields"', () => {
@@ -791,14 +792,14 @@ describe('resetRequestTypeState', () => {
     });
 
     it('should trigger "resetFieldState" with correct argument', () => {
-      expect(form.resetFieldState).toHaveBeenCalledWith(REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE);
+      expect(form.resetFieldState).toHaveBeenCalledWith(fieldName);
     });
   });
 
-  describe('when request type field does not exist', () => {
+  describe('when field does not exist', () => {
     beforeEach(() => {
       form.getRegisteredFields.mockReturnValue([]);
-      resetRequestTypeState(form);
+      resetFieldState(form, fieldName);
     });
 
     it('should not trigger "resetFieldState"', () => {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -35,7 +35,6 @@ import {
   requestTypesMap,
   REQUEST_LEVEL_TYPES,
   fulfillmentTypeMap,
-  REQUEST_FORM_FIELD_NAMES,
 } from './constants';
 
 describe('escapeValue', () => {

--- a/test/jest/__mock__/finalFormComponents.mock.js
+++ b/test/jest/__mock__/finalFormComponents.mock.js
@@ -23,6 +23,9 @@ jest.mock('react-final-form', () => ({
         input: {
           validate,
           'data-testid': testId,
+          onChange: (e) => {
+            validate(e.target.value);
+          },
         },
       });
     }


### PR DESCRIPTION
## Purpose
Add functionality to get service points that depend on the request type.
If the request type is selected - a dropdown with service points becomes visible and contains service points that allowed for the selected request type.

## Refs 
[UIREQ-977](https://issues.folio.org/browse/UIREQ-977)