### PR TITLE
UIREQ-1020: Prefer @folio/stripes exports to private paths when importing components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * UI tests replacement with RTL/Jest for urls. Refs UIREQ-896.
 * Reassign limit variable from hardcoded value to MAX_RECORDS constant for `ItemsDialog.js`. Refs UIREQ-913.
 * Reassign limit variable from hardcoded value to MAX_RECORDS constant for `RequestsRoute.js`. Refs UIREQ-914.
-* Include pickup service point in display of result list. Refs-900.
+* Include pickup service point in display of result list. Refs UIREQ-900.
 * Include "Effective call number string" in display of result list. Refs UIREQ-898.
 * Include call number in Action menu list of fields to display. Refs UIREQ-899.
 * Include pickup service point in Action menu list of fields to display. Refs UIREQ-901.
@@ -22,7 +22,7 @@
 * Create Jest/RTL test for ReferredRecord.js. Refs UIREQ-936.
 * Create Jest/RTL test for NoteCreateRoute.js. Refs: UIREQ-943.
 * Leverage cookie-based authentication in all API requests. Refs UIREQ-861.
-* Create Jest/RTL test for NoteEditRoute.js. Refs: UIREQ-944.
+* Create Jest/RTL test for NoteEditRoute.js. Refs UIREQ-944.
 * Update `circulation` okapi interface to `14.0` version. Refs UIREQ-954.
 * Added requestDate token. Refs UIREQ-962.
 * Update `request-storage` okapi interface to `6.0` version. Refs UIREQ-963.
@@ -64,6 +64,7 @@
 * Add new pickup service point error. Refs UIREQ-981.
 * Move request popup show available Request Types. Refs UIREQ-1005.
 * Cover RequesterInformation by jest/RTL tests. Refs UIREQ-952.
+* Prefer `@folio/stripes` exports to private paths when importing components. Refs UIREQ-1020.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/components/InstanceInformation/InstanceInformation.js
+++ b/src/components/InstanceInformation/InstanceInformation.js
@@ -10,7 +10,7 @@ import {
   Icon,
   Row,
   TextField,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { Pluggable } from '@folio/stripes/core';
 
 import {

--- a/src/components/InstanceInformation/InstanceInformation.test.js
+++ b/src/components/InstanceInformation/InstanceInformation.test.js
@@ -13,7 +13,7 @@ import { Field } from 'react-final-form';
 import {
   Icon,
   TextField,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { Pluggable } from '@folio/stripes/core';
 
 import InstanceInformation, {

--- a/src/components/ItemInformation/ItemInformation.js
+++ b/src/components/ItemInformation/ItemInformation.js
@@ -10,7 +10,7 @@ import {
   Icon,
   Row,
   TextField,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import {
   REQUEST_FORM_FIELD_NAMES,

--- a/src/components/ItemInformation/ItemInformation.test.js
+++ b/src/components/ItemInformation/ItemInformation.test.js
@@ -13,7 +13,7 @@ import { Field } from 'react-final-form';
 import {
   Icon,
   TextField,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import ItemInformation from './ItemInformation';
 import ItemDetail from '../../ItemDetail';

--- a/src/components/RequestInformation/RequestInformation.js
+++ b/src/components/RequestInformation/RequestInformation.js
@@ -14,7 +14,7 @@ import {
   Select,
   TextArea,
   Timepicker,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 
 import {
   requestStatuses,

--- a/src/components/RequesterInformation/RequesterInformation.js
+++ b/src/components/RequesterInformation/RequesterInformation.js
@@ -10,7 +10,7 @@ import {
   Icon,
   Row,
   TextField,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import {
   Pluggable,
   stripesShape,

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-jest.mock('@folio/stripes-components', () => ({
-  ...jest.requireActual('@folio/stripes-components'),
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
   Accordion: jest.fn(({
     children,
     label,

--- a/test/jest/helpers/translationsProperties.js
+++ b/test/jest/helpers/translationsProperties.js
@@ -1,5 +1,3 @@
-import stripesComponentsTranslations from '@folio/stripes-components/translations/stripes-components/en';
-
 import translations from '../../../translations/ui-requests/en';
 
 const translationsProperties = [
@@ -7,10 +5,6 @@ const translationsProperties = [
     prefix: 'ui-requests',
     translations,
   },
-  {
-    prefix: 'stripes-components',
-    translations: stripesComponentsTranslations,
-  }
 ];
 
 export default translationsProperties;


### PR DESCRIPTION
## Purpose
Prefer @folio/stripes exports to private paths when importing components

## Refs
https://issues.folio.org/browse/UIREQ-1020