### PR TITLE
UIREQ-1105: Hide Action menu on secondary requests (ECS + mod-tlr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Requests app.: Cancelling request (ECS with mod-tlr enabled). Refs UIREQ-1090.
 * Requests app.: Reorder request queue (ECS with mod-tlr enabled). Refs UIREQ-1098.
 * Requests app.: Moving request (ECS with mod-tlr enabled). Refs UIREQ-1100.
+* Hide Action menu on secondary requests (ECS + mod-tlr). Refs UIREQ-1105.
 
 ## [9.1.1] (https://github.com/folio-org/ui-checkin/tree/v9.1.1) (2024-03-27)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v9.1.0...v9.1.1)

--- a/src/ViewRequest.js
+++ b/src/ViewRequest.js
@@ -75,6 +75,16 @@ const ECS_REQUEST_PHASE = {
   SECONDARY: 'Secondary',
 };
 
+export const isActionMenuVisible = (stripes, isEcsTlrSecondaryRequest, isDCBTransaction) => (
+  isEcsTlrSecondaryRequest
+    ? false
+    : stripes.hasPerm('ui-requests.create')
+    || stripes.hasPerm('ui-requests.edit')
+    || stripes.hasPerm('ui-requests.moveRequest')
+    || stripes.hasPerm('ui-requests.reorderQueue')
+    || !isDCBTransaction
+);
+
 class ViewRequest extends React.Component {
   static manifest = {
     selectedRequest: {
@@ -508,10 +518,7 @@ class ViewRequest extends React.Component {
       ? <FormattedDate value={request.requestExpirationDate} />
       : '-';
 
-    const showActionMenu = stripes.hasPerm('ui-requests.create')
-      || stripes.hasPerm('ui-requests.edit')
-      || stripes.hasPerm('ui-requests.moveRequest')
-      || stripes.hasPerm('ui-requests.reorderQueue') || !isDCBTransaction;
+    const showActionMenu = isActionMenuVisible(stripes, isEcsTlrSecondaryRequest, isDCBTransaction);
 
     const actionMenu = ({ onToggle }) => {
       if (isRequestClosed) {

--- a/src/ViewRequest.test.js
+++ b/src/ViewRequest.test.js
@@ -10,7 +10,9 @@ import {
   defaultKeyboardShortcuts,
 } from '@folio/stripes/components';
 
-import ViewRequest from './ViewRequest';
+import ViewRequest, {
+  isActionMenuVisible,
+} from './ViewRequest';
 import RequestForm from './RequestForm';
 import {
   INVALID_REQUEST_HARDCODED_ID,
@@ -491,6 +493,40 @@ describe('ViewRequest', () => {
           expect(defaultProps.stripes.hasPerm).toHaveBeenCalled();
         });
       });
+    });
+  });
+
+  describe('isActionMenuVisible', () => {
+    let stripes = {
+      hasPerm: () => true,
+    };
+
+    it('should return false when isEcsTlrSecondaryRequest true', () => {
+      expect(isActionMenuVisible(stripes, true, true)).toBeFalsy();
+    });
+
+    it('should return true when isDCBTransaction false and all permission true', () => {
+      expect(isActionMenuVisible(stripes, false, false)).toBeTruthy();
+    });
+
+    it('should return true when isDCBTransaction true and all permission true', () => {
+      expect(isActionMenuVisible(stripes, false, true)).toBeTruthy();
+    });
+
+    it('should return true when isDCBTransaction false and all permission false', () => {
+      stripes = {
+        hasPerm: () => false,
+      };
+
+      expect(isActionMenuVisible(stripes, false, false)).toBeTruthy();
+    });
+
+    it('should return true when isDCBTransaction true and all permission false', () => {
+      stripes = {
+        hasPerm: () => false,
+      };
+
+      expect(isActionMenuVisible(stripes, false, true)).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## Purpose
Hide Action menu on secondary requests (ECS + mod-tlr)

# Refs
https://issues.folio.org/browse/UIREQ-1105