### PR TITLE
UIREQ-1080: Add support for Barcode tag with sanitize

### DIFF
--- a/src/components/ComponentToPrint/ComponentToPrint.js
+++ b/src/components/ComponentToPrint/ComponentToPrint.js
@@ -20,7 +20,7 @@ const rules = [
 const parser = new Parser();
 
 const ComponentToPrint = ({ dataSource, templateFn }) => {
-  const componentStr = sanitize(templateFn(dataSource));
+  const componentStr = sanitize(templateFn(dataSource), { ADD_TAGS: ['Barcode'] });
   const Component = parser.parseWithInstructions(componentStr, () => true, rules) || null;
 
   return Component;

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -1048,7 +1048,7 @@ class RequestsRoute extends React.Component {
     const slipTypeInLowerCase = slipType.toLowerCase();
     const slipTemplate = staffSlips.find(slip => slip.name.toLowerCase() === slipTypeInLowerCase);
 
-    return sanitize(get(slipTemplate, 'template', ''));
+    return sanitize(get(slipTemplate, 'template', ''), { ADD_TAGS: ['Barcode'] });
   }
 
   handleFilterChange = ({ name, values }) => {


### PR DESCRIPTION
## Purpose
Only certain HTML tags should be rendered when displaying staff slips. Add support for `Barcode `tag with sanitize.

# Refs
https://issues.folio.org/browse/UIREQ-1080

## Approach
For resolve current problem we should use `DOMPurify.sanitize` confirmed with John. Add support for Barcode tag with sanitize. Change log was already updated.
