### PR TITLE
UIREQ-1127, UIREQ-1128: Hide Duplicate and Move action buttons in ECS env with mod-tlr enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Populate the token 'request.barcodeImage' in the pick slip. Refs UIREQ-1117.
 * Populate the token "staffUsername" in the pick slip. Refs UIREQ-1124.
 * Implement availability of "Printed" and "# Copies" columns upon "Enable view print details (Pick slips)" configuration. Refs UIREQ-1121.
+* Hide Duplicate and Move action buttons in ECS env with mod-tlr enabled. Refs UIREQ-1127, UIREQ-1125.
 
 ## [9.1.1] (https://github.com/folio-org/ui-checkin/tree/v9.1.1) (2024-03-27)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v9.1.0...v9.1.1)

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
           "inventory-storage.instances.item.get",
           "inventory-storage.instances.collection.get",
           "manualblocks.collection.get",
-          "circulation.requests.hold-shelf-clearance-report.get"
+          "circulation.requests.hold-shelf-clearance-report.get",
+          "circulation.settings.collection.get"
         ],
         "visible": true
       },

--- a/src/ItemDetail.test.js
+++ b/src/ItemDetail.test.js
@@ -9,6 +9,7 @@ import ItemDetail from './ItemDetail';
 import { INVALID_REQUEST_HARDCODED_ID } from './constants';
 
 jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
   Link: jest.fn(({ to, children }) => <a href={to}>{children}</a>),
 }));
 

--- a/src/PositionLink.test.js
+++ b/src/PositionLink.test.js
@@ -10,6 +10,7 @@ import {
 import PositionLink from './PositionLink';
 
 jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
   Link: jest.fn(({ to, children }) => <a href={to}>{children}</a>),
 }));
 

--- a/src/ViewRequest.test.js
+++ b/src/ViewRequest.test.js
@@ -11,7 +11,8 @@ import {
 } from '@folio/stripes/components';
 
 import ViewRequest, {
-  isActionMenuVisible,
+  isAnyActionButtonVisible,
+  shouldHideMoveAndDuplicate,
 } from './ViewRequest';
 import RequestForm from './RequestForm';
 import {
@@ -120,6 +121,7 @@ describe('ViewRequest', () => {
     },
     stripes: {
       hasPerm: jest.fn(() => true),
+      hasInterface: jest.fn(() => true),
       connect: jest.fn((component) => component),
       logger: {
         log: jest.fn(),
@@ -130,6 +132,8 @@ describe('ViewRequest', () => {
         id: 'testId',
       },
     },
+    isEcsTlrSettingEnabled: false,
+    isEcsTlrSettingReceived: true,
   };
   const defaultDCBLendingProps = {
     ...defaultProps,
@@ -501,37 +505,39 @@ describe('ViewRequest', () => {
     });
   });
 
-  describe('isActionMenuVisible', () => {
-    let stripes = {
-      hasPerm: () => true,
+  describe('isAnyActionButtonVisible', () => {
+    describe('When visibility conditions are provided', () => {
+      it('should return true', () => {
+        expect(isAnyActionButtonVisible([true, false])).toBe(true);
+      });
+    });
+
+    describe('When visibility conditions are not provided', () => {
+      it('should return false', () => {
+        expect(isAnyActionButtonVisible()).toBe(false);
+      });
+    });
+  });
+
+  describe('shouldHideMoveAndDuplicate', () => {
+    const stripes = {
+      hasInterface: () => true,
     };
 
-    it('should return false when isEcsTlrSecondaryRequest true', () => {
-      expect(isActionMenuVisible(stripes, true, true)).toBeFalsy();
+    it('should return true for primary request', () => {
+      expect(shouldHideMoveAndDuplicate(stripes, true)).toBe(true);
     });
 
-    it('should return true when isDCBTransaction false and all permission true', () => {
-      expect(isActionMenuVisible(stripes, false, false)).toBeTruthy();
+    it('should return true if ecs tlr enabled', () => {
+      expect(shouldHideMoveAndDuplicate(stripes, false, true, true)).toBe(true);
     });
 
-    it('should return true when isDCBTransaction true and all permission true', () => {
-      expect(isActionMenuVisible(stripes, false, true)).toBeTruthy();
+    it('should return true if settings are not received', () => {
+      expect(shouldHideMoveAndDuplicate(stripes, false, false, true)).toBe(true);
     });
 
-    it('should return true when isDCBTransaction false and all permission false', () => {
-      stripes = {
-        hasPerm: () => false,
-      };
-
-      expect(isActionMenuVisible(stripes, false, false)).toBeTruthy();
-    });
-
-    it('should return true when isDCBTransaction true and all permission false', () => {
-      stripes = {
-        hasPerm: () => false,
-      };
-
-      expect(isActionMenuVisible(stripes, false, true)).toBeFalsy();
+    it('should return false', () => {
+      expect(shouldHideMoveAndDuplicate(stripes, false, true, false)).toBe(false);
     });
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -320,6 +320,7 @@ export const RESOURCE_TYPES = {
   USER: 'user',
   HOLDING: 'holding',
   REQUEST_TYPES: 'requestTypes',
+  ECS_TLR_SETTINGS: 'ecsTlrSettings',
 };
 
 export const ENTER_EVENT_KEY = 'Enter';

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -23,6 +23,7 @@ import {
   IfPermission,
   CalloutContext,
   TitleManager,
+  checkIfUserInCentralTenant,
 } from '@folio/stripes/core';
 import {
   Button,
@@ -68,6 +69,7 @@ import {
   SETTINGS_KEYS,
   ITEM_QUERIES,
   PRINT_DETAILS_COLUMNS,
+  RESOURCE_TYPES,
 } from '../constants';
 import {
   buildUrl,
@@ -82,6 +84,7 @@ import {
   getSelectedSlipDataMulti,
   selectedRowsNonPrintable,
   getNextSelectedRowsState,
+  isMultiDataTenant,
 } from '../utils';
 import packageInfo from '../../package';
 import CheckboxColumn from '../components/CheckboxColumn';
@@ -216,6 +219,15 @@ export const urls = {
     }
 
     return requestUrl;
+  },
+  ecsTlrSettings: (value, idType, stripes) => {
+    const isUserInCentralTenant = checkIfUserInCentralTenant(stripes);
+
+    if (isUserInCentralTenant) {
+      return 'tlr/settings';
+    }
+
+    return 'circulation/settings?query=name==ecsTlrFeature';
   },
 };
 
@@ -624,6 +636,8 @@ class RequestsRoute extends React.Component {
     this.expiredHoldsReportColumnHeaders = this.getColumnHeaders(expiredHoldsReportHeaders);
 
     this.state = {
+      isEcsTlrSettingReceived: false,
+      isEcsTlrSettingEnabled: false,
       csvReportPending: false,
       submitting: false,
       errorMessage: '',
@@ -653,13 +667,20 @@ class RequestsRoute extends React.Component {
   }
 
   componentDidMount() {
+    const { stripes } = this.props;
+
     this.setCurrentServicePointId();
+
+    if (stripes?.user?.user?.tenants) {
+      this.getEcsTlrSettings();
+    }
   }
 
   componentDidUpdate(prevProps) {
+    const { submitting } = this.state;
+    const { stripes } = this.props;
     const patronBlocks = get(this.props.resources, ['patronBlocks', 'records'], []);
     const prevBlocks = get(prevProps.resources, ['patronBlocks', 'records'], []);
-    const { submitting } = this.state;
     const prevExpired = prevBlocks.filter(p => moment(moment(p.expirationDate).format()).isSameOrBefore(moment().format()) && p.expirationDate) || [];
     const expired = patronBlocks.filter(p => moment(moment(p.expirationDate).format()).isSameOrBefore(moment().format()) && p.expirationDate) || [];
     const { id: currentServicePointId } = this.getCurrentServicePointInfo();
@@ -716,6 +737,41 @@ class RequestsRoute extends React.Component {
 
     if (!this.props.resources.records.isPending) {
       this.onSearchComplete(this.props.resources.records);
+    }
+
+    if (stripes?.user?.user?.tenants && stripes.user.user !== prevProps.stripes?.user?.user) {
+      this.getEcsTlrSettings();
+    }
+  }
+
+  /* For multi data tenant environments
+  * ECS TLR setting has to be retrieved (Settings>Circulation>Consortium title level requests (TLR)).
+  * In a case if this setting is enabled we should hide Move and Duplicate buttons in action menu. */
+  getEcsTlrSettings = () => {
+    const { stripes } = this.props;
+
+    if (isMultiDataTenant(stripes)) {
+      this.findResource(RESOURCE_TYPES.ECS_TLR_SETTINGS)
+        .then(res => {
+          let isEcsTlrSettingEnabled;
+
+          if (checkIfUserInCentralTenant(stripes)) {
+            isEcsTlrSettingEnabled = res?.ecsTlrFeatureEnabled;
+          } else {
+            isEcsTlrSettingEnabled = res?.circulationSettings?.[0]?.value?.enabled;
+          }
+
+          this.setState({
+            isEcsTlrSettingReceived: true,
+            isEcsTlrSettingEnabled,
+          });
+        })
+        .catch(() => {
+          this.setState({
+            isEcsTlrSettingReceived: false,
+            isEcsTlrSettingEnabled: false,
+          });
+        });
     }
   }
 
@@ -901,7 +957,8 @@ class RequestsRoute extends React.Component {
 
   // idType can be 'id', 'barcode', etc.
   findResource(resource, value, idType = 'id') {
-    const query = urls[resource](value, idType);
+    const { stripes } = this.props;
+    const query = urls[resource](value, idType, stripes);
 
     return fetch(`${this.okapiUrl}/${query}`, this.httpHeadersOptions).then(response => response.json());
   }
@@ -1321,6 +1378,8 @@ class RequestsRoute extends React.Component {
       holdsShelfReportPending,
       createTitleLevelRequestsByDefault,
       isViewPrintDetailsEnabled,
+      isEcsTlrSettingReceived,
+      isEcsTlrSettingEnabled,
     } = this.state;
     const isPrintHoldRequestsEnabled = getPrintHoldRequestsEnabled(resources.printHoldRequests);
     const { name: servicePointName } = this.getCurrentServicePointInfo();
@@ -1615,6 +1674,8 @@ class RequestsRoute extends React.Component {
                 query: resources.query,
                 onDuplicate: this.onDuplicate,
                 buildRecordsForHoldsShelfReport: this.buildRecordsForHoldsShelfReport,
+                isEcsTlrSettingReceived,
+                isEcsTlrSettingEnabled,
               }}
               viewRecordOnCollapse={this.viewRecordOnCollapse}
               viewRecordPerms="ui-requests.view"

--- a/src/utils.js
+++ b/src/utils.js
@@ -513,3 +513,7 @@ export function resetFieldState(form, fieldName) {
     form.resetFieldState(fieldName);
   }
 }
+
+export const isMultiDataTenant = (stripes) => {
+  return stripes.hasInterface('consortia') && stripes.hasInterface('ecs-tlr');
+};

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -34,6 +34,7 @@ import {
   selectedRowsNonPrintable,
   isPrintable,
   getNextSelectedRowsState,
+  isMultiDataTenant,
 } from './utils';
 
 import {
@@ -1088,5 +1089,31 @@ describe('getRequestTypeOptions', () => {
     ];
 
     expect(getRequestTypeOptions(requestTypes)).toEqual(expectedResult);
+  });
+});
+
+describe('isMultiDataTenant', () => {
+  describe('When multi data tenant', () => {
+    const stripes = {
+      hasInterface: () => true,
+    };
+
+    it('should return true', () => {
+      const result = isMultiDataTenant(stripes);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('When single data tenant', () => {
+    const stripes = {
+      hasInterface: () => false,
+    };
+
+    it('should return false', () => {
+      const result = isMultiDataTenant(stripes);
+
+      expect(result).toBe(false);
+    });
   });
 });

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -6,6 +6,7 @@ const mockStripes = buildStripes();
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
   AppContextMenu: ({ children }) => (typeof children === 'function' ? children(jest.fn()) : children),
+  checkIfUserInCentralTenant: jest.fn(),
   IntlConsumer: jest.fn(({ children }) => {
     const intl = {
       formatMessage: jest.fn(({ id }) => id),


### PR DESCRIPTION
## Purpose
For ECS environments with mod-tlr enabled "Duplicate" and "Move request" buttons from action dropdown should be hidden.

## Approach
"Duplicate" and "Move request" should be hidden if request is primary, if request is secondary, if ECS TLR setting is enabled.
New functionality was implemented based on those three conditions. 

## Refs
[UIREQ-1127](https://folio-org.atlassian.net/browse/UIREQ-1127)
[UIREQ-1128](https://folio-org.atlassian.net/browse/UIREQ-1128)