### PR TITLE
UIREQ-1042: Add support for search-slips okapi interface version 0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Request Action - Create new option Print search slips. Refs UIREQ-1039.
 * Hide Actions menu on closed request of DCB Transaction. Refs UIREQ-1040.
 * Update Jest/RTL tests, remove outdated imports. Refs UIREQ-996.
+* Add support for `search-slips` okapi interface version `0.1`. Refs UIREQ-1042.
 
 ## [9.0.1](https://github.com/folio-org/ui-requests/tree/v9.0.1) (2023-12-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v9.0.0...v9.0.1)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "inventory": "10.0 11.0 12.0 13.0",
       "request-storage": "6.0",
       "pick-slips": "0.1",
+      "search-slips": "0.1",
       "automated-patron-blocks": "0.1"
     },
     "permissionSets": [


### PR DESCRIPTION
## Purpose
Add support for search-slips okapi interface version 0.1

## Refs
https://issues.folio.org/browse/UIREQ-1042

## Notes
Associated with https://github.com/folio-org/ui-requests/pull/1122
Should be merged after https://issues.folio.org/browse/CIRC-1933