### PR TITLE
UIREQ-1138 Change import of `exportToCsv` from `stripes-util` to `stripes-components`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * React v19: refactor away from default props for functional components. Refs UIREQ-1101.
 * Add icons to requests action menu. Refs UIREQ-1116.
 * Revise "Enter" button on New request page. Refs UIREQ-1114.
+* Change import of `exportToCsv` from `stripes-util` to `stripes-components`. Refs UIREQ-1138.
 
 ## [11.0.3] (https://github.com/folio-org/ui-requests/tree/v11.0.3) (2025-01-10)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v11.0.2...v11.0.3)

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.js
@@ -34,6 +34,7 @@ import {
   NoValue,
   MCLPagingTypes,
   Icon,
+  exportToCsv,
 } from '@folio/stripes/components';
 import {
   deparseFilters,
@@ -41,7 +42,6 @@ import {
   SearchAndSort,
 } from '@folio/stripes/smart-components';
 import {
-  exportCsv,
   effectiveCallNumber,
   getHeaderWithCredentials,
 } from '@folio/stripes/util';
@@ -638,7 +638,7 @@ class RequestsRoute extends React.Component {
     this.findResource = this.findResource.bind(this);
     this.toggleModal = this.toggleModal.bind(this);
     this.buildRecords = this.buildRecords.bind(this);
-    // Map to pass into exportCsv
+    // Map to pass into exportToCsv
     this.columnHeadersMap = this.getColumnHeaders(reportHeaders);
     this.expiredHoldsReportColumnHeaders = this.getColumnHeaders(expiredHoldsReportHeaders);
 
@@ -860,7 +860,7 @@ class RequestsRoute extends React.Component {
     this.columnHeadersMap = this.state.isViewPrintDetailsEnabled ? this.columnHeadersMap :
       getFilteredColumnHeadersMap(this.columnHeadersMap);
 
-    exportCsv(recordsToCSV, {
+    exportToCsv(recordsToCSV, {
       onlyFields: this.columnHeadersMap,
       excludeFields: ['id'],
     });
@@ -1211,7 +1211,7 @@ class RequestsRoute extends React.Component {
     }
 
     const recordsToCSV = buildHoldRecords(requests);
-    exportCsv(recordsToCSV, {
+    exportToCsv(recordsToCSV, {
       onlyFields: this.expiredHoldsReportColumnHeaders,
       excludeFields: ['id'],
     });

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
@@ -24,11 +24,9 @@ import {
 import {
   TextLink,
   Checkbox,
+  exportToCsv,
 } from '@folio/stripes/components';
-import {
-  exportCsv,
-  effectiveCallNumber,
-} from '@folio/stripes/util';
+import { effectiveCallNumber } from '@folio/stripes/util';
 
 import RequestsRoute, {
   buildHoldRecords,
@@ -610,11 +608,11 @@ describe('RequestsRoute', () => {
       expect(printContent).toBeInTheDocument();
     });
 
-    it('should trigger "exportCsv"', async () => {
+    it('should trigger "exportToCsv"', async () => {
       await userEvent.click(screen.getByRole('button', { name: 'ui-requests.exportSearchResultsCsv' }));
 
       await waitFor(() => {
-        expect(exportCsv).toHaveBeenCalled();
+        expect(exportToCsv).toHaveBeenCalled();
       });
     });
 
@@ -818,12 +816,12 @@ describe('RequestsRoute', () => {
         expect(defaultProps.mutator.savePrintDetails.POST).not.toHaveBeenCalled();
       });
 
-      it('should trigger "exportCsv"', async () => {
+      it('should trigger "exportToCsv"', async () => {
         renderComponent(getPropsWithSortInQuery());
         await userEvent.click(screen.getByRole('button', { name: 'ui-requests.exportSearchResultsCsv' }));
 
         await waitFor(() => {
-          expect(exportCsv).toHaveBeenCalled();
+          expect(exportToCsv).toHaveBeenCalled();
         });
       });
 

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -36,6 +36,7 @@ import {
   NoValue,
   MCLPagingTypes,
   Icon,
+  exportToCsv,
 } from '@folio/stripes/components';
 import {
   deparseFilters,
@@ -43,7 +44,6 @@ import {
   SearchAndSort,
 } from '@folio/stripes/smart-components';
 import {
-  exportCsv,
   effectiveCallNumber,
   getHeaderWithCredentials,
 } from '@folio/stripes/util';
@@ -647,7 +647,7 @@ class RequestsRoute extends React.Component {
     this.findResource = this.findResource.bind(this);
     this.toggleModal = this.toggleModal.bind(this);
     this.buildRecords = this.buildRecords.bind(this);
-    // Map to pass into exportCsv
+    // Map to pass into exportToCsv
     this.columnHeadersMap = this.getColumnHeaders(reportHeaders);
     this.expiredHoldsReportColumnHeaders = this.getColumnHeaders(expiredHoldsReportHeaders);
 
@@ -921,7 +921,7 @@ class RequestsRoute extends React.Component {
       this.columnHeadersMap :
       this.columnHeadersMap.filter(({ value }) => (value !== PROXY_COLUMNS.BARCODE && value !== PROXY_COLUMNS.NAME));
 
-    exportCsv(recordsToCSV, {
+    exportToCsv(recordsToCSV, {
       onlyFields: finalColumnHeadersMap,
       excludeFields: ['id'],
     });
@@ -1287,7 +1287,7 @@ class RequestsRoute extends React.Component {
     }
 
     const recordsToCSV = buildHoldRecords(requests);
-    exportCsv(recordsToCSV, {
+    exportToCsv(recordsToCSV, {
       onlyFields: this.expiredHoldsReportColumnHeaders,
       excludeFields: ['id'],
     });

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -25,9 +25,9 @@ import {
 import {
   TextLink,
   Checkbox,
+  exportToCsv,
 } from '@folio/stripes/components';
 import {
-  exportCsv,
   effectiveCallNumber,
   getHeaderWithCredentials,
 } from '@folio/stripes/util';
@@ -634,11 +634,11 @@ describe('RequestsRoute', () => {
       expect(printContent).toBeInTheDocument();
     });
 
-    it("should trigger 'exportCsv'", async () => {
+    it("should trigger 'exportToCsv'", async () => {
       await userEvent.click(screen.getByRole('button', { name: 'ui-requests.exportSearchResultsCsv' }));
 
       await waitFor(() => {
-        expect(exportCsv).toHaveBeenCalled();
+        expect(exportToCsv).toHaveBeenCalled();
       });
     });
 
@@ -974,12 +974,12 @@ describe('RequestsRoute', () => {
         expect(defaultProps.mutator.savePrintDetails.POST).not.toHaveBeenCalled();
       });
 
-      it('should trigger "exportCsv"', async () => {
+      it('should trigger "exportToCsv"', async () => {
         renderComponent(getPropsWithSortInQuery());
         await userEvent.click(screen.getByRole('button', { name: 'ui-requests.exportSearchResultsCsv' }));
 
         await waitFor(() => {
-          expect(exportCsv).toHaveBeenCalled();
+          expect(exportToCsv).toHaveBeenCalled();
         });
       });
 

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -209,4 +209,5 @@ jest.mock('@folio/stripes/components', () => ({
   }),
   TextLink: jest.fn(({ to, children }) => <div><a href={to}>{children}</a></div>),
   Timepicker: jest.fn(() => <div>Timepicker</div>),
+  exportToCsv: jest.fn(),
 }));

--- a/test/jest/__mock__/stripesUtils.mock.js
+++ b/test/jest/__mock__/stripesUtils.mock.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/util', () => ({
-  exportCsv: jest.fn(),
   effectiveCallNumber: jest.fn().mockReturnValue('effectiveCallNumber'),
   getHeaderWithCredentials: jest.fn()
 }));


### PR DESCRIPTION
## Description
Use `exportToCsv` from `stripes-components` instead of a deprecated `exportCsv` from `stripes-utils`

## Issues
[UIREQ-1138](https://folio-org.atlassian.net/browse/UIREQ-1138)