### PR TITLE
UIREQ-1044: Increase code coverage for src/ChooseRequestTypeDialog.js by Jest/RTL tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [11.1.0] IN PROGRESS
 
 * Migrate from `mod-circulation` to `mod-circulation-bff` for `Print pick slips` and `Print search slips`. Refs UIREQ-1154.
+* Increase code coverage for src/ChooseRequestTypeDialog.js by Jest/RTL tests. Refs UIREQ-1044.
 
 ## [11.0.1] (https://github.com/folio-org/ui-requests/tree/v11.0.1) (2024-12-02)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v11.0.0...v11.0.1)

--- a/src/ChooseRequestTypeDialog.js
+++ b/src/ChooseRequestTypeDialog.js
@@ -81,6 +81,7 @@ class ChooseRequestTypeDialog extends React.Component {
         {isLoading ?
           <Loading data-testid="loading" /> :
           <Select
+            data-testid="requestType"
             label={<FormattedMessage id="ui-requests.moveRequest.chooseRequestMessage" />}
             name="requestType"
             onChange={this.selectRequestType}

--- a/src/ChooseRequestTypeDialog.test.js
+++ b/src/ChooseRequestTypeDialog.test.js
@@ -1,6 +1,7 @@
 import {
   render,
   screen,
+  fireEvent,
 } from '@folio/jest-config-stripes/testing-library/react';
 
 import { Button } from '@folio/stripes/components';
@@ -23,9 +24,12 @@ jest.mock('./utils', () => ({
 
 const labelIds = {
   chooseRequestType: 'ui-requests.moveRequest.chooseRequestType',
+  confirmButtonLabel: 'ui-requests.moveRequest.confirm',
+  requestTypeError: 'ui-requests.moveRequest.error.itemLevelRequest',
 };
 const testIds = {
   loading: 'loading',
+  requestType: 'requestType',
 };
 
 describe('ChooseRequestTypeDialog', () => {
@@ -84,6 +88,38 @@ describe('ChooseRequestTypeDialog', () => {
 
     it('should not render Loading component', () => {
       expect(screen.queryByTestId(testIds.loading)).not.toBeInTheDocument();
+    });
+
+    it('should handle confirmation after changing request type', () => {
+      const requestType = screen.getByTestId(testIds.requestType);
+      const confirmButton = screen.getByText(labelIds.confirmButtonLabel);
+      const event = {
+        target: {
+          value: '',
+        },
+      };
+
+      fireEvent.change(requestType, event);
+      fireEvent.click(confirmButton);
+
+      expect(mockOnConfirm).toHaveBeenCalledWith(event.target.value);
+    });
+  });
+
+  describe('When request type is not provided', () => {
+    const props = {
+      ...defaultTestProps,
+      requestTypes: [],
+    };
+
+    beforeEach(() => {
+      render(<ChooseRequestTypeDialog {...props} />);
+    });
+
+    it('should render request type error', () => {
+      const requestTypeError = screen.getByText(labelIds.requestTypeError);
+
+      expect(requestTypeError).toBeInTheDocument();
     });
   });
 

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -180,6 +180,7 @@ jest.mock('@folio/stripes/components', () => ({
       <select {...props}>
         {props.children}
       </select>
+      <span>{props.error}</span>
     </div>)),
   TextArea: jest.fn(({
     'data-testid': testId,


### PR DESCRIPTION
## Purpose
Increase code coverage for src/ChooseRequestTypeDialog.js by Jest/RTL tests

## Refs
[UIREQ-1044](https://folio-org.atlassian.net/browse/UIREQ-1044)