### PR TITLE
UIREQ-1005: Move request popup show available Request Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * Ensure Only Available Service Points Display When Placing a New Request. Refs UIREQ-977.
 * *BREAKING* Upgrade React to v18. Refs UIREQ-998.
 * Create Jest/RTL test for DraggableRow.js. Refs UIREQ-940.
+* Create Jest/RTL test for ComponentToPrint.js. Refs UIREQ-931.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * *BREAKING* Upgrade React to v18. Refs UIREQ-998.
 * Create Jest/RTL test for DraggableRow.js. Refs UIREQ-940.
 * Create Jest/RTL test for ComponentToPrint.js. Refs UIREQ-931.
+* Move request popup show available Request Types. Refs UIREQ-1005.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/ChooseRequestTypeDialog.js
+++ b/src/ChooseRequestTypeDialog.js
@@ -10,31 +10,31 @@ import {
 } from '@folio/stripes/components';
 
 import { Loading } from './components';
-import {
-  getRequestTypeOptions,
-} from './utils';
+import { REQUEST_LEVEL_TYPES } from './constants';
+
+export const getRequestTypeError = (requestLevel) => {
+  if (requestLevel === REQUEST_LEVEL_TYPES.TITLE) {
+    return <FormattedMessage id="ui-requests.moveRequest.error.titleLevelRequest" />;
+  }
+
+  return <FormattedMessage id="ui-requests.moveRequest.error.itemLevelRequest" />;
+};
 
 class ChooseRequestTypeDialog extends React.Component {
   static propTypes = {
-    item: PropTypes.object.isRequired,
-    isLoading: PropTypes.bool,
+    isLoading: PropTypes.bool.isRequired,
+    requestLevel: PropTypes.string.isRequired,
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    requestTypes: PropTypes.arrayOf(PropTypes.string),
     open: PropTypes.bool,
-  };
-
-  static defaultProps = {
-    isLoading: false,
   };
 
   constructor(props) {
     super(props);
 
-    const { item } = this.props;
-
-    this.options = getRequestTypeOptions(item);
     this.state = {
-      requestType: this.options[0].value,
+      requestType: props.requestTypes[0]?.value,
     };
   }
 
@@ -55,15 +55,19 @@ class ChooseRequestTypeDialog extends React.Component {
       open,
       onCancel,
       isLoading,
+      requestTypes,
+      requestLevel,
     } = this.props;
-    const { requestType } = this.state;
+    const isRequestTypeDisabled = requestTypes.length === 0;
+    const isConfirmButtonDisabled = isRequestTypeDisabled || isLoading;
+    const requestTypesError = isRequestTypeDisabled ? getRequestTypeError(requestLevel) : null;
     const footer = (
       <ModalFooter>
         <Button
           data-test-confirm-request-type
           buttonStyle="primary"
           onClick={this.onConfirm}
-          disabled={isLoading}
+          disabled={isConfirmButtonDisabled}
         >
           <FormattedMessage id="ui-requests.moveRequest.confirm" />
         </Button>
@@ -87,13 +91,14 @@ class ChooseRequestTypeDialog extends React.Component {
       >
         {isLoading
           ? <Loading data-testid="loading" />
-          : this.options.length > 1 ?
-            <Select
+          : <Select
               label={<FormattedMessage id="ui-requests.moveRequest.chooseRequestMessage" />}
               name="requestType"
               onChange={this.selectRequestType}
+              disabled={isRequestTypeDisabled}
+              error={requestTypesError}
             >
-              {this.options.map(({ id, value }) => (
+              {requestTypes.map(({ id, value }) => (
                 <FormattedMessage id={id} key={id}>
                   {translatedLabel => (
                     <option
@@ -105,7 +110,7 @@ class ChooseRequestTypeDialog extends React.Component {
                 </FormattedMessage>
               ))}
             </Select>
-            : <FormattedMessage id="ui-requests.moveRequest.requestTypeChangeMessage" values={{ requestType }} />}
+          }
       </Modal>
     );
   }

--- a/src/ChooseRequestTypeDialog.js
+++ b/src/ChooseRequestTypeDialog.js
@@ -89,28 +89,28 @@ class ChooseRequestTypeDialog extends React.Component {
         onClose={onCancel}
         footer={footer}
       >
-        {isLoading
-          ? <Loading data-testid="loading" />
-          : <Select
-              label={<FormattedMessage id="ui-requests.moveRequest.chooseRequestMessage" />}
-              name="requestType"
-              onChange={this.selectRequestType}
-              disabled={isRequestTypeDisabled}
-              error={requestTypesError}
-            >
-              {requestTypes.map(({ id, value }) => (
-                <FormattedMessage id={id} key={id}>
-                  {translatedLabel => (
-                    <option
-                      value={value}
-                    >
-                      {translatedLabel}
-                    </option>
-                  )}
-                </FormattedMessage>
-              ))}
-            </Select>
-          }
+        {isLoading ?
+          <Loading data-testid="loading" /> :
+          <Select
+            label={<FormattedMessage id="ui-requests.moveRequest.chooseRequestMessage" />}
+            name="requestType"
+            onChange={this.selectRequestType}
+            disabled={isRequestTypeDisabled}
+            error={requestTypesError}
+          >
+            {requestTypes.map(({ id, value }) => (
+              <FormattedMessage id={id} key={id}>
+                {translatedLabel => (
+                  <option
+                    value={value}
+                  >
+                    {translatedLabel}
+                  </option>
+                )}
+              </FormattedMessage>
+            ))}
+          </Select>
+        }
       </Modal>
     );
   }

--- a/src/ChooseRequestTypeDialog.test.js
+++ b/src/ChooseRequestTypeDialog.test.js
@@ -9,7 +9,10 @@ import '../test/jest/__mock__';
 import { Button } from '@folio/stripes/components';
 
 import { Loading } from './components';
-import ChooseRequestTypeDialog from './ChooseRequestTypeDialog';
+import ChooseRequestTypeDialog, {
+  getRequestTypeError,
+} from './ChooseRequestTypeDialog';
+import { REQUEST_LEVEL_TYPES } from './constants';
 
 jest.mock('./components', () => ({
   Loading: jest.fn(({ 'data-testid': dataTestId }) => (
@@ -26,19 +29,29 @@ jest.mock('./utils', () => ({
 const testIds = {
   loading: 'loading',
 };
+const labelIds = {
+  titleLevelRequestError: 'ui-requests.moveRequest.error.titleLevelRequest',
+  itemLevelRequestError: 'ui-requests.moveRequest.error.itemLevelRequest',
+};
 
 describe('ChooseRequestTypeDialog', () => {
   const buttonCallOrder = {
     confirm: 1,
     cancel: 2,
   };
-  const testItem = {};
   const mockOnConfirm = jest.fn();
   const mockOnCancel = jest.fn();
   const defaultTestProps = {
-    item: testItem,
     onConfirm: mockOnConfirm,
     onCancel: mockOnCancel,
+    requestTypes: [
+      {
+        id: 'testId',
+        value: 'Page',
+      }
+    ],
+    requestLevel: REQUEST_LEVEL_TYPES.ITEM,
+    isLoading: false,
   };
 
   afterEach(() => {
@@ -106,6 +119,24 @@ describe('ChooseRequestTypeDialog', () => {
 
     it('should render Loading component', () => {
       expect(screen.getByTestId(testIds.loading)).toBeVisible();
+    });
+  });
+
+  describe('getRequestTypeError', () => {
+    it('should render title level request error', () => {
+      const requestLevel = REQUEST_LEVEL_TYPES.TITLE;
+
+      render(getRequestTypeError(requestLevel));
+
+      expect(screen.getByText(labelIds.titleLevelRequestError)).toBeInTheDocument();
+    });
+
+    it('should render item level request error', () => {
+      const requestLevel = REQUEST_LEVEL_TYPES.ITEM;
+
+      render(getRequestTypeError(requestLevel));
+
+      expect(screen.getByText(labelIds.itemLevelRequestError)).toBeInTheDocument();
     });
   });
 });

--- a/src/MoveRequestManager.js
+++ b/src/MoveRequestManager.js
@@ -22,13 +22,7 @@ import { getRequestTypeOptions } from './utils';
 
 export const getRequestTypeUrl = (request, okapiUrl, id) => {
   const url = `circulation/requests/allowed-service-points?requester=${request.requesterId}`;
-  let resourceQuery = '';
-
-  if (request.requestLevel === REQUEST_LEVEL_TYPES.ITEM) {
-    resourceQuery = `&item=${id}`;
-  } else {
-    resourceQuery = `&instance=${id}`;
-  }
+  const resourceQuery = request.requestLevel === REQUEST_LEVEL_TYPES.ITEM ? `&item=${id}` : `&instance=${id}`;
 
   return `${okapiUrl}/${url}${resourceQuery}`;
 };

--- a/src/MoveRequestManager.js
+++ b/src/MoveRequestManager.js
@@ -6,7 +6,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { stripesConnect } from '@folio/stripes/core';
+import {
+  stripesConnect,
+  stripesShape,
+} from '@folio/stripes/core';
 import {
   getHeaderWithCredentials,
 } from '@folio/stripes/util';
@@ -28,7 +31,7 @@ export const getRequestTypeUrl = (request, okapiUrl) => {
   }
 
   return `${okapiUrl}/${url}${resourceQuery}`;
-}
+};
 
 class MoveRequestManager extends React.Component {
   static propTypes = {
@@ -43,6 +46,7 @@ class MoveRequestManager extends React.Component {
         POST: PropTypes.func.isRequired,
       }),
     }).isRequired,
+    stripes: stripesShape.isRequired,
   };
 
   static manifest = {

--- a/src/MoveRequestManager.test.js
+++ b/src/MoveRequestManager.test.js
@@ -173,6 +173,13 @@ describe('MoveRequestManager', () => {
 
   describe('Request type dialog', () => {
     beforeEach(() => {
+      global.fetch = jest.fn(() => Promise.resolve({
+        ok: true,
+        json: () => ({
+          Hold: ['id'],
+        })
+      }));
+
       render(
         <MoveRequestManager
           {...basicProps}
@@ -251,6 +258,7 @@ describe('MoveRequestManager', () => {
 
       beforeEach(async () => {
         global.fetch = jest.fn(() => Promise.resolve({
+          ok: true,
           json: () => ({
             Hold: ['holdId'],
             Recall: ['recallId'],
@@ -358,6 +366,7 @@ describe('MoveRequestManager', () => {
         };
 
         global.fetch = jest.fn(() => Promise.resolve({
+          ok: true,
           json: () => ({
             Hold: ['holdId'],
             Recall: ['recallId'],
@@ -395,27 +404,26 @@ describe('MoveRequestManager', () => {
   describe('getRequestTypeUrl', () => {
     const okapiUrl = 'okapiUrl';
     const requesterId = 'requesterId';
+    const resourceId = 'resourceId';
 
     it('should return item related link', () => {
       const request = {
         requestLevel: REQUEST_LEVEL_TYPES.ITEM,
-        itemId: 'itemId',
         requesterId,
       };
-      const expectedResult = `${okapiUrl}/circulation/requests/allowed-service-points?requester=${requesterId}&item=${request.itemId}`;
+      const expectedResult = `${okapiUrl}/circulation/requests/allowed-service-points?requester=${requesterId}&item=${resourceId}`;
 
-      expect(getRequestTypeUrl(request, okapiUrl)).toBe(expectedResult);
+      expect(getRequestTypeUrl(request, okapiUrl, resourceId)).toBe(expectedResult);
     });
 
     it('should return title related link', () => {
       const request = {
         requestLevel: REQUEST_LEVEL_TYPES.TITLE,
-        instanceId: 'instanceId',
         requesterId,
       };
-      const expectedResult = `${okapiUrl}/circulation/requests/allowed-service-points?requester=${requesterId}&instance=${request.instanceId}`;
+      const expectedResult = `${okapiUrl}/circulation/requests/allowed-service-points?requester=${requesterId}&instance=${resourceId}`;
 
-      expect(getRequestTypeUrl(request, okapiUrl)).toBe(expectedResult);
+      expect(getRequestTypeUrl(request, okapiUrl, resourceId)).toBe(expectedResult);
     });
   });
 });

--- a/src/MoveRequestManager.test.js
+++ b/src/MoveRequestManager.test.js
@@ -17,6 +17,7 @@ import ChooseRequestTypeDialog from './ChooseRequestTypeDialog';
 import ErrorModal from './components/ErrorModal';
 import {
   REQUEST_LEVEL_TYPES,
+  requestTypeOptionMap,
   requestTypesMap,
 } from './constants';
 
@@ -42,7 +43,7 @@ const basicProps = {
     instance: {
       title: 'instanceTitle',
     },
-    requestLevel: 'Item',
+    requestLevel: REQUEST_LEVEL_TYPES.ITEM,
   },
   mutator: {
     move: {
@@ -128,7 +129,7 @@ describe('MoveRequestManager', () => {
   beforeEach(() => {
     global.fetch = jest.fn(() => Promise.resolve({
       json: () => ({
-        Hold: ['id'],
+        [requestTypesMap.HOLD]: ['id'],
       })
     }));
   });
@@ -176,7 +177,7 @@ describe('MoveRequestManager', () => {
       global.fetch = jest.fn(() => Promise.resolve({
         ok: true,
         json: () => ({
-          Hold: ['id'],
+          [requestTypesMap.HOLD]: ['id'],
         })
       }));
 
@@ -200,8 +201,8 @@ describe('MoveRequestManager', () => {
         isLoading: false,
         requestTypes: [
           {
-            id: 'ui-requests.requestMeta.type.hold',
-            value: 'Hold',
+            id: requestTypeOptionMap[requestTypesMap.HOLD],
+            value: requestTypesMap.HOLD,
           }
         ],
         requestLevel: basicProps.request.requestLevel,
@@ -260,8 +261,8 @@ describe('MoveRequestManager', () => {
         global.fetch = jest.fn(() => Promise.resolve({
           ok: true,
           json: () => ({
-            Hold: ['holdId'],
-            Recall: ['recallId'],
+            [requestTypesMap.HOLD]: ['holdId'],
+            [requestTypesMap.RECALL]: ['recallId'],
           })
         }));
 
@@ -368,8 +369,8 @@ describe('MoveRequestManager', () => {
         global.fetch = jest.fn(() => Promise.resolve({
           ok: true,
           json: () => ({
-            Hold: ['holdId'],
-            Recall: ['recallId'],
+            [requestTypesMap.HOLD]: ['holdId'],
+            [requestTypesMap.RECALL]: ['recallId'],
           })
         }));
 

--- a/src/MoveRequestManager.test.js
+++ b/src/MoveRequestManager.test.js
@@ -4,7 +4,6 @@ import {
   fireEvent,
   cleanup,
   waitFor,
-  act,
 } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
@@ -182,7 +181,7 @@ describe('MoveRequestManager', () => {
 
       const rowButton = screen.getByTestId(testIds.rowButton);
 
-      act(() => fireEvent.click(rowButton));
+      fireEvent.click(rowButton);
     });
 
     it('should trigger "ChooseRequestTypeDialog" with correct props', async () => {

--- a/src/components/ComponentToPrint/ComponentToPrint.test.js
+++ b/src/components/ComponentToPrint/ComponentToPrint.test.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Parser } from 'html-to-react';
+import {
+  render,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import ComponentToPrint from './ComponentToPrint';
+
+const testIds = {
+  barcode: 'barcodeComponent',
+};
+
+jest.mock('react-barcode', () => {
+  return jest.fn().mockImplementation(() => <div data-testid={testIds.barcode} />);
+});
+
+describe('ComponentToPrint', () => {
+  const templateFnMock = jest.fn();
+  const templateFn = jest.fn(() => '<barcode>123456</barcode>');
+  const dataSource = { 'request': 1 };
+  const parser = new Parser();
+  let originalParseWithInstructions;
+
+  beforeEach(() => {
+    templateFnMock.mockClear();
+    templateFn.mockClear();
+    originalParseWithInstructions = parser.parseWithInstructions;
+  });
+
+  afterEach(() => {
+    parser.parseWithInstructions = originalParseWithInstructions;
+  });
+
+  it('should handle null result from parseWithInstructions', () => {
+    parser.parseWithInstructions = jest.fn(() => null);
+
+    render(<ComponentToPrint dataSource={dataSource} templateFn={templateFn} />);
+
+    expect(screen.queryByTestId('barcode')).not.toBeInTheDocument();
+  });
+
+  it('should handle empty template string', () => {
+    const emptyTemplateFn = jest.fn(() => null);
+    const { container } = render(<ComponentToPrint dataSource={dataSource} templateFn={emptyTemplateFn} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should process the barcode rule with empty string', () => {
+    const mockBarcodeValue = '123456789';
+    const emptyString = '';
+    const mockComponentStr = `<div><barcode>${mockBarcodeValue}</barcode><barcode>${emptyString}</barcode></div>`;
+
+    templateFn.mockReturnValue(mockComponentStr);
+
+    render(<ComponentToPrint dataSource={dataSource} templateFn={templateFn} />);
+
+    expect(screen.getAllByTestId(testIds.barcode)[0]).toBeInTheDocument();
+  });
+
+  it('should process the barcode rule with data', () => {
+    const mockParsedComponent = <div data-testid="mock-component">Mock Component</div>;
+
+    parser.parseWithInstructions = jest.fn(() => mockParsedComponent);
+
+    render(<ComponentToPrint dataSource={dataSource} templateFn={templateFn} />);
+
+    expect(screen.getAllByTestId(testIds.barcode)[0]).toBeInTheDocument();
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -151,20 +151,18 @@ export const requestTypeOptionMap = {
   'Page': 'ui-requests.requestMeta.type.page',
 };
 
-export const requestTypesByItemStatus = {
-  [itemStatuses.CHECKED_OUT]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
-  [itemStatuses.AVAILABLE]: [requestTypesMap.PAGE],
-  [itemStatuses.AWAITING_PICKUP]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
-  [itemStatuses.AWAITING_DELIVERY]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
-  [itemStatuses.IN_TRANSIT]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
-  [itemStatuses.MISSING]: [requestTypesMap.HOLD],
-  [itemStatuses.PAGED]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
-  [itemStatuses.ON_ORDER]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
-  [itemStatuses.IN_PROCESS]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
-  [itemStatuses.RESTRICTED]: [requestTypesMap.HOLD, requestTypesMap.RECALL],
-};
-
-export const requestableItemStatuses = Object.keys(requestTypesByItemStatus);
+export const requestableItemStatuses = [
+  itemStatuses.CHECKED_OUT,
+  itemStatuses.AVAILABLE,
+  itemStatuses.AWAITING_PICKUP,
+  itemStatuses.AWAITING_DELIVERY,
+  itemStatuses.IN_TRANSIT,
+  itemStatuses.MISSING,
+  itemStatuses.PAGED,
+  itemStatuses.ON_ORDER,
+  itemStatuses.IN_PROCESS,
+  itemStatuses.RESTRICTED,
+];
 
 export const reportHeaders = [
   'requestType',

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,9 +24,7 @@ import {
 } from '@folio/stripes/components';
 
 import {
-  requestTypesByItemStatus,
   requestTypeOptionMap,
-  itemStatuses,
   fulfillmentTypeMap,
   requestStatuses,
   requestTypesMap,
@@ -100,13 +98,7 @@ export function getPatronGroup(patron, patronGroups) {
 }
 
 export function duplicateRequest(request) {
-  const itemStatus = get(request, 'item.status');
-  const requestType = request.requestType;
-  const requestTypes = requestTypesByItemStatus[itemStatus] || [];
   const clonedRequest = cloneDeep(request);
-
-  // check if the current request type is valid if not pick a first available type
-  clonedRequest.requestType = requestTypes.find(rt => rt === requestType) || requestTypes[0];
 
   return omit(clonedRequest, [
     'cancellationAdditionalInformation',
@@ -126,18 +118,11 @@ export function duplicateRequest(request) {
   ]);
 }
 
-export function getRequestTypeOptions(item) {
-  const itemStatus = item?.status?.name;
-  const requestTypes = requestTypesByItemStatus[itemStatus] || [];
-
-  return requestTypes.map(type => ({
-    id: requestTypeOptionMap[type],
-    value: type,
+export function getRequestTypeOptions(requestTypes) {
+  return requestTypes.map(requestType => ({
+    id: requestTypeOptionMap[requestType],
+    value: requestType,
   }));
-}
-
-export function isPagedItem(item) {
-  return item?.status?.name === itemStatuses.PAGED;
 }
 
 export function isDelivery(request) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -27,6 +27,7 @@ import {
   isSubmittingButtonDisabled,
   isFormEditing,
   resetFieldState,
+  getRequestTypeOptions,
 } from './utils';
 
 import {
@@ -35,6 +36,7 @@ import {
   requestTypesMap,
   REQUEST_LEVEL_TYPES,
   fulfillmentTypeMap,
+  requestTypeOptionMap,
 } from './constants';
 
 describe('escapeValue', () => {
@@ -128,38 +130,6 @@ describe('duplicateRequest', () => {
 
     omit.forEach(i => {
       expect(duped).not.toHaveProperty(i);
-    });
-  });
-
-  describe('adjusts request type if necessary', () => {
-    it('leaves request type if it is valid for item type', () => {
-      const r = {
-        monkey: 'bagel',
-        requestType: requestTypesMap.RECALL,
-        item: { status: itemStatuses.CHECKED_OUT },
-      };
-      const duped = duplicateRequest(r);
-      expect(duped.requestType).toBe(requestTypesMap.RECALL);
-    });
-
-    it('changes request type if it is invalid for item-status', () => {
-      const r = {
-        monkey: 'bagel',
-        requestType: requestTypesMap.RECALL,
-        item: { status: itemStatuses.AVAILABLE },
-      };
-      const duped = duplicateRequest(r);
-      expect(duped.requestType).toBe(requestTypesMap.PAGE);
-    });
-
-    it('omits request type if it is invalid for item-status', () => {
-      const r = {
-        monkey: 'bagel',
-        requestType: requestTypesMap.RECALL,
-        item: { status: itemStatuses.AGED_TO_LOST },
-      };
-      const duped = duplicateRequest(r);
-      expect(duped.requestType).toBeUndefined();
     });
   });
 });
@@ -804,5 +774,19 @@ describe('resetFieldState', () => {
     it('should not trigger "resetFieldState"', () => {
       expect(form.resetFieldState).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('getRequestTypeOptions', () => {
+  it('should return modified array of request type options', () => {
+    const requestTypes = ['Hold'];
+    const expectedResult = [
+      {
+        id: requestTypeOptionMap[requestTypes[0]],
+        value: requestTypes[0],
+      }
+    ];
+
+    expect(getRequestTypeOptions(requestTypes)).toEqual(expectedResult);
   });
 });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -32,8 +32,6 @@ import {
 
 import {
   INVALID_REQUEST_HARDCODED_ID,
-  itemStatuses,
-  requestTypesMap,
   REQUEST_LEVEL_TYPES,
   fulfillmentTypeMap,
   requestTypeOptionMap,

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -200,12 +200,13 @@
   "items.instanceItems.notFound": "No items found",
 
   "moveRequest.requestTypeChangeHeading": "Current requests type not allowed for selected item",
-  "moveRequest.requestTypeChangeMessage": "Request will be converted to <strong>{requestType}</strong>.",
   "moveRequest.chooseRequestMessage": "Please select allowed type",
   "moveRequest.confirm": "Confirm",
   "moveRequest.success": "Request has been moved successfully",
   "moveRequest.secondPositionTitle": "Request moved to position 2 of the queue",
   "moveRequest.secondPositionMessage": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue.",
+  "moveRequest.error.titleLevelRequest": "None available for this title and patron combination",
+  "moveRequest.error.itemLevelRequest": "None available for this item and patron combination",
 
   "createRequest.success": "Request has been successfully created for {requester}",
   "createRequest.fail": "This request was not placed successfully",


### PR DESCRIPTION
## Purpose
In the scope of the story, I had to get only available request types and show them inside the dropdown. If there are no available request types appropriate error should be shown.
Also, in the scope of this PR I have removed unused constants and functionality related to duplication request.

## Refs
[UIREQ-1005](https://issues.folio.org/browse/UIREQ-1005)

## Screenshots
### Dropdown with request types
![image](https://github.com/folio-org/ui-requests/assets/42437614/13564314-440e-4f45-b9a6-51a4dda6284f)


### Error when we do not have available request types
![image](https://github.com/folio-org/ui-requests/assets/42437614/3dfc3bea-80b3-4dbf-a9e3-a6913d215b67)
