### PR TITLE
UIREQ-1148: Update permissions set to be able to get item/instance information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix issue with Proxy's patron group and delivery address that shown instead of Sponsor's when creating request. Refs UIREQ-1132, UIREQ-1133.
 * Add missing sub-permissions to fetch staff slips records. Refs UIREQ-1129.
 * Add missing sub-permissions to fetch "pick-slips" and "search-slips" records in "Requests: View, edit, cancel" permission. Refs UIREQ-1137.
+* Update permissions set to be able to get item/instance information. Refs UIREQ-1148.
 
 ## [9.1.1] (https://github.com/folio-org/ui-checkin/tree/v9.1.1) (2024-03-27)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v9.1.0...v9.1.1)

--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
           "circulation.pick-slips.get",
           "circulation.search-slips.get",
           "circulation.print-events-entry.item.post",
-          "inventory-storage.locations.item.get"
+          "inventory-storage.locations.item.get",
+          "circulation.items-by-instance.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Update permissions set to be able to get item/instance information

## Approach
Add `circulation.items-by-instance.get` sub-permission to `ui-requests.create` permission.

## Refs
[UIREQ-1148](https://folio-org.atlassian.net/browse/UIREQ-1148)