### PR TITLE
UIREQ-1149: Use "instanceId" param for ILR from items response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Add sorting to 'Printed' and '# Copies' columns in the Request App. Refs UIREQ-1140.
 * Implement "Print Status" filters as server-side filters. Refs UIREQ-1147.
 * Navigate to first page when saving the pick slip print log from beyond the first page. Refs UIREQ-1145.
+* Use `instanceId` param for ILR from items response. Refs UIREQ-1149.
 
 ## [9.1.2] (https://github.com/folio-org/ui-requests/tree/v9.1.2) (2024-09-13)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v9.1.1...v9.1.2)

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -143,7 +143,6 @@ class RequestForm extends React.Component {
     values: PropTypes.object.isRequired,
     form: PropTypes.object.isRequired,
     blocked: PropTypes.bool.isRequired,
-    instanceId: PropTypes.string.isRequired,
     isPatronBlocksOverridden: PropTypes.bool.isRequired,
     onSubmit: PropTypes.func,
     parentMutator: PropTypes.shape({
@@ -160,7 +159,6 @@ class RequestForm extends React.Component {
     onSetSelectedInstance: PropTypes.func.isRequired,
     onSetBlocked: PropTypes.func.isRequired,
     onSetIsPatronBlocksOverridden: PropTypes.func.isRequired,
-    onSetInstanceId: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -717,22 +715,21 @@ class RequestForm extends React.Component {
   findItemRelatedResources(item) {
     const {
       findResource,
-      onSetInstanceId,
     } = this.props;
-    if (!item) return null;
+
+    if (!item) {
+      return null;
+    }
 
     return Promise.all(
       [
         findResource('loan', item.id),
         findResource('requestsForItem', item.id),
-        findResource(RESOURCE_TYPES.HOLDING, item.holdingsRecordId),
       ],
     ).then((results) => {
       const selectedLoan = results[0]?.loans?.[0];
       const itemRequestCount = results[1]?.requests?.length;
-      const holdingsRecord = results[2]?.holdingsRecords?.[0];
 
-      onSetInstanceId(holdingsRecord?.instanceId);
       this.setState({
         itemRequestCount,
         selectedLoan,
@@ -811,6 +808,11 @@ class RequestForm extends React.Component {
 
           return foundItem;
         })
+        .catch(() => {
+          onSetSelectedItem(null);
+
+          return null;
+        })
         .then(item => {
           if (item && selectedUser?.id) {
             const requester = getRequester(proxy, selectedUser);
@@ -887,6 +889,11 @@ class RequestForm extends React.Component {
           });
 
           return instance;
+        })
+        .catch(() => {
+          onSetSelectedInstance(null);
+
+          return null;
         })
         .then(instance => {
           if (instance && selectedUser?.id) {
@@ -1093,7 +1100,6 @@ class RequestForm extends React.Component {
       selectedUser,
       selectedInstance,
       isPatronBlocksOverridden,
-      instanceId,
       blocked,
       values,
       onCancel,
@@ -1283,7 +1289,6 @@ class RequestForm extends React.Component {
                               onSetSelectedInstance={onSetSelectedInstance}
                               isLoading={isItemOrInstanceLoading}
                               instanceRequestCount={instanceRequestCount}
-                              instanceId={instanceId}
                             />
                           </div>
                         </Accordion>
@@ -1305,7 +1310,6 @@ class RequestForm extends React.Component {
                               onSetSelectedItem={onSetSelectedItem}
                               values={values}
                               itemRequestCount={itemRequestCount}
-                              instanceId={instanceId}
                               selectedLoan={selectedLoan}
                               isLoading={isItemOrInstanceLoading}
                             />

--- a/src/RequestFormContainer.js
+++ b/src/RequestFormContainer.js
@@ -39,7 +39,6 @@ const RequestFormContainer = ({
   const [selectedUser, setSelectedUser] = useState({ ...requester, id: requesterId });
   const [selectedInstance, setSelectedInstance] = useState(request?.instance);
   const [isPatronBlocksOverridden, setIsPatronBlocksOverridden] = useState(false);
-  const [instanceId, setInstanceId] = useState('');
   const [blocked, setBlocked] = useState(false);
 
   const setItem = (optedItem) => {
@@ -60,10 +59,6 @@ const RequestFormContainer = ({
 
   const setStateIsPatronBlocksOverridden = (value) => {
     setIsPatronBlocksOverridden(value);
-  };
-
-  const setStateInstanceId = (id) => {
-    setInstanceId(id);
   };
 
   const getPatronManualBlocks = (resources) => {
@@ -142,7 +137,7 @@ const RequestFormContainer = ({
       };
     }
 
-    requestData.instanceId = request?.instanceId || instanceId || selectedInstance?.id;
+    requestData.instanceId = request?.instanceId || selectedInstance?.id || selectedItem?.instanceId;
     requestData.requestLevel = request?.requestLevel || getRequestLevelValue(requestData.createTitleLevelRequest);
 
     if (requestData.requestLevel === REQUEST_LEVEL_TYPES.ITEM) {
@@ -179,7 +174,6 @@ const RequestFormContainer = ({
       selectedUser={selectedUser}
       selectedInstance={selectedInstance}
       isPatronBlocksOverridden={isPatronBlocksOverridden}
-      instanceId={instanceId}
       onGetPatronManualBlocks={getPatronManualBlocks}
       onGetAutomatedPatronBlocks={getAutomatedPatronBlocks}
       onSetBlocked={setIsBlocked}
@@ -187,7 +181,6 @@ const RequestFormContainer = ({
       onSetSelectedUser={setUser}
       onSetSelectedInstance={setInstance}
       onSetIsPatronBlocksOverridden={setStateIsPatronBlocksOverridden}
-      onSetInstanceId={setStateInstanceId}
       onSubmit={handleSubmit}
     />
   );

--- a/src/RequestFormContainer.test.js
+++ b/src/RequestFormContainer.test.js
@@ -55,7 +55,6 @@ describe('RequestFormContainer', () => {
         },
         selectedInstance: defaultProps.request.instance,
         isPatronBlocksOverridden: false,
-        instanceId: '',
         onGetPatronManualBlocks: expect.any(Function),
         onGetAutomatedPatronBlocks: expect.any(Function),
         onSetBlocked: expect.any(Function),
@@ -63,7 +62,6 @@ describe('RequestFormContainer', () => {
         onSetSelectedUser: expect.any(Function),
         onSetSelectedInstance: expect.any(Function),
         onSetIsPatronBlocksOverridden: expect.any(Function),
-        onSetInstanceId: expect.any(Function),
         onSubmit: expect.any(Function),
       };
 
@@ -100,6 +98,10 @@ describe('RequestFormContainer', () => {
       };
       const props = {
         ...defaultProps,
+        request: {
+          ...defaultProps.request,
+          instanceId: null,
+        },
         itemId: 'itemId',
         item: {
           id: 'id',
@@ -107,6 +109,7 @@ describe('RequestFormContainer', () => {
       };
       const selectedItem = {
         holdingsRecordId: 'holdingsRecordId',
+        instanceId: 'instanceId',
       };
       const selectItemLabel = 'Select Item';
 
@@ -144,7 +147,7 @@ describe('RequestFormContainer', () => {
         const expectedArg = {
           holdingsRecordId: selectedItem.holdingsRecordId,
           fulfillmentPreference: fulfillmentTypeMap.HOLD_SHELF,
-          instanceId: defaultProps.request.instanceId,
+          instanceId: selectedItem.instanceId,
           requestLevel: REQUEST_LEVEL_TYPES.ITEM,
           pickupServicePointId: submitData.pickupServicePointId,
           item: submitData.item,

--- a/src/components/InstanceInformation/InstanceInformation.js
+++ b/src/components/InstanceInformation/InstanceInformation.js
@@ -37,7 +37,6 @@ class InstanceInformation extends Component {
     values: PropTypes.object.isRequired,
     onSetSelectedInstance: PropTypes.func.isRequired,
     isLoading: PropTypes.bool.isRequired,
-    instanceId: PropTypes.string.isRequired,
     request: PropTypes.object,
     instanceRequestCount: PropTypes.number,
     selectedInstance: PropTypes.object,
@@ -159,7 +158,6 @@ class InstanceInformation extends Component {
       values,
       isLoading,
       instanceRequestCount,
-      instanceId,
     } = this.props;
     const {
       isInstanceClicked,
@@ -247,7 +245,7 @@ class InstanceInformation extends Component {
           {
             isTitleInfoVisible &&
               <TitleInformation
-                instanceId={request?.instanceId || selectedInstance.id || instanceId}
+                instanceId={request?.instanceId || selectedInstance.id}
                 titleLevelRequestsCount={titleLevelRequestsCount}
                 title={selectedInstance.title}
                 contributors={selectedInstance.contributors || selectedInstance.contributorNames}

--- a/src/components/InstanceInformation/InstanceInformation.test.js
+++ b/src/components/InstanceInformation/InstanceInformation.test.js
@@ -52,13 +52,13 @@ const basicProps = {
   },
   selectedInstance: {
     title: 'instance title',
+    id: 'instanceId',
     contributors: {},
     publication: {},
     editions: {},
     identifiers: {},
   },
   instanceRequestCount: 1,
-  instanceId: 'instanceId',
   isLoading: false,
   submitting: false,
 };
@@ -584,26 +584,6 @@ describe('InstanceInformation', () => {
     });
 
     describe('when instance is selected', () => {
-      it('should render "TitleInformation" with correct props', () => {
-        render(
-          <InstanceInformation
-            {...basicProps}
-          />
-        );
-
-        const expectedProps = {
-          instanceId: basicProps.instanceId,
-          titleLevelRequestsCount: basicProps.instanceRequestCount,
-          title: basicProps.selectedInstance.title,
-          contributors: basicProps.selectedInstance.contributors,
-          publications: basicProps.selectedInstance.publication,
-          editions: basicProps.selectedInstance.editions,
-          identifiers: basicProps.selectedInstance.identifiers,
-        };
-
-        expect(TitleInformation).toHaveBeenCalledWith(expectedProps, {});
-      });
-
       it('should render "TitleInformation" with "request.instanceId"', () => {
         const instanceId = 'instanceId';
         const props = {
@@ -627,21 +607,13 @@ describe('InstanceInformation', () => {
       });
 
       it('should render "TitleInformation" with "selectedInstance.id"', () => {
-        const selectedInstanceId = 'selectedInstanceId';
-        const props = {
-          ...basicProps,
-          selectedInstance: {
-            ...basicProps.selectedInstance,
-            id: selectedInstanceId,
-          },
-        };
         const expectedProps = {
-          instanceId: selectedInstanceId,
+          instanceId: basicProps.selectedInstance.id,
         };
 
         render(
           <InstanceInformation
-            {...props}
+            {...basicProps}
           />
         );
 

--- a/src/components/ItemInformation/ItemInformation.js
+++ b/src/components/ItemInformation/ItemInformation.js
@@ -35,7 +35,6 @@ class ItemInformation extends Component {
     request: PropTypes.object.isRequired,
     onSetSelectedItem: PropTypes.func.isRequired,
     itemRequestCount: PropTypes.number.isRequired,
-    instanceId: PropTypes.string.isRequired,
     isLoading: PropTypes.bool.isRequired,
     submitting: PropTypes.bool.isRequired,
     isItemIdRequest: PropTypes.bool.isRequired,
@@ -162,7 +161,6 @@ class ItemInformation extends Component {
       isLoading,
       selectedItem,
       request,
-      instanceId,
       selectedLoan,
       itemRequestCount,
     } = this.props;
@@ -235,7 +233,7 @@ class ItemInformation extends Component {
             selectedItem &&
               <ItemDetail
                 request={request}
-                currentInstanceId={instanceId}
+                currentInstanceId={selectedItem.instanceId}
                 item={selectedItem}
                 loan={selectedLoan}
                 requestCount={itemRequestCount}

--- a/src/components/ItemInformation/ItemInformation.test.js
+++ b/src/components/ItemInformation/ItemInformation.test.js
@@ -48,7 +48,6 @@ const basicProps = {
   selectedLoan: {},
   selectedItem: {},
   itemRequestCount: 1,
-  instanceId: 'instanceId',
   isLoading: false,
   submitting: false,
   isItemIdRequest: true,
@@ -546,10 +545,18 @@ describe('ItemInformation', () => {
     });
 
     describe('when item is selected', () => {
+      const props = {
+        ...basicProps,
+        selectedItem: {
+          id: 'itemId',
+          instanceId: 'instanceId',
+        },
+      };
+
       beforeEach(() => {
         render(
           <ItemInformation
-            {...basicProps}
+            {...props}
           />
         );
       });
@@ -557,7 +564,7 @@ describe('ItemInformation', () => {
       it('should render "ItemDetail" with correct props', () => {
         const expectedProps = {
           request: basicProps.request,
-          currentInstanceId: basicProps.instanceId,
+          currentInstanceId: basicProps.selectedItem.instanceId,
           item: basicProps.selectedItem,
           loan: basicProps.selectedLoan,
           requestCount: basicProps.itemRequestCount,

--- a/src/constants.js
+++ b/src/constants.js
@@ -329,7 +329,6 @@ export const RESOURCE_TYPES = {
   ITEM: 'item',
   INSTANCE: 'instance',
   USER: 'user',
-  HOLDING: 'holding',
   REQUEST_TYPES: 'requestTypes',
   ECS_TLR_SETTINGS: 'ecsTlrSettings',
 };

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -202,11 +202,6 @@ export const urls = {
 
     return `request-preference-storage/request-preference?${query}`;
   },
-  holding: (value, idType) => {
-    const query = stringify({ query: `(${idType}=="${value}")` });
-
-    return `holdings-storage/holdings?${query}`;
-  },
   requestTypes: ({
     requesterId,
     itemId,

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -1827,29 +1827,6 @@ describe('RequestsRoute', () => {
       });
     });
 
-    describe('holding', () => {
-      const value = 'value';
-      let queryString;
-
-      beforeEach(() => {
-        queryString = urls.holding(value, idType);
-      });
-
-      it('should trigger "stringify" with correct argument', () => {
-        const expectedArgument = {
-          query: `(${idType}=="${value}")`,
-        };
-
-        expect(stringify).toHaveBeenCalledWith(expectedArgument);
-      });
-
-      it('should return correct url', () => {
-        const expectedResult = `holdings-storage/holdings?${mockedQueryValue}`;
-
-        expect(queryString).toBe(expectedResult);
-      });
-    });
-
     describe('requestTypes', () => {
       const requesterId = 'requesterIdUrl';
       const operation = REQUEST_OPERATIONS.CREATE;


### PR DESCRIPTION
## Purpose
In some cases when we create an Item level request we do not send `instanceId` param to the server.
In this PR I get `instanseId` param from item that was received from `circulation/items-by-instance`  endpoint.

## Refs
[UIREQ-1149](https://folio-org.atlassian.net/browse/UIREQ-1149)