### PR TITLE
UIREQ-1262: Implement support for fields without information in Requests UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Filter request print tracking data for duplicates. Refs UIREQ-1261.
 * Support new item tokens for printing pick slips, search slips, etc. Fixes UIREQ-1267.
 * Make focus indicator visible for instance name on the Requests Queue page. Refs UIREQ-1215.
+* Use NoValue component for absent information. Refs UIREQ-1262.
 
 ## [11.0.4] (https://github.com/folio-org/ui-requests/tree/v11.0.4) (2025-02-07)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v11.0.3...v11.0.4)

--- a/src/ItemsDialog.js
+++ b/src/ItemsDialog.js
@@ -20,6 +20,7 @@ import {
   MultiColumnList,
   Pane,
   Paneset,
+  NoValue,
 } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 
@@ -63,10 +64,11 @@ export const COLUMN_MAP = {
 };
 
 export const formatter = {
+  barcode: item => (item?.barcode || <NoValue />),
   itemStatus: item => <FormattedMessage id={itemStatusesTranslations[item.status.name]} />,
-  location: item => get(item, 'effectiveLocation.name', ''),
+  location: item => get(item, 'effectiveLocation.name', <NoValue />),
   materialType: item => item.materialType.name,
-  loanType: item => (item.temporaryLoanType ? get(item, 'temporaryLoanType.name', '') : get(item, 'permanentLoanType.name', '')),
+  loanType: item => (item.temporaryLoanType ? get(item, 'temporaryLoanType.name', <NoValue />) : get(item, 'permanentLoanType.name', <NoValue />)),
 };
 
 export const MAX_HEIGHT = 500;

--- a/src/ItemsDialog.test.js
+++ b/src/ItemsDialog.test.js
@@ -8,6 +8,7 @@ import {
   MultiColumnList,
   Pane,
   Paneset,
+  NoValue,
 } from '@folio/stripes/components';
 
 import {
@@ -392,6 +393,7 @@ describe('ItemsDialog', () => {
 
   describe('formatter', () => {
     const item = {
+      barcode: 'barcode',
       status: {
         name: 'Aged to lost',
       },
@@ -409,6 +411,25 @@ describe('ItemsDialog', () => {
       },
     };
 
+    afterEach(() => {
+      NoValue.mockClear();
+    });
+
+    describe('barcode', () => {
+      it('should return item barcode', () => {
+        expect(formatter.barcode(item)).toBe(item.barcode);
+      });
+
+      it('should trigger NoValue component', () => {
+        render(formatter.barcode({
+          ...item,
+          barcode: undefined,
+        }));
+
+        expect(NoValue).toHaveBeenCalled();
+      });
+    });
+
     describe('itemStatus', () => {
       it('should return formatted message', () => {
         expect(formatter.itemStatus(item).props.id).toEqual('ui-requests.item.status.agedToLost');
@@ -420,11 +441,13 @@ describe('ItemsDialog', () => {
         expect(formatter.location(item)).toEqual('effective location name');
       });
 
-      it('should return default value for effective location name', () => {
-        expect(formatter.location({
+      it('should trigger NoValue component', () => {
+        render(formatter.location({
           ...item,
           effectiveLocation: {},
-        })).toEqual('');
+        }));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -440,13 +463,15 @@ describe('ItemsDialog', () => {
           expect(formatter.loanType(item)).toEqual('temporary loan type name');
         });
 
-        it('should return default value for temporary loan type name', () => {
-          expect(formatter.loanType({
+        it('should trigger NoValue component', () => {
+          render(formatter.loanType({
             ...item,
             temporaryLoanType: {
               other: '',
             },
-          })).toEqual('');
+          }));
+
+          expect(NoValue).toHaveBeenCalled();
         });
       });
 
@@ -458,14 +483,16 @@ describe('ItemsDialog', () => {
           })).toEqual('permanent loan type name');
         });
 
-        it('should return default value for permanent loan type name', () => {
-          expect(formatter.loanType({
+        it('should trigger NoValue component', () => {
+          render(formatter.loanType({
             ...item,
             temporaryLoanType: false,
             permanentLoanType: {
               other: '',
             },
-          })).toEqual('');
+          }));
+
+          expect(NoValue).toHaveBeenCalled();
         });
       });
     });

--- a/src/deprecated/components/ItemsDialog/ItemsDialog.js
+++ b/src/deprecated/components/ItemsDialog/ItemsDialog.js
@@ -20,6 +20,7 @@ import {
   MultiColumnList,
   Pane,
   Paneset,
+  NoValue,
 } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 
@@ -63,10 +64,11 @@ export const COLUMN_MAP = {
 };
 
 export const formatter = {
+  barcode: item => (item?.barcode || <NoValue />),
   itemStatus: item => <FormattedMessage id={itemStatusesTranslations[item.status.name]} />,
-  location: item => get(item, 'effectiveLocation.name', ''),
+  location: item => get(item, 'effectiveLocation.name', <NoValue />),
   materialType: item => item.materialType.name,
-  loanType: item => (item.temporaryLoanType ? get(item, 'temporaryLoanType.name', '') : get(item, 'permanentLoanType.name', '')),
+  loanType: item => (item.temporaryLoanType ? get(item, 'temporaryLoanType.name', <NoValue />) : get(item, 'permanentLoanType.name', <NoValue />)),
 };
 
 export const MAX_HEIGHT = 500;

--- a/src/deprecated/components/ItemsDialog/ItemsDialog.test.js
+++ b/src/deprecated/components/ItemsDialog/ItemsDialog.test.js
@@ -8,6 +8,7 @@ import {
   MultiColumnList,
   Pane,
   Paneset,
+  NoValue,
 } from '@folio/stripes/components';
 
 import {
@@ -409,6 +410,7 @@ describe('ItemsDialog', () => {
 
   describe('formatter', () => {
     const item = {
+      barcode: 'barcode',
       status: {
         name: 'Aged to lost',
       },
@@ -426,6 +428,25 @@ describe('ItemsDialog', () => {
       },
     };
 
+    afterEach(() => {
+      NoValue.mockClear();
+    });
+
+    describe('barcode', () => {
+      it('should return item barcode', () => {
+        expect(formatter.barcode(item)).toBe(item.barcode);
+      });
+
+      it('should trigger NoValue component', () => {
+        render(formatter.barcode({
+          ...item,
+          barcode: undefined,
+        }));
+
+        expect(NoValue).toHaveBeenCalled();
+      });
+    });
+
     describe('itemStatus', () => {
       it('should return formatted message', () => {
         expect(formatter.itemStatus(item).props.id).toEqual('ui-requests.item.status.agedToLost');
@@ -437,11 +458,13 @@ describe('ItemsDialog', () => {
         expect(formatter.location(item)).toEqual('effective location name');
       });
 
-      it('should return default value for effective location name', () => {
-        expect(formatter.location({
+      it('should trigger NoValue component', () => {
+        render(formatter.location({
           ...item,
           effectiveLocation: {},
-        })).toEqual('');
+        }));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -457,13 +480,15 @@ describe('ItemsDialog', () => {
           expect(formatter.loanType(item)).toEqual('temporary loan type name');
         });
 
-        it('should return default value for temporary loan type name', () => {
-          expect(formatter.loanType({
+        it('should trigger NoValue component', () => {
+          render(formatter.loanType({
             ...item,
             temporaryLoanType: {
               other: '',
             },
-          })).toEqual('');
+          }));
+
+          expect(NoValue).toHaveBeenCalled();
         });
       });
 
@@ -475,14 +500,16 @@ describe('ItemsDialog', () => {
           })).toEqual('permanent loan type name');
         });
 
-        it('should return default value for permanent loan type name', () => {
-          expect(formatter.loanType({
+        it('should trigger NoValue component', () => {
+          render(formatter.loanType({
             ...item,
             temporaryLoanType: false,
             permanentLoanType: {
               other: '',
             },
-          })).toEqual('');
+          }));
+
+          expect(NoValue).toHaveBeenCalled();
         });
       });
     });

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.js
@@ -107,7 +107,6 @@ import SinglePrintButtonForPickSlip from '../../../components/SinglePrintButtonF
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
-export const DEFAULT_FORMATTER_VALUE = '';
 
 export const getPrintHoldRequestsEnabled = (printHoldRequests) => {
   const value = printHoldRequests.records[0]?.value;
@@ -238,15 +237,15 @@ export const getListFormatter = (
       selectedRows={selectedRows}
       toggleRowSelection={toggleRowSelection}
     />),
-  'itemBarcode': rq => (rq.item ? rq.item.barcode : DEFAULT_FORMATTER_VALUE),
-  'position': rq => (rq.position || DEFAULT_FORMATTER_VALUE),
-  'proxy': rq => (rq.proxy ? getFullName(rq.proxy) : DEFAULT_FORMATTER_VALUE),
+  'itemBarcode': rq => (rq?.item?.barcode || <NoValue />),
+  'position': rq => (rq.position || <NoValue />),
+  'proxy': rq => (rq.proxy ? getFullName(rq.proxy) : <NoValue />),
   'requestDate': rq => (
     <AppIcon size="small" app="requests">
       <FormattedTime value={rq.requestDate} day="numeric" month="numeric" year="numeric" />
     </AppIcon>
   ),
-  'requester': rq => (rq.requester ? getFullName(rq.requester) : DEFAULT_FORMATTER_VALUE),
+  'requester': rq => (rq.requester ? getFullName(rq.requester) : <NoValue />),
   'singlePrint': rq => {
     const singlePrintButtonProps = {
       request: rq,
@@ -263,17 +262,17 @@ export const getListFormatter = (
     return (
       <SinglePrintButtonForPickSlip {...singlePrintButtonProps} />);
   },
-  'requesterBarcode': rq => (rq.requester ? rq.requester.barcode : DEFAULT_FORMATTER_VALUE),
+  'requesterBarcode': rq => (rq?.requester?.barcode || <NoValue />),
   'requestStatus': rq => (requestStatusesTranslations[rq.status]
     ? <FormattedMessage id={requestStatusesTranslations[rq.status]} />
     : <NoValue />),
   'type': rq => <FormattedMessage id={requestTypesTranslations[rq.requestType]} />,
-  'title': rq => <TextLink to={getRowURL(rq.id)}>{(rq.instance ? rq.instance.title : DEFAULT_FORMATTER_VALUE)}</TextLink>,
-  'year': rq => getFormattedYears(rq.instance?.publication, DEFAULT_DISPLAYED_YEARS_AMOUNT),
-  'callNumber': rq => effectiveCallNumber(rq.item),
-  'servicePoint': rq => get(rq, 'pickupServicePoint.name', DEFAULT_FORMATTER_VALUE),
-  'copies': rq => get(rq, PRINT_DETAILS_COLUMNS.COPIES, DEFAULT_FORMATTER_VALUE),
-  'printed': rq => (rq.printDetails ? getLastPrintedDetails(rq.printDetails, intl) : DEFAULT_FORMATTER_VALUE),
+  'title': rq => <TextLink to={getRowURL(rq.id)}>{(rq.instance ? rq.instance.title : <NoValue />)}</TextLink>,
+  'year': rq => (getFormattedYears(rq.instance?.publication, DEFAULT_DISPLAYED_YEARS_AMOUNT) || <NoValue />),
+  'callNumber': rq => (effectiveCallNumber(rq.item) || <NoValue />),
+  'servicePoint': rq => get(rq, 'pickupServicePoint.name', <NoValue />),
+  'copies': rq => get(rq, PRINT_DETAILS_COLUMNS.COPIES, <NoValue />),
+  'printed': rq => (rq.printDetails ? getLastPrintedDetails(rq.printDetails, intl) : <NoValue />),
 });
 
 export const buildHoldRecords = (records) => {

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
@@ -25,6 +25,7 @@ import {
   TextLink,
   Checkbox,
   exportToCsv,
+  NoValue,
 } from '@folio/stripes/components';
 import { effectiveCallNumber } from '@folio/stripes/util';
 
@@ -35,7 +36,6 @@ import RequestsRoute, {
   getLastPrintedDetails,
   getFilteredColumnHeadersMap,
   urls,
-  DEFAULT_FORMATTER_VALUE,
   extractPickSlipRequestIds,
 } from './RequestsRoute';
 import CheckboxColumn from '../../../components/CheckboxColumn';
@@ -1162,6 +1162,10 @@ describe('RequestsRoute', () => {
     };
     const requestWithoutData = {};
 
+    afterEach(() => {
+      NoValue.mockClear();
+    });
+
     describe('select', () => {
       it('should render CheckboxColumn', () => {
         const selectedRequest = {};
@@ -1213,8 +1217,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.itemBarcode(requestWithData)).toBe(requestWithData.item.barcode);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.itemBarcode(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.itemBarcode(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1223,8 +1229,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.position(requestWithData)).toBe(requestWithData.position);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.position(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.position(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1237,8 +1245,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.proxy(requestWithData)).toBe(mockProxy);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.proxy(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.proxy(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1272,8 +1282,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.requester(requestWithData)).toBe(mockRequester);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.requester(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.requester(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1282,8 +1294,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.requesterBarcode(requestWithData)).toBe(requestWithData.requester.barcode);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.requester(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.requesterBarcode(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1377,8 +1391,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.printed(requestWithData)).toBe(expectedOutput);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.printed(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.printed(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
   });

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -116,7 +116,6 @@ import SinglePrintButtonForPickSlip from '../components/SinglePrintButtonForPick
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
-export const DEFAULT_FORMATTER_VALUE = '';
 
 export const getPrintHoldRequestsEnabled = (printHoldRequests) => {
   const value = printHoldRequests.records[0]?.value;
@@ -257,15 +256,15 @@ export const getListFormatter = (
       selectedRows={selectedRows}
       toggleRowSelection={toggleRowSelection}
     />),
-  'itemBarcode': rq => (rq.item ? rq.item.barcode : DEFAULT_FORMATTER_VALUE),
-  'position': rq => (rq.position || DEFAULT_FORMATTER_VALUE),
-  ...(isProxyAvailable ? { 'proxy': rq => (rq.proxy ? getFullName(rq.proxy) : DEFAULT_FORMATTER_VALUE) } : {}),
+  'itemBarcode': rq => (rq?.item?.barcode || <NoValue />),
+  'position': rq => (rq.position || <NoValue />),
+  ...(isProxyAvailable ? { 'proxy': rq => (rq.proxy ? getFullName(rq.proxy) : <NoValue />) } : {}),
   'requestDate': rq => (
     <AppIcon size="small" app="requests">
       <FormattedTime value={rq.requestDate} day="numeric" month="numeric" year="numeric" />
     </AppIcon>
   ),
-  'requester': rq => (rq.requester ? getFullName(rq.requester) : DEFAULT_FORMATTER_VALUE),
+  'requester': rq => (rq.requester ? getFullName(rq.requester) : <NoValue />),
   'singlePrint': rq => {
     const singlePrintButtonProps = {
       request: rq,
@@ -282,18 +281,18 @@ export const getListFormatter = (
     return (
       <SinglePrintButtonForPickSlip {...singlePrintButtonProps} />);
   },
-  'requesterBarcode': rq => (rq.requester ? rq.requester.barcode : DEFAULT_FORMATTER_VALUE),
+  'requesterBarcode': rq => (rq?.requester?.barcode || <NoValue />),
   'requestStatus': rq => (requestStatusesTranslations[rq.status]
     ? <FormattedMessage id={requestStatusesTranslations[rq.status]} />
     : <NoValue />),
   'type': rq => <FormattedMessage id={requestTypesTranslations[rq.requestType]} />,
-  'title': rq => <TextLink to={getRowURL(rq.id)}>{(rq.instance ? rq.instance.title : DEFAULT_FORMATTER_VALUE)}</TextLink>,
-  'year': rq => getFormattedYears(rq.instance?.publication, DEFAULT_DISPLAYED_YEARS_AMOUNT),
-  'callNumber': rq => effectiveCallNumber(rq.item),
-  'servicePoint': rq => get(rq, 'pickupServicePoint.name', DEFAULT_FORMATTER_VALUE),
-  'retrievalServicePoint': rq => get(rq, 'item.retrievalServicePointName', DEFAULT_FORMATTER_VALUE),
-  'copies': rq => get(rq, PRINT_DETAILS_COLUMNS.COPIES, DEFAULT_FORMATTER_VALUE),
-  'printed': rq => (rq.printDetails ? getLastPrintedDetails(rq.printDetails, intl) : DEFAULT_FORMATTER_VALUE),
+  'title': rq => <TextLink to={getRowURL(rq.id)}>{(rq.instance ? rq.instance.title : <NoValue />)}</TextLink>,
+  'year': rq => (getFormattedYears(rq.instance?.publication, DEFAULT_DISPLAYED_YEARS_AMOUNT) || <NoValue />),
+  'callNumber': rq => (effectiveCallNumber(rq.item) || <NoValue />),
+  'servicePoint': rq => get(rq, 'pickupServicePoint.name', <NoValue />),
+  'retrievalServicePoint': rq => get(rq, 'item.retrievalServicePointName', <NoValue />),
+  'copies': rq => get(rq, PRINT_DETAILS_COLUMNS.COPIES, <NoValue />),
+  'printed': rq => (rq.printDetails ? getLastPrintedDetails(rq.printDetails, intl) : <NoValue />),
 });
 
 export const buildHoldRecords = (records) => {

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -26,6 +26,7 @@ import {
   TextLink,
   Checkbox,
   exportToCsv,
+  NoValue,
 } from '@folio/stripes/components';
 import {
   effectiveCallNumber,
@@ -39,7 +40,6 @@ import RequestsRoute, {
   getLastPrintedDetails,
   getFilteredColumnHeadersMap,
   urls,
-  DEFAULT_FORMATTER_VALUE,
   extractPickSlipRequestIds,
 } from './RequestsRoute';
 import CheckboxColumn from '../components/CheckboxColumn';
@@ -1323,6 +1323,10 @@ describe('RequestsRoute', () => {
     };
     const requestWithoutData = {};
 
+    afterEach(() => {
+      NoValue.mockClear();
+    });
+
     describe('select', () => {
       it('should render CheckboxColumn', () => {
         const selectedRequest = {};
@@ -1374,8 +1378,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.itemBarcode(requestWithData)).toBe(requestWithData.item.barcode);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.itemBarcode(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.itemBarcode(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1384,8 +1390,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.position(requestWithData)).toBe(requestWithData.position);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.position(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.position(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1398,8 +1406,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.proxy(requestWithData)).toBe(mockProxy);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.proxy(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.proxy(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1433,8 +1443,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.requester(requestWithData)).toBe(mockRequester);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.requester(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.requester(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1443,8 +1455,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.requesterBarcode(requestWithData)).toBe(requestWithData.requester.barcode);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.requester(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.requesterBarcode(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
 
@@ -1544,8 +1558,10 @@ describe('RequestsRoute', () => {
         expect(listFormatter.printed(requestWithData)).toBe(expectedOutput);
       });
 
-      it('should return empty string', () => {
-        expect(listFormatter.printed(requestWithoutData)).toBe(DEFAULT_FORMATTER_VALUE);
+      it('should trigger NoValue component', () => {
+        render(listFormatter.printed(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
       });
     });
   });

--- a/src/views/components/ItemLink.js
+++ b/src/views/components/ItemLink.js
@@ -2,10 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-import {
-  MISSING_VALUE_SYMBOL,
-} from '../../constants';
-
+import { NoValue } from '@folio/stripes/components';
 
 const ItemLink = ({
   request: {
@@ -14,11 +11,9 @@ const ItemLink = ({
     itemId,
     item,
   },
-}) => (
-  item
+}) => item?.barcode
     ? (<Link to={`/inventory/view/${instanceId}/${holdingsRecordId}/${itemId}`}>{item.barcode}</Link>)
-    : MISSING_VALUE_SYMBOL
-);
+    : <NoValue />;
 
 ItemLink.propTypes = {
   request: PropTypes.shape({

--- a/src/views/components/ItemLink.test.js
+++ b/src/views/components/ItemLink.test.js
@@ -4,12 +4,9 @@ import {
   render,
   screen,
 } from '@folio/jest-config-stripes/testing-library/react';
+import { NoValue } from '@folio/stripes/components';
 
 import ItemLink from './ItemLink';
-
-import {
-  MISSING_VALUE_SYMBOL,
-} from '../../constants';
 
 describe('ItemLink', () => {
   const mockedItem = {
@@ -57,8 +54,8 @@ describe('ItemLink', () => {
       );
     });
 
-    it('should render `-` instead of link', () => {
-      expect(screen.getByText(MISSING_VALUE_SYMBOL)).toBeInTheDocument();
+    it('should trigger NoValue component', () => {
+      expect(NoValue).toHaveBeenCalled();
     });
   });
 });

--- a/src/views/components/RequesterLink.js
+++ b/src/views/components/RequesterLink.js
@@ -2,12 +2,14 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
+import { NoValue } from '@folio/stripes/components';
+
 const RequesterLink = ({
   request: {
     requesterId,
     requester: { barcode },
   },
-}) => <Link to={`/users/view/${requesterId}`}>{barcode}</Link>;
+}) => barcode ? <Link to={`/users/view/${requesterId}`}>{barcode}</Link> : <NoValue />;
 
 RequesterLink.propTypes = {
   request: PropTypes.shape({

--- a/src/views/components/RequesterLink.test.js
+++ b/src/views/components/RequesterLink.test.js
@@ -4,33 +4,54 @@ import {
   render,
   screen,
 } from '@folio/jest-config-stripes/testing-library/react';
+import { NoValue } from '@folio/stripes/components';
 
 import RequesterLink from './RequesterLink';
 
 describe('RequesterLink', () => {
-  const mockedRequester = {
-    barcode: 'testRequesterBarcode',
-  };
-  const mockedRequest = {
-    requesterId: 'testRequesterId',
-    requester: mockedRequester,
-  };
+  describe('When barcode is presented', () => {
+    const mockedRequester = {
+      barcode: 'testRequesterBarcode',
+    };
+    const mockedRequest = {
+      requesterId: 'testRequesterId',
+      requester: mockedRequester,
+    };
 
-  beforeEach(() => {
-    render(
-      <BrowserRouter>
-        <RequesterLink request={mockedRequest} />
-      </BrowserRouter>
-    );
+    beforeEach(() => {
+      render(
+        <BrowserRouter>
+          <RequesterLink request={mockedRequest} />
+        </BrowserRouter>
+      );
+    });
+
+    it('should render `Link` with correct label', () => {
+      expect(screen.getByText(mockedRequester.barcode)).toBeInTheDocument();
+    });
+
+    it('should render `Link` with correct `href` attribute', () => {
+      const expectedResult = `/users/view/${mockedRequest.requesterId}`;
+
+      expect(screen.getByRole('link')).toHaveAttribute('href', expectedResult);
+    });
   });
 
-  it('should render `Link` with correct label', () => {
-    expect(screen.getByText(mockedRequester.barcode)).toBeInTheDocument();
-  });
+  describe('When barcode is not presented', () => {
+    const request = {
+      requester: {},
+    };
 
-  it('should render `Link` with correct `href` attribute', () => {
-    const expectedResult = `/users/view/${mockedRequest.requesterId}`;
+    beforeEach(() => {
+      render(
+        <BrowserRouter>
+          <RequesterLink request={request} />
+        </BrowserRouter>
+      );
+    });
 
-    expect(screen.getByRole('link')).toHaveAttribute('href', expectedResult);
+    it('should trigger NoValue component', () => {
+      expect(NoValue).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Purpose
Use NoValue component for absent information.

## Refs
[UIREQ-1262](https://folio-org.atlassian.net/browse/UIREQ-1262)

## Notes
There is a code duplication in `deprecated` folder. That folder will be deleted later.

## Screenshots
![image](https://github.com/user-attachments/assets/3d593a3e-213d-40fc-9c3c-2c106cf1fce3)


![image](https://github.com/user-attachments/assets/ce8c6e98-5200-45a9-8857-58f2c1db6bac)


![image](https://github.com/user-attachments/assets/bc47f57b-6d3d-43d8-84af-862beac1bca6)

