### PR TITLE
UIREQ-918: Correctly escape CQL special characters in tag API queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * *BREAKING* Upgrade React to v18. Refs UIREQ-998.
 * Create Jest/RTL test for DraggableRow.js. Refs UIREQ-940.
 * Create Jest/RTL test for ComponentToPrint.js. Refs UIREQ-931.
+* Correctly escape CQL special characters in tag API queries. Refs UIREQ-918.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/components/RequestsFilters/RequestsFiltersConfig.js
+++ b/src/components/RequestsFilters/RequestsFiltersConfig.js
@@ -2,6 +2,8 @@ import {
   requestFilterTypes,
 } from '../../constants';
 
+export const escapingForSpecialCharactersWhichCanBreakCQL = (string = '') => string.replace(/[\\"?*]/g, '\\$&');
+
 export default [
   {
     name: 'requestType',
@@ -29,9 +31,10 @@ export default [
     operator: '==',
     parse: (value) => {
       if (Array.isArray(value)) {
-        return `tags.tagList==(${value.map(v => `*"*${v}*"*`)
-          .join(' or ')})`;
-      } else return `tags.tagList==*"*${value}*"*`;
+        return `(tags.tagList==(${value.map(v => `"*\\"*${escapingForSpecialCharactersWhichCanBreakCQL(v)}*\\"*"`).join(' or ')}))`;
+      } else {
+        return `(tags.tagList==("*\\"*${escapingForSpecialCharactersWhichCanBreakCQL(value)}*\\"*"))`;
+      }
     }
   },
   {


### PR DESCRIPTION
## Purpose
Correctly escape CQL special characters in tag API queries

## Refs
https://issues.folio.org/browse/UIREQ-918