### PR TITLE
UIREQ-1073: Use Save & close button label stripes-component translation key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add displaySummary field for Requests csv export. Refs UIREQ-1068.
 * Add support for displaySummary token for Staff Slips. Refs UIREQ-1067.
 * Only certain HTML tags should be rendered when displaying staff slips. Refs UIREQ-1080.
+* Use Save & close button label stripes-component translation key. Refs UIREQ-1073.
 
 ## [9.0.1](https://github.com/folio-org/ui-requests/tree/v9.0.1) (2023-12-04)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v9.0.0...v9.0.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -1229,7 +1229,7 @@ class RequestForm extends React.Component {
                       buttonStyle="primary mega"
                       disabled={isSubmittingDisabled}
                     >
-                      <FormattedMessage id="ui-requests.common.saveAndClose" />
+                      <FormattedMessage id="stripes-components.saveAndClose" />
                     </Button>
                   </div>
                 </PaneFooter>

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -210,8 +210,8 @@
   "cancel.additionalInfoLabel": "Additional information for patron {required}",
   "cancel.additionalInfoPlaceholderRequired": "Enter more information about the cancellation (required)",
   "cancel.additionalInfoPlaceholderOptional": "Enter more information about the cancellation (optional)",
-  
-  "items.selectItem": "Select item", 
+
+  "items.selectItem": "Select item",
   "items.instanceItems": "Other items in {title}",
   "items.instanceItems.notFound": "No items found",
 
@@ -274,7 +274,6 @@
   "printSearchSlips": "Print search slips for {sp}",
 
   "common.cancel": "Cancel",
-  "common.saveAndClose": "Save & close",
 
   "filters.requestType.holds": "Holds",
   "filters.requestType.pages": "Pages",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIREQ-1073
We removed local `saveAndClose` label and replace it with `stripes-components.saveAndClose`. Also all related tests updated