### PR TITLE
UIREQ-1095: Pickup service point on an item request is not populated with the user's default pickup service point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use Save & close button label stripes-component translation key. Refs UIREQ-1073.
 * Include single print and selection print options on results list and actions menu. Refs UIREQ-966.
+* Set up default pickup service point if it is available. Refs UIREQ-1095.
 
 ## [9.1.1] (https://github.com/folio-org/ui-checkin/tree/v9.1.1) (2024-03-27)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v9.1.0...v9.1.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -639,7 +639,7 @@ class RequestForm extends React.Component {
     }
   }
 
-  updateRequestPreferencesFields() {
+  updateRequestPreferencesFields = () => {
     const {
       defaultDeliveryAddressTypeId,
       defaultServicePointId,
@@ -1340,6 +1340,7 @@ class RequestForm extends React.Component {
                     label={<FormattedMessage id="ui-requests.requestMeta.information" />}
                   >
                     <RequestInformation
+                      updateRequestPreferencesFields={this.updateRequestPreferencesFields}
                       request={request}
                       requestTypeOptions={requestTypeOptions}
                       isTlrEnabledOnEditPage={isTlrEnabledOnEditPage}

--- a/src/components/RequestInformation/RequestInformation.js
+++ b/src/components/RequestInformation/RequestInformation.js
@@ -51,6 +51,7 @@ const RequestInformation = ({
   isRequestTypeLoading,
   values,
   form,
+  updateRequestPreferencesFields,
 }) => {
   const isEditForm = isFormEditing(request);
   const holdShelfExpireDate = get(request, ['status'], '') === requestStatuses.AWAITING_PICKUP
@@ -78,6 +79,7 @@ const RequestInformation = ({
     form.change(REQUEST_FORM_FIELD_NAMES.PICKUP_SERVICE_POINT_ID, undefined);
     resetFieldState(form, REQUEST_FORM_FIELD_NAMES.PICKUP_SERVICE_POINT_ID);
     input.onChange(e);
+    updateRequestPreferencesFields();
   };
 
   return (
@@ -256,6 +258,7 @@ RequestInformation.propTypes = {
   request: PropTypes.object.isRequired,
   values: PropTypes.object.isRequired,
   form: PropTypes.object.isRequired,
+  updateRequestPreferencesFields: PropTypes.func.isRequired,
   requestTypeOptions: PropTypes.arrayOf(PropTypes.object),
 };
 

--- a/src/components/RequestInformation/RequestInformation.test.js
+++ b/src/components/RequestInformation/RequestInformation.test.js
@@ -68,6 +68,7 @@ const basicProps = {
     patronComments: 'comments',
   },
   MetadataDisplay: () => <div data-testid={testIds.metadataDisplay}>MetadataDisplay</div>,
+  updateRequestPreferencesFields: jest.fn(),
 };
 
 describe('RequestInformation', () => {
@@ -388,6 +389,10 @@ describe('RequestInformation', () => {
         fireEvent.change(requestTypeSelect, event);
       });
 
+      afterEach(() => {
+        basicProps.updateRequestPreferencesFields.mockClear();
+      });
+
       it('should trigger "form.change" with correct arguments', () => {
         const expectedArgs = [REQUEST_FORM_FIELD_NAMES.PICKUP_SERVICE_POINT_ID, undefined];
 
@@ -398,6 +403,10 @@ describe('RequestInformation', () => {
         const expectedArgs = [basicProps.form, REQUEST_FORM_FIELD_NAMES.PICKUP_SERVICE_POINT_ID];
 
         expect(resetFieldState).toHaveBeenCalledWith(...expectedArgs);
+      });
+
+      it('should update request preferences', () => {
+        expect(basicProps.updateRequestPreferencesFields).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## Purpose
If a user has a default service point it should be automatically preselected as an initial value.

## Approach
Initially we had always visible Fulfilment Preference field and after initial render of parent component all default values were set to appropriate fields.
But now Fulfilment Preference is not visible by default and it becomes visible only when user selects Request Type.
As a result I added method that set Fulfilment Preference default values to Request Type filed handler. 

## Refs
[UIREQ-1095](https://folio-org.atlassian.net/browse/UIREQ-1095)