### PR TITLE
UIREQ-1177: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Send `holdingsRecordId` param for Item level requests. Refs UIREQ-1167.
 * Add `tlr.settings.get` permission. Refs UIREQ-1169.
 * Add `mod-settings.global.read.circulation` permission. Refs UIREQ-1170.
+* Add `mod-settings.entries.collection.get` permission. Refs UIREQ-1177.
 
 ## [10.0.0] (https://github.com/folio-org/ui-requests/tree/v10.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v9.1.2...v10.0.0)

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
           "circulation.requests.hold-shelf-clearance-report.get",
           "circulation.settings.collection.get",
           "tlr.settings.get",
-          "mod-settings.global.read.circulation"
+          "mod-settings.global.read.circulation",
+          "mod-settings.entries.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Add `mod-settings.entries.collection.get` permission to be able to get requests related settings if user has only requests related permissions.

## Refs
[UIREQ-1177](https://folio-org.atlassian.net/browse/UIREQ-1177)