### PR TITLE
UIREQ-1028: Add "operation" parameter to "allowed-service-points" endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIREQ-1025.
 * Rename modal window for select request type. Refs UIREQ-1026.
 * Create request from user without barcode. Refs UIREQ-1023.
+* Add "operation" parameter to "allowed-service-points" endpoint. Refs UIREQ-1028.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/MoveRequestManager.js
+++ b/src/MoveRequestManager.js
@@ -18,6 +18,7 @@ import ItemsDialog from './ItemsDialog';
 import ChooseRequestTypeDialog from './ChooseRequestTypeDialog';
 import ErrorModal from './components/ErrorModal';
 import { getRequestTypeOptions } from './utils';
+import { REQUEST_OPERATIONS } from './constants';
 
 class MoveRequestManager extends React.Component {
   static propTypes = {
@@ -155,7 +156,7 @@ class MoveRequestManager extends React.Component {
         token: stripes.store.getState().okapi.token,
       })
     };
-    const url = `${stripes.okapi.url}/circulation/requests/allowed-service-points?requester=${request.requesterId}&item=${selectedItem.id}`;
+    const url = `${stripes.okapi.url}/circulation/requests/allowed-service-points?requestId=${request.id}&operation=${REQUEST_OPERATIONS.MOVE}`;
 
     this.setState({
       isRequestTypesLoading: true,
@@ -220,6 +221,7 @@ class MoveRequestManager extends React.Component {
       requestTypes,
       isRequestTypesLoading,
     } = this.state;
+    const isLoading = moveInProgress || isRequestTypesLoading;
 
     return (
       <>
@@ -227,7 +229,7 @@ class MoveRequestManager extends React.Component {
           open={moveRequest}
           instanceId={request.instanceId}
           title={request.instance.title}
-          isLoading={moveInProgress}
+          isLoading={isLoading}
           onClose={onCancelMove}
           skippedItemId={request.itemId}
           onRowClick={(_, item) => this.onItemSelected(item)}
@@ -236,7 +238,7 @@ class MoveRequestManager extends React.Component {
           <ChooseRequestTypeDialog
             open={chooseRequestType}
             data-test-choose-request-type-modal
-            isLoading={moveInProgress || isRequestTypesLoading}
+            isLoading={isLoading}
             requestTypes={getRequestTypeOptions(requestTypes)}
             onConfirm={this.confirmChoosingRequestType}
             onCancel={this.cancelMoveRequest}

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -60,6 +60,7 @@ import {
   DEFAULT_REQUEST_TYPE_VALUE,
   requestTypeOptionMap,
   REQUEST_LAYERS,
+  REQUEST_OPERATIONS,
 } from './constants';
 import {
   handleKeyCommand,
@@ -677,8 +678,19 @@ class RequestForm extends React.Component {
       request,
     } = this.props;
     const isEditForm = isFormEditing(request);
+    let requestParams;
 
-    if (!isEditForm) {
+    if (isEditForm) {
+      requestParams = {
+        operation: REQUEST_OPERATIONS.REPLACE,
+        requestId: request.id,
+      };
+    } else {
+      requestParams = {
+        operation: REQUEST_OPERATIONS.CREATE,
+        [resourceType]: resourceId,
+        requesterId,
+      };
       form.change(REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE, DEFAULT_REQUEST_TYPE_VALUE);
     }
 
@@ -686,10 +698,7 @@ class RequestForm extends React.Component {
       isRequestTypeLoading: true,
     });
 
-    findResource(RESOURCE_TYPES.REQUEST_TYPES, {
-      [resourceType]: resourceId,
-      requesterId,
-    })
+    findResource(RESOURCE_TYPES.REQUEST_TYPES, requestParams)
       .then(requestTypes => {
         if (!isEmpty(requestTypes)) {
           this.setState({

--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -34,6 +34,7 @@ import {
   REQUEST_FORM_FIELD_NAMES,
   DEFAULT_REQUEST_TYPE_VALUE,
   RESOURCE_KEYS,
+  REQUEST_OPERATIONS,
 } from './constants';
 
 let mockedTlrSettings;
@@ -479,6 +480,7 @@ describe('RequestForm', () => {
       expect(findResourceMock).toHaveBeenCalledWith(RESOURCE_TYPES.REQUEST_TYPES, {
         [ID_TYPE_MAP.INSTANCE_ID]: newProps.selectedInstance.id,
         requesterId: newProps.selectedUser.id,
+        operation: REQUEST_OPERATIONS.CREATE,
       });
     });
   });
@@ -539,6 +541,7 @@ describe('RequestForm', () => {
         {
           [ID_TYPE_MAP.INSTANCE_ID]: instanceId,
           requesterId,
+          operation: REQUEST_OPERATIONS.CREATE,
         }
       ];
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -339,3 +339,9 @@ export const BASE_SPINNER_PROPS = {
   icon: 'spinner-ellipsis',
   width: '10px',
 };
+
+export const REQUEST_OPERATIONS = {
+  CREATE: 'create',
+  REPLACE: 'replace',
+  MOVE: 'move',
+};

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -151,17 +151,22 @@ export const urls = {
     requesterId,
     itemId,
     instanceId,
+    requestId,
+    operation,
   }) => {
-    const requestUrl = `circulation/requests/allowed-service-points?requester=${requesterId}`;
-    let itemQuery = '';
-
-    if (itemId) {
-      itemQuery = `&item=${itemId}`;
-    } else if (instanceId) {
-      itemQuery = `&instance=${instanceId}`;
+    if (requestId) {
+      return `circulation/requests/allowed-service-points?operation=${operation}&requestId=${requestId}`;
     }
 
-    return `${requestUrl}${itemQuery}`;
+    let requestUrl = `circulation/requests/allowed-service-points?requesterId=${requesterId}&operation=${operation}`;
+
+    if (itemId) {
+      requestUrl = `${requestUrl}&itemId=${itemId}`;
+    } else if (instanceId) {
+      requestUrl = `${requestUrl}&instanceId=${instanceId}`;
+    }
+
+    return requestUrl;
   },
 };
 

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -56,6 +56,7 @@ import {
   DEFAULT_DISPLAYED_YEARS_AMOUNT,
   OPEN_REQUESTS_STATUSES,
   MAX_RECORDS,
+  REQUEST_OPERATIONS,
 } from '../constants';
 import { historyData } from '../../test/jest/fixtures/historyData';
 
@@ -1126,24 +1127,37 @@ describe('RequestsRoute', () => {
 
     describe('requestTypes', () => {
       const requesterId = 'requesterIdUrl';
+      const operation = REQUEST_OPERATIONS.CREATE;
       const itemId = 'itemIdUrl';
       const instanceId = 'instanceIdUrl';
 
       it('should return url with "itemId"', () => {
-        const expectedUrl = `circulation/requests/allowed-service-points?requester=${requesterId}&item=${itemId}`;
+        const expectedUrl = `circulation/requests/allowed-service-points?requesterId=${requesterId}&operation=${operation}&itemId=${itemId}`;
 
         expect(urls.requestTypes({
           requesterId,
           itemId,
+          operation,
         })).toBe(expectedUrl);
       });
 
       it('should return url with "instanceId"', () => {
-        const expectedUrl = `circulation/requests/allowed-service-points?requester=${requesterId}&instance=${instanceId}`;
+        const expectedUrl = `circulation/requests/allowed-service-points?requesterId=${requesterId}&operation=${operation}&instanceId=${instanceId}`;
 
         expect(urls.requestTypes({
           requesterId,
           instanceId,
+          operation,
+        })).toBe(expectedUrl);
+      });
+
+      it('should return url with "requestId"', () => {
+        const requestId = 'requestId';
+        const expectedUrl = `circulation/requests/allowed-service-points?operation=${operation}&requestId=${requestId}`;
+
+        expect(urls.requestTypes({
+          requestId,
+          operation,
         })).toBe(expectedUrl);
       });
     });


### PR DESCRIPTION
## Purpose
- Add "operation" parameter to "allowed-service-points" endpoint. 
- use "requestId" param instead of combination of "requesterId" and "itemId"/"instanceId" for request editing and moving

## Refs
[UIREQ-1028](https://issues.folio.org/browse/UIREQ-1028)