### PR TITLE
UIREQ-1005: Get request types for items only

### DIFF
--- a/src/ChooseRequestTypeDialog.js
+++ b/src/ChooseRequestTypeDialog.js
@@ -10,20 +10,10 @@ import {
 } from '@folio/stripes/components';
 
 import { Loading } from './components';
-import { REQUEST_LEVEL_TYPES } from './constants';
-
-export const getRequestTypeError = (requestLevel) => {
-  if (requestLevel === REQUEST_LEVEL_TYPES.TITLE) {
-    return <FormattedMessage id="ui-requests.moveRequest.error.titleLevelRequest" />;
-  }
-
-  return <FormattedMessage id="ui-requests.moveRequest.error.itemLevelRequest" />;
-};
 
 class ChooseRequestTypeDialog extends React.Component {
   static propTypes = {
     isLoading: PropTypes.bool.isRequired,
-    requestLevel: PropTypes.string.isRequired,
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     requestTypes: PropTypes.arrayOf(PropTypes.string),
@@ -56,11 +46,10 @@ class ChooseRequestTypeDialog extends React.Component {
       onCancel,
       isLoading,
       requestTypes,
-      requestLevel,
     } = this.props;
     const isRequestTypeDisabled = requestTypes.length === 0;
     const isConfirmButtonDisabled = isRequestTypeDisabled || isLoading;
-    const requestTypesError = isRequestTypeDisabled ? getRequestTypeError(requestLevel) : null;
+    const requestTypesError = isRequestTypeDisabled ? <FormattedMessage id="ui-requests.moveRequest.error.itemLevelRequest" /> : null;
     const footer = (
       <ModalFooter>
         <Button

--- a/src/ChooseRequestTypeDialog.test.js
+++ b/src/ChooseRequestTypeDialog.test.js
@@ -9,9 +9,7 @@ import '../test/jest/__mock__';
 import { Button } from '@folio/stripes/components';
 
 import { Loading } from './components';
-import ChooseRequestTypeDialog, {
-  getRequestTypeError,
-} from './ChooseRequestTypeDialog';
+import ChooseRequestTypeDialog from './ChooseRequestTypeDialog';
 import { REQUEST_LEVEL_TYPES } from './constants';
 
 jest.mock('./components', () => ({
@@ -119,24 +117,6 @@ describe('ChooseRequestTypeDialog', () => {
 
     it('should render Loading component', () => {
       expect(screen.getByTestId(testIds.loading)).toBeVisible();
-    });
-  });
-
-  describe('getRequestTypeError', () => {
-    it('should render title level request error', () => {
-      const requestLevel = REQUEST_LEVEL_TYPES.TITLE;
-
-      render(getRequestTypeError(requestLevel));
-
-      expect(screen.getByText(labelIds.titleLevelRequestError)).toBeInTheDocument();
-    });
-
-    it('should render item level request error', () => {
-      const requestLevel = REQUEST_LEVEL_TYPES.ITEM;
-
-      render(getRequestTypeError(requestLevel));
-
-      expect(screen.getByText(labelIds.itemLevelRequestError)).toBeInTheDocument();
     });
   });
 });

--- a/src/ChooseRequestTypeDialog.test.js
+++ b/src/ChooseRequestTypeDialog.test.js
@@ -27,10 +27,6 @@ jest.mock('./utils', () => ({
 const testIds = {
   loading: 'loading',
 };
-const labelIds = {
-  titleLevelRequestError: 'ui-requests.moveRequest.error.titleLevelRequest',
-  itemLevelRequestError: 'ui-requests.moveRequest.error.itemLevelRequest',
-};
 
 describe('ChooseRequestTypeDialog', () => {
   const buttonCallOrder = {

--- a/src/MoveRequestManager.js
+++ b/src/MoveRequestManager.js
@@ -17,15 +17,7 @@ import {
 import ItemsDialog from './ItemsDialog';
 import ChooseRequestTypeDialog from './ChooseRequestTypeDialog';
 import ErrorModal from './components/ErrorModal';
-import { REQUEST_LEVEL_TYPES } from './constants';
 import { getRequestTypeOptions } from './utils';
-
-export const getRequestTypeUrl = (request, okapiUrl, id) => {
-  const url = `circulation/requests/allowed-service-points?requester=${request.requesterId}`;
-  const resourceQuery = request.requestLevel === REQUEST_LEVEL_TYPES.ITEM ? `&item=${id}` : `&instance=${id}`;
-
-  return `${okapiUrl}/${url}${resourceQuery}`;
-};
 
 class MoveRequestManager extends React.Component {
   static propTypes = {
@@ -163,7 +155,7 @@ class MoveRequestManager extends React.Component {
         token: stripes.store.getState().okapi.token,
       })
     };
-    const url = getRequestTypeUrl(request, stripes.okapi.url, selectedItem.id);
+    const url = `${stripes.okapi.url}/circulation/requests/allowed-service-points?requester=${request.requesterId}&item=${selectedItem.id}`;
 
     this.setState({
       isRequestTypesLoading: true,
@@ -246,7 +238,6 @@ class MoveRequestManager extends React.Component {
             data-test-choose-request-type-modal
             isLoading={moveInProgress || isRequestTypesLoading}
             requestTypes={getRequestTypeOptions(requestTypes)}
-            requestLevel={request.requestLevel}
             onConfirm={this.confirmChoosingRequestType}
             onCancel={this.cancelMoveRequest}
           /> }

--- a/src/MoveRequestManager.test.js
+++ b/src/MoveRequestManager.test.js
@@ -9,9 +9,7 @@ import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '../test/jest/__mock__';
 
-import MoveRequestManager, {
-  getRequestTypeUrl,
-} from './MoveRequestManager';
+import MoveRequestManager from './MoveRequestManager';
 import ItemsDialog from './ItemsDialog';
 import ChooseRequestTypeDialog from './ChooseRequestTypeDialog';
 import ErrorModal from './components/ErrorModal';
@@ -43,7 +41,6 @@ const basicProps = {
     instance: {
       title: 'instanceTitle',
     },
-    requestLevel: REQUEST_LEVEL_TYPES.ITEM,
   },
   mutator: {
     move: {
@@ -205,7 +202,6 @@ describe('MoveRequestManager', () => {
             value: requestTypesMap.HOLD,
           }
         ],
-        requestLevel: basicProps.request.requestLevel,
       };
 
       await waitFor(() => expect(ChooseRequestTypeDialog).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {}));
@@ -399,32 +395,6 @@ describe('MoveRequestManager', () => {
 
         await waitFor(() => expect(ErrorModal).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {}));
       });
-    });
-  });
-
-  describe('getRequestTypeUrl', () => {
-    const okapiUrl = 'okapiUrl';
-    const requesterId = 'requesterId';
-    const resourceId = 'resourceId';
-
-    it('should return item related link', () => {
-      const request = {
-        requestLevel: REQUEST_LEVEL_TYPES.ITEM,
-        requesterId,
-      };
-      const expectedResult = `${okapiUrl}/circulation/requests/allowed-service-points?requester=${requesterId}&item=${resourceId}`;
-
-      expect(getRequestTypeUrl(request, okapiUrl, resourceId)).toBe(expectedResult);
-    });
-
-    it('should return title related link', () => {
-      const request = {
-        requestLevel: REQUEST_LEVEL_TYPES.TITLE,
-        requesterId,
-      };
-      const expectedResult = `${okapiUrl}/circulation/requests/allowed-service-points?requester=${requesterId}&instance=${resourceId}`;
-
-      expect(getRequestTypeUrl(request, okapiUrl, resourceId)).toBe(expectedResult);
     });
   });
 });

--- a/src/MoveRequestManager.test.js
+++ b/src/MoveRequestManager.test.js
@@ -14,7 +14,6 @@ import ItemsDialog from './ItemsDialog';
 import ChooseRequestTypeDialog from './ChooseRequestTypeDialog';
 import ErrorModal from './components/ErrorModal';
 import {
-  REQUEST_LEVEL_TYPES,
   requestTypeOptionMap,
   requestTypesMap,
 } from './constants';

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -206,7 +206,6 @@
   "moveRequest.success": "Request has been moved successfully",
   "moveRequest.secondPositionTitle": "Request moved to position 2 of the queue",
   "moveRequest.secondPositionMessage": "Requests cannot be moved above page requests, even when fulfillment has not begun. This request will be moved to position 2 in the request queue.",
-  "moveRequest.error.titleLevelRequest": "None available for this title and patron combination",
   "moveRequest.error.itemLevelRequest": "None available for this item and patron combination",
 
   "createRequest.success": "Request has been successfully created for {requester}",


### PR DESCRIPTION
## Purpose
Delete functionality that gets available request types for title. 
Only available request types for items should be retrieved from the server side.

Current PR is an improvement of https://github.com/folio-org/ui-requests/pull/1091


## Refs
[UIREQ-1005](https://issues.folio.org/browse/UIREQ-1005)