### PR TITLE
UIREQ-1132, UIREQ-1133: Fix issue with Proxy's patron group and delivery address that shown instead of Sponsor's when creating request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Populate the token "staffUsername" in the pick slip. Refs UIREQ-1124.
 * Implement availability of "Printed" and "# Copies" columns upon "Enable view print details (Pick slips)" configuration. Refs UIREQ-1121.
 * Implement availability of "Print status" filters upon "Enable view print details (Pick slips)" configuration. Refs UIREQ-1119.
+* Fix issue with Proxy's patron group and delivery address that shown instead of Sponsor's when creating request. Refs UIREQ-1132, UIREQ-1133.
 
 ## [9.1.1] (https://github.com/folio-org/ui-checkin/tree/v9.1.1) (2024-03-27)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v9.1.0...v9.1.1)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -78,6 +78,7 @@ import {
   isSubmittingButtonDisabled,
   isFormEditing,
   resetFieldState,
+  getRequester,
 } from './utils';
 
 import css from './requests.css';
@@ -186,7 +187,7 @@ class RequestForm extends React.Component {
     const { titleLevelRequestsFeatureEnabled } = this.getTlrSettings();
 
     this.state = {
-      proxy: {},
+      proxy: null,
       selectedLoan: loan,
       ...getDefaultRequestPreferences(request, initialValues),
       isAwaitingForProxySelection: false,
@@ -452,17 +453,13 @@ class RequestForm extends React.Component {
     const {
       form,
       selectedUser,
-      onSetSelectedUser,
     } = this.props;
 
     if (selectedUser.id === proxy.id) {
-      onSetSelectedUser(selectedUser);
       this.setState({
         proxy: selectedUser,
       });
-      form.change(REQUEST_FORM_FIELD_NAMES.REQUESTER_ID, selectedUser.id);
     } else {
-      onSetSelectedUser(selectedUser);
       this.setState({
         proxy,
         requestTypes: {},
@@ -767,6 +764,7 @@ class RequestForm extends React.Component {
       onSetSelectedItem,
       selectedUser,
     } = this.props;
+    const { proxy } = this.state;
 
     this.setState({
       isItemOrInstanceLoading: true,
@@ -816,7 +814,8 @@ class RequestForm extends React.Component {
         })
         .then(item => {
           if (item && selectedUser?.id) {
-            this.findRequestTypes(item.id, selectedUser.id, ID_TYPE_MAP.ITEM_ID);
+            const requester = getRequester(proxy, selectedUser);
+            this.findRequestTypes(item.id, requester.id, ID_TYPE_MAP.ITEM_ID);
           }
 
           return item;
@@ -849,6 +848,7 @@ class RequestForm extends React.Component {
       onSetSelectedInstance,
       selectedUser,
     } = this.props;
+    const { proxy } = this.state;
 
     this.setState({
       isItemOrInstanceLoading: true,
@@ -897,7 +897,8 @@ class RequestForm extends React.Component {
         })
         .then(instance => {
           if (instance && selectedUser?.id) {
-            this.findRequestTypes(instance.id, selectedUser.id, ID_TYPE_MAP.INSTANCE_ID);
+            const requester = getRequester(proxy, selectedUser);
+            this.findRequestTypes(instance.id, requester.id, ID_TYPE_MAP.INSTANCE_ID);
           }
 
           return instance;
@@ -1137,26 +1138,26 @@ class RequestForm extends React.Component {
     const patronBlocks = onGetPatronManualBlocks(parentResources);
     const automatedPatronBlocks = onGetAutomatedPatronBlocks(parentResources);
     const isEditForm = isFormEditing(request);
-
+    const selectedProxy = getProxy(request, proxy);
+    const requester = getRequester(selectedProxy, selectedUser);
     let deliveryLocations;
     let deliveryLocationsDetail = [];
     let addressDetail;
-    if (selectedUser && selectedUser.personal && selectedUser.personal.addresses) {
-      deliveryLocations = selectedUser.personal.addresses.map((a) => {
+    if (requester?.personal?.addresses) {
+      deliveryLocations = requester.personal.addresses.map((a) => {
         const typeName = find(addressTypes, { id: a.addressTypeId }).addressType;
         return { label: typeName, value: a.addressTypeId };
       });
       deliveryLocations = sortBy(deliveryLocations, ['label']);
-      deliveryLocationsDetail = keyBy(selectedUser.personal.addresses, a => a.addressTypeId);
+      deliveryLocationsDetail = keyBy(requester.personal.addresses, a => a.addressTypeId);
     }
 
     if (selectedAddressTypeId) {
       addressDetail = toUserAddress(deliveryLocationsDetail[selectedAddressTypeId]);
     }
 
-    const patronGroup = getPatronGroup(selectedUser, patronGroups);
+    const patronGroup = getPatronGroup(requester, patronGroups);
     const fulfillmentTypeOptions = getFulfillmentTypeOptions(hasDelivery, optionLists?.fulfillmentTypes || []);
-    const selectedProxy = getProxy(request, proxy);
     const isSubmittingDisabled = isSubmittingButtonDisabled(pristine, submitting);
     const isTitleLevelRequest = createTitleLevelRequest || request?.requestLevel === REQUEST_LEVEL_TYPES.TITLE;
     const getPatronBlockModalOpenStatus = () => {

--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -35,6 +35,7 @@ import {
   isFormEditing,
   getFulfillmentPreference,
   resetFieldState,
+  getRequester,
 } from './utils';
 
 const testIds = {
@@ -70,6 +71,7 @@ jest.mock('./utils', () => ({
   getDefaultRequestPreferences: jest.fn(),
   isFormEditing: jest.fn(),
   getFulfillmentPreference: jest.fn(),
+  getRequester: jest.fn((proxy, selectedUser) => selectedUser),
 }));
 jest.mock('./components/FulfilmentPreference', () => jest.fn(({
   changeDeliveryAddress,
@@ -1323,6 +1325,10 @@ describe('RequestForm', () => {
             expect(resetFieldState).toHaveBeenCalledWith(...expectedArgs);
           });
 
+          it('should get requester information', () => {
+            expect(getRequester).toHaveBeenCalled();
+          });
+
           it('should get information about loans', () => {
             const expectedArgs = [
               'loan',
@@ -1630,6 +1636,10 @@ describe('RequestForm', () => {
           const expectedArgs = [basicProps.form, REQUEST_FORM_FIELD_NAMES.REQUEST_TYPE];
 
           expect(resetFieldState).toHaveBeenCalledWith(...expectedArgs);
+        });
+
+        it('should get requester information', () => {
+          expect(getRequester).toHaveBeenCalled();
         });
 
         it('should get information about open instance requests', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -519,3 +519,11 @@ export function resetFieldState(form, fieldName) {
     form.resetFieldState(fieldName);
   }
 }
+
+export const getRequester = (proxy, selectedUser) => {
+  if (proxy && proxy.id !== selectedUser?.id) {
+    return proxy;
+  }
+
+  return selectedUser;
+};

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -34,6 +34,7 @@ import {
   selectedRowsNonPrintable,
   isPrintable,
   getNextSelectedRowsState,
+  getRequester,
 } from './utils';
 
 import {
@@ -1092,5 +1093,23 @@ describe('getRequestTypeOptions', () => {
     ];
 
     expect(getRequestTypeOptions(requestTypes)).toEqual(expectedResult);
+  });
+});
+
+describe('getRequester', () => {
+  const selectedUser = {
+    id: 'selectedUserId',
+  };
+
+  it('should return proxy user', () => {
+    const proxy = {
+      id: 'proxyId',
+    };
+
+    expect(getRequester(proxy, selectedUser)).toEqual(proxy);
+  });
+
+  it('should return selected user', () => {
+    expect(getRequester(null, selectedUser)).toEqual(selectedUser);
   });
 });


### PR DESCRIPTION
## Purpose
Fix issue with Proxy's patron group and delivery address that shown instead of Sponsor's when creating request

## Approach
Use proxy patron group and delivery address if proxy selected. In other cases use data of selected user.

## Refs
[UIREQ-1132](https://folio-org.atlassian.net/browse/UIREQ-1132)
[UIREQ-1133](https://folio-org.atlassian.net/browse/UIREQ-1133)