### PR TITLE
UIREQ-1170: Add missed permission to get global circulation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Send `holdingsRecordId` param for Item level requests. Refs UIREQ-1167.
 * Review and cleanup Module Descriptor. Refs UIREQ-1156.
 * Add `tlr.settings.get` permission. Refs UIREQ-1169.
+* Add `mod-settings.global.read.circulation` permission. Refs UIREQ-1170.
 
 ## [9.1.2] (https://github.com/folio-org/ui-requests/tree/v9.1.2) (2024-09-13)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v9.1.1...v9.1.2)

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
           "manualblocks.collection.get",
           "circulation.requests.hold-shelf-clearance-report.get",
           "circulation.settings.collection.get",
-          "tlr.settings.get"
+          "tlr.settings.get",
+          "mod-settings.global.read.circulation"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Add `mod-settings.global.read.circulation` sub permission to get information about TLR related settings.

## Refs
[UIREQ-1170](https://folio-org.atlassian.net/browse/UIREQ-1170)