### PR TITLE
UIREQ-1169: Add missed permission to get tlr settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Also support okapiInterfaces `inventory` `14.0`. Refs UIREQ-1160.
 * Use `instanceId` param for ILR from items response. Refs UIREQ-1149.
 * Send `holdingsRecordId` param for Item level requests. Refs UIREQ-1167.
+* Add `tlr.settings.get` permission. Refs UIREQ-1169.
 
 ## [9.1.2] (https://github.com/folio-org/ui-requests/tree/v9.1.2) (2024-09-13)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v9.1.1...v9.1.2)

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
         "subPermissions": [
           "module.requests.enabled",
           "circulation.loans.collection.get",
-          "circulation.settings.collection.get",
           "circulation.settings.item.get",
           "circulation.requests.collection.get",
           "circulation.requests.item.get",
@@ -108,7 +107,8 @@
           "inventory-storage.instances.collection.get",
           "manualblocks.collection.get",
           "circulation.requests.hold-shelf-clearance-report.get",
-          "circulation.settings.collection.get"
+          "circulation.settings.collection.get",
+          "tlr.settings.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
- Add missed **"tlr.settings.get"** permission to get tlr settings.
- Remove duplicated permission.

## Refs
[UIREQ-1169](https://folio-org.atlassian.net/browse/UIREQ-1169)