### PR TITLE
UIREQ-1062: Use settings/entries endpoint to get settings information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Increase code coverage for src/RequestForm.js by Jest/RTL tests. Refs UIREQ-1043.
 * Add functionality to handle page title on the requests list page. Refs UIREQ-1058.
 * Error in Export Hold Shelf Clearance Report. Refs UIREQ-1057.
+* Use settings/entries endpoint to get settings information. Refs UIREQ-1062.
 
 ## [9.0.1](https://github.com/folio-org/ui-requests/tree/v9.0.1) (2023-12-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v9.0.0...v9.0.1)

--- a/src/ViewRequest.test.js
+++ b/src/ViewRequest.test.js
@@ -75,7 +75,11 @@ describe('ViewRequest', () => {
   };
   const mockedConfig = {
     records: [
-      { value: '{"titleLevelRequestsFeatureEnabled":true}' },
+      {
+        value: {
+          titleLevelRequestsFeatureEnabled: true,
+        },
+      }
     ],
   };
   const defaultProps = {
@@ -190,7 +194,9 @@ describe('ViewRequest', () => {
         describe('request is valid', () => {
           describe('TLR in enabled', () => {
             beforeAll(() => {
-              mockedConfig.records[0].value = '{"titleLevelRequestsFeatureEnabled":true}';
+              mockedConfig.records[0].value = {
+                titleLevelRequestsFeatureEnabled: true,
+              };
             });
 
             it('should render "Duplicate" button', () => {
@@ -200,7 +206,9 @@ describe('ViewRequest', () => {
 
           describe('TLR in disabled', () => {
             beforeAll(() => {
-              mockedConfig.records[0].value = '{"titleLevelRequestsFeatureEnabled":false}';
+              mockedConfig.records[0].value = {
+                titleLevelRequestsFeatureEnabled: false,
+              };
             });
 
             it('should not render "Duplicate" button', () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -391,3 +391,11 @@ export const DCB_USER = {
 
 export const DCB_INSTANCE_ID = '9d1b77e4-f02e-4b7f-b296-3f2042ddac54';
 export const DCB_HOLDINGS_RECORD_ID = '10cd3a5a-d36f-4c7a-bc4f-e1ae3cf820c9';
+
+export const SETTINGS_SCOPES = {
+  CIRCULATION: 'circulation',
+};
+
+export const SETTINGS_KEYS = {
+  GENERAL_TLR: 'generalTlr',
+};

--- a/src/routes/RequestQueueRoute.js
+++ b/src/routes/RequestQueueRoute.js
@@ -9,7 +9,11 @@ import { stripesConnect } from '@folio/stripes/core';
 
 import RequestQueueView from '../views/RequestQueueView';
 import urls from './urls';
-import { requestStatuses } from '../constants';
+import {
+  requestStatuses,
+  SETTINGS_SCOPES,
+  SETTINGS_KEYS,
+} from '../constants';
 import {
   getTlrSettings,
   isPageRequest,
@@ -29,10 +33,10 @@ class RequestQueueRoute extends React.Component {
   static manifest = {
     configs: {
       type: 'okapi',
-      records: 'configs',
-      path: 'configurations/entries',
+      records: 'items',
+      path: 'settings/entries',
       params: {
-        query: '(module==SETTINGS and configName==TLR)',
+        query: `(scope==${SETTINGS_SCOPES.CIRCULATION} and key==${SETTINGS_KEYS.GENERAL_TLR})`,
       },
     },
     addressTypes: {

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -60,6 +60,8 @@ import {
   fulfillmentTypeMap,
   DEFAULT_REQUEST_TYPE_VALUE,
   INPUT_REQUEST_SEARCH_SELECTOR,
+  SETTINGS_SCOPES,
+  SETTINGS_KEYS,
 } from '../constants';
 import {
   buildUrl,
@@ -398,10 +400,10 @@ class RequestsRoute extends React.Component {
     },
     configs: {
       type: 'okapi',
-      records: 'configs',
-      path: 'configurations/entries',
+      records: 'items',
+      path: 'settings/entries',
       params: {
-        query: '(module==SETTINGS and configName==TLR)',
+        query: `(scope==${SETTINGS_SCOPES.CIRCULATION} and key==${SETTINGS_KEYS.GENERAL_TLR})`,
       },
     },
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -291,13 +291,7 @@ export function parseErrorMessage(errorMessage) {
     ));
 }
 
-export const getTlrSettings = (settings) => {
-  try {
-    return JSON.parse(settings);
-  } catch (error) {
-    return {};
-  }
-};
+export const getTlrSettings = (settings) => settings || {};
 
 export const getRequestLevelValue = (value) => {
   return value

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -143,16 +143,12 @@ describe('getTlrSettings', () => {
     createTitleLevelRequestsByDefault: false,
   };
 
-  it('should return parsed settings', () => {
-    expect(getTlrSettings(JSON.stringify(defaultSettings))).toEqual(defaultSettings);
+  it('should return passed settings', () => {
+    expect(getTlrSettings(defaultSettings)).toEqual(defaultSettings);
   });
 
   it('should return empty object if nothing passed', () => {
     expect(getTlrSettings()).toEqual({});
-  });
-
-  it('should return empty object if invalid settings passed', () => {
-    expect(getTlrSettings("{'foo': 1}")).toEqual({});
   });
 });
 


### PR DESCRIPTION
## Purpose
Use `settings/entries` endpoint instead of `configuration/entries` endpoint to get settings information.

## Refs
[UIREQ-1062](https://folio-org.atlassian.net/browse/UIREQ-1062)