### PR TITLE
UIREQ-1254: Hide edit, cancel, move and duplicate buttons for intermediate requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * *BREAKING* Update `react-intl` to `^7`. Refs UIREQ-1259.
 * Migrate to shared GA workflows. Refs UIREQ-1257.
 * *BREAKING* Update stripes-* dependencies to latest version. Refs UIREQ-1258.
+* Hide edit, cancel, move and duplicate buttons for intermediate requests in central tenant. Refs UIREQ-1254.
 
 ## [11.0.4] (https://github.com/folio-org/ui-requests/tree/v11.0.4) (2025-02-07)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v11.0.3...v11.0.4)

--- a/src/ViewRequest.test.js
+++ b/src/ViewRequest.test.js
@@ -13,6 +13,7 @@ import {
   Icon,
   PaneHeaderIconButton,
 } from '@folio/stripes/components';
+import { checkIfUserInCentralTenant } from '@folio/stripes/core';
 
 import ViewRequest, {
   isAnyActionButtonVisible,
@@ -288,6 +289,7 @@ describe('ViewRequest', () => {
       <ViewRequest {...props} />
     </CommandList>
   );
+  checkIfUserInCentralTenant.mockReturnValue(true);
 
   describe('Non DCB Transactions', () => {
     beforeEach(() => {
@@ -1336,6 +1338,10 @@ describe('ViewRequest', () => {
 
     it('should return false', () => {
       expect(shouldHideMoveAndDuplicate(stripes, false, true, false)).toBe(false);
+    });
+
+    it('should return true for intermediate request in central tenant', () => {
+      expect(shouldHideMoveAndDuplicate(stripes, false, false, false, true)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Purpose
Hide edit, cancel, move and duplicate buttons for intermediate requests in central tenant.

## Refs
[UIREQ-1254](https://folio-org.atlassian.net/browse/UIREQ-1254)