### PR TITLE
UIREQ-1030: Add "itemId" parameter to "allowed-service-points" endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * Hit Enter or Search should move focus to the Results List pane header. Refs UIREQ-564.
 * Add "operation" parameter to "allowed-service-points" endpoint. Refs UIREQ-1028.
 * Fix issues with skipped tests. Refs UIREQ-1024.
+* Add "itemId" parameter to "allowed-service-points" endpoint. Refs UIREQ-1030.
 
 ## [8.0.2](https://github.com/folio-org/ui-requests/tree/v8.0.2) (2023-03-29)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v8.0.1...v8.0.2)

--- a/src/MoveRequestManager.js
+++ b/src/MoveRequestManager.js
@@ -156,7 +156,7 @@ class MoveRequestManager extends React.Component {
         token: stripes.store.getState().okapi.token,
       })
     };
-    const url = `${stripes.okapi.url}/circulation/requests/allowed-service-points?requestId=${request.id}&operation=${REQUEST_OPERATIONS.MOVE}`;
+    const url = `${stripes.okapi.url}/circulation/requests/allowed-service-points?requestId=${request.id}&itemId=${selectedItem.id}&operation=${REQUEST_OPERATIONS.MOVE}`;
 
     this.setState({
       isRequestTypesLoading: true,

--- a/src/MoveRequestManager.test.js
+++ b/src/MoveRequestManager.test.js
@@ -14,6 +14,7 @@ import ItemsDialog from './ItemsDialog';
 import ChooseRequestTypeDialog from './ChooseRequestTypeDialog';
 import ErrorModal from './components/ErrorModal';
 import {
+  REQUEST_OPERATIONS,
   requestTypeOptionMap,
   requestTypesMap,
 } from './constants';
@@ -40,6 +41,7 @@ const basicProps = {
     instance: {
       title: 'instanceTitle',
     },
+    id: 'requestId',
   },
   mutator: {
     move: {
@@ -63,18 +65,17 @@ const basicProps = {
     },
   },
 };
+const selectedItem = {
+  id: 'selectedItemId',
+  status: {
+    name: 'Checked out',
+  },
+};
 
 jest.mock('./ItemsDialog', () => jest.fn(({
   children,
   onRowClick,
 }) => {
-  const selectedItem = {
-    id: 'selectedItemId',
-    status: {
-      name: 'Checked out',
-    },
-  };
-
   return (
     <div>
       <button
@@ -186,6 +187,12 @@ describe('MoveRequestManager', () => {
       const rowButton = screen.getByTestId(testIds.rowButton);
 
       fireEvent.click(rowButton);
+    });
+
+    it('should trigger fetch with correct argument', () => {
+      const expectedUrl = `${basicProps.stripes.okapi.url}/circulation/requests/allowed-service-points?requestId=${basicProps.request.id}&itemId=${selectedItem.id}&operation=${REQUEST_OPERATIONS.MOVE}`;
+
+      expect(global.fetch).toHaveBeenCalledWith(expectedUrl, {});
     });
 
     it('should trigger "ChooseRequestTypeDialog" with correct props', async () => {


### PR DESCRIPTION
## Purpose
Server should be able to take information about selected item that will be used for moving request.

## Approach
Add "itemId" parameter to the request url.

## Refs
[UIREQ-1030](https://issues.folio.org/browse/UIREQ-1030)