### PR TITLE
UIREQ-1063: "Create title level request" option is still checked after disabling on settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Increase code coverage for src/RequestForm.js by Jest/RTL tests. Refs UIREQ-1043.
 * Add functionality to handle page title on the requests list page. Refs UIREQ-1058.
 * Error in Export Hold Shelf Clearance Report. Refs UIREQ-1057.
+* Make updating of TLR settings when settings config is changed. Refs UIREQ-1063.
 
 ## [9.0.1](https://github.com/folio-org/ui-requests/tree/v9.0.1) (2023-12-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v9.0.0...v9.0.1)

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -612,7 +612,7 @@ class RequestsRoute extends React.Component {
       this.setCurrentServicePointId();
     }
 
-    if (prevConfigs.hasLoaded !== configs.hasLoaded && configs.hasLoaded) {
+    if (configs?.records[0]?.value !== prevConfigs?.records[0]?.value) {
       const {
         titleLevelRequestsFeatureEnabled = false,
         createTitleLevelRequestsByDefault = false,

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -434,11 +434,15 @@ describe('RequestsRoute', () => {
     fulfillmentPreference: 'Hold Shelf',
   };
 
-  const renderComponent = (props = defaultProps) => render(
-    <CalloutContext.Provider value={{ sendCallout: () => {} }}>
-      <RequestsRoute {...props} />
-    </CalloutContext.Provider>,
-  );
+  const renderComponent = (props = defaultProps) => {
+    const { rerender } = render(
+      <CalloutContext.Provider value={{ sendCallout: () => {} }}>
+        <RequestsRoute {...props} />
+      </CalloutContext.Provider>,
+    );
+
+    return rerender;
+  }
 
   afterEach(() => {
     getTlrSettings.mockClear();
@@ -680,6 +684,55 @@ describe('RequestsRoute', () => {
 
       expect(duplicateRequest).toHaveBeenCalledWith(mockedRequest);
       expect(mockedUpdateFunc).toHaveBeenCalledWith(defaultExpectedResultForUpdate);
+    });
+  });
+
+  describe('Component updating', () => {
+    let rerender;
+
+    beforeEach(() => {
+      rerender = renderComponent();
+    });
+
+    it('should get new settings', () => {
+      const newProps = {
+        ...defaultProps,
+        resources: {
+          ...defaultProps.resources,
+          configs: {
+            hasLoaded: true,
+            records: [
+              {
+                value: '{"createTitleLevelRequestsByDefault": true}',
+              }
+            ],
+          },
+        },
+      };
+
+      rerender(
+        <CalloutContext.Provider value={{ sendCallout: () => {} }}>
+          <RequestsRoute {...newProps} />
+        </CalloutContext.Provider>,
+      );
+
+      expect(getTlrSettings).toHaveBeenCalledWith(newProps.resources.configs.records[0].value);
+    });
+
+    it('should not get new settings', () => {
+      const newProps = {
+        ...defaultProps,
+        addressTypes: {},
+      };
+      const getUpdatedSettingsCallNumber = 2;
+
+      rerender(
+        <CalloutContext.Provider value={{ sendCallout: () => {} }}>
+          <RequestsRoute {...newProps} />
+        </CalloutContext.Provider>,
+      );
+
+      expect(getTlrSettings).not.toHaveBeenNthCalledWith(getUpdatedSettingsCallNumber, defaultProps.resources.configs.records[0].value);
     });
   });
 

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -442,7 +442,7 @@ describe('RequestsRoute', () => {
     );
 
     return rerender;
-  }
+  };
 
   afterEach(() => {
     getTlrSettings.mockClear();


### PR DESCRIPTION
## Purpose
Make updating of TLR settings when settings config is changed

## Refs
[UIREQ-1063](https://folio-org.atlassian.net/browse/UIREQ-1063)