### PR TITLE
UIREQ-1217: Printing of request slips is unavailable with only "Requests: View" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Hide edit, cancel, move and duplicate buttons for intermediate requests in central tenant. Refs UIREQ-1254.
 * Filter request print tracking data for duplicates. Refs UIREQ-1261.
 * Support new item tokens for printing pick slips, search slips, etc. Fixes UIREQ-1267.
+* Add missed sub-permissions for "Requests: View" permission. Refs UIREQ-1217.
 
 ## [11.0.4] (https://github.com/folio-org/ui-requests/tree/v11.0.4) (2025-02-07)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v11.0.3...v11.0.4)

--- a/package.json
+++ b/package.json
@@ -115,7 +115,14 @@
           "circulation.settings.collection.get",
           "tlr.settings.get",
           "mod-settings.global.read.circulation",
-          "mod-settings.entries.collection.get"
+          "mod-settings.entries.collection.get",
+          "mod-settings.entries.item.get",
+          "circulation.search-slips.get",
+          "circulation.pick-slips.get",
+          "circulation-bff.search-slips.collection.get",
+          "circulation-bff.pick-slips.collection.get",
+          "circulation-storage.staff-slips.collection.get",
+          "tags.collection.get"
         ],
         "visible": true
       },
@@ -131,11 +138,6 @@
           "circulation-bff.requests.allowed-service-points.get",
           "circulation-storage.requests.item.post",
           "circulation-storage.request-preferences.collection.get",
-          "circulation-storage.staff-slips.collection.get",
-          "circulation.pick-slips.get",
-          "circulation.search-slips.get",
-          "circulation-bff.pick-slips.collection.get",
-          "circulation-bff.search-slips.collection.get",
           "circulation.print-events-entry.item.post",
           "inventory-storage.locations.item.get",
           "circulation-bff.requests.search-instances.get",
@@ -148,20 +150,14 @@
         "displayName": "Requests: View, edit, cancel",
         "subPermissions": [
           "ui-requests.view",
-          "circulation.pick-slips.get",
-          "circulation.search-slips.get",
-          "circulation-bff.pick-slips.collection.get",
-          "circulation-bff.search-slips.collection.get",
           "circulation.requests.item.put",
           "circulation.requests.allowed-service-points.get",
           "circulation-bff.requests.allowed-service-points.get",
           "circulation.print-events-entry.item.post",
-          "circulation-storage.staff-slips.collection.get",
           "circulation-storage.requests.collection.delete",
           "circulation-storage.requests.item.put",
           "circulation-storage.requests.item.delete",
           "circulation-storage.request-preferences.collection.get",
-          "tags.collection.get",
           "tags.item.post"
         ],
         "visible": true


### PR DESCRIPTION
## Purpose
Add missed sub-permissions for "Requests: View" permission.

## Refs
[UIREQ-1217](https://folio-org.atlassian.net/browse/UIREQ-1217)