### PR TITLE
UIREQ-1263: Use convertToSlipData and supporting functions from stripes-util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for ui-requests
 
-## 12.1.0 IN PROGRESS
+## 13.0.0 IN PROGRESS
 
 * Fix issue when creating a request with an item that does not have a barcode. Refs UIREQ-1275.
+* *BREAKING* Use `convertToSlipData` and supporting functions from `stripes-util`. Refs UIREQ-1263.
 
 ## [12.0.0] (https://github.com/folio-org/ui-requests/tree/v12.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v11.0.6...v12.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/requests",
-  "version": "12.1.0",
+  "version": "13.0.0",
   "description": "Requests manager",
   "repository": "folio-org/ui-requests",
   "publishConfig": {

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.js
@@ -42,6 +42,7 @@ import {
   SearchAndSort,
 } from '@folio/stripes/smart-components';
 import {
+  convertToSlipData,
   effectiveCallNumber,
   getHeaderWithCredentials,
 } from '@folio/stripes/util';
@@ -71,7 +72,6 @@ import {
   buildUrl,
   getFullName,
   duplicateRequest,
-  convertToSlipData,
   getInstanceQueryString,
   isDuplicateMode,
   generateUserName,
@@ -1416,8 +1416,13 @@ class RequestsRoute extends React.Component {
     const isSearchSlipsEmpty = isEmpty(searchSlips);
     const pickSlipsPrintTemplate = this.getPrintTemplate(SLIPS_TYPE.PICK_SLIP);
     const searchSlipsPrintTemplate = this.getPrintTemplate(SLIPS_TYPE.SEARCH_SLIP_HOLD_REQUESTS);
-    const pickSlipsData = convertToSlipData(pickSlips, intl, timezone, locale, SLIPS_TYPE.PICK_SLIP, user);
-    const searchSlipsData = convertToSlipData(searchSlips, intl, timezone, locale, SLIPS_TYPE.SEARCH_SLIP_HOLD_REQUESTS);
+    const pickSlipsData = convertToSlipData(pickSlips, intl, timezone, locale, {
+      slipName: SLIPS_TYPE.PICK_SLIP,
+      user,
+    });
+    const searchSlipsData = convertToSlipData(searchSlips, intl, timezone, locale, {
+      slipName: SLIPS_TYPE.SEARCH_SLIP_HOLD_REQUESTS,
+    });
     let multiSelectPickSlipData = getSelectedSlipDataMulti(pickSlipsData, selectedRows);
 
     const resultsFormatter = getListFormatter(

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
@@ -67,6 +67,12 @@ import {
 } from '../../../constants';
 import { historyData } from '../../../../test/jest/fixtures/historyData';
 
+jest.mock('@folio/stripes/util', () => ({
+  ...jest.requireActual('@folio/stripes/util'),
+  effectiveCallNumber: jest.fn(),
+  convertToSlipData: jest.fn(() => ([{}])),
+}));
+
 const createRefMock = {
   current: {
     focus: jest.fn(),

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -44,6 +44,7 @@ import {
   SearchAndSort,
 } from '@folio/stripes/smart-components';
 import {
+  convertToSlipData,
   effectiveCallNumber,
   getHeaderWithCredentials,
 } from '@folio/stripes/util';
@@ -78,7 +79,6 @@ import {
   buildUrl,
   getFullName,
   duplicateRequest,
-  convertToSlipData,
   getTlrSettings,
   getInstanceQueryString,
   isDuplicateMode,
@@ -1496,8 +1496,13 @@ class RequestsRoute extends React.Component {
     const isSearchSlipsEmpty = isEmpty(searchSlips);
     const pickSlipsPrintTemplate = this.getPrintTemplate(SLIPS_TYPE.PICK_SLIP);
     const searchSlipsPrintTemplate = this.getPrintTemplate(SLIPS_TYPE.SEARCH_SLIP_HOLD_REQUESTS);
-    const pickSlipsData = convertToSlipData(pickSlips, intl, timezone, locale, SLIPS_TYPE.PICK_SLIP, user);
-    const searchSlipsData = convertToSlipData(searchSlips, intl, timezone, locale, SLIPS_TYPE.SEARCH_SLIP_HOLD_REQUESTS);
+    const pickSlipsData = convertToSlipData(pickSlips, intl, timezone, locale, {
+      slipName: SLIPS_TYPE.PICK_SLIP,
+      user,
+    });
+    const searchSlipsData = convertToSlipData(searchSlips, intl, timezone, locale, {
+      slipName: SLIPS_TYPE.SEARCH_SLIP_HOLD_REQUESTS,
+    });
     let multiSelectPickSlipData = getSelectedSlipDataMulti(pickSlipsData, selectedRows);
 
     const resultsFormatter = getListFormatter(

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -73,6 +73,13 @@ import {
 } from '../constants';
 import { historyData } from '../../test/jest/fixtures/historyData';
 
+jest.mock('@folio/stripes/util', () => ({
+  ...jest.requireActual('@folio/stripes/util'),
+  effectiveCallNumber: jest.fn(),
+  getHeaderWithCredentials: jest.fn(),
+  convertToSlipData: jest.fn(() => ([{}])),
+}));
+
 const createRefMock = {
   current: {
     focus: jest.fn(),

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,7 +14,6 @@ import {
 import queryString from 'query-string';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import moment from 'moment-timezone';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -35,7 +34,6 @@ import {
   DCB_INSTANCE_ID,
   DCB_HOLDINGS_RECORD_ID,
   DCB_USER,
-  SLIPS_TYPE,
   REQUEST_ERROR_MESSAGE_TRANSLATION_KEYS,
 } from './constants';
 
@@ -173,13 +171,6 @@ export function buildTemplate(template = '') {
   };
 }
 
-export function buildLocaleDateAndTime(dateTime, timezone, locale) {
-  return moment(dateTime)
-    .tz(timezone)
-    .locale(locale)
-    .format('L LT');
-}
-
 export function getSelectedSlipData(pickSlipsData, selectedRequestId) {
   const sel = pickSlipsData.filter((pickSlip) => {
     return pickSlip['request.requestID'] === selectedRequestId;
@@ -236,90 +227,6 @@ export const getNextSelectedRowsState = (selectedRows, row) => {
   }
 
   return newSelectedRows;
-};
-
-export const convertToSlipData = (source, intl, timeZone, locale, slipName = SLIPS_TYPE.PICK_SLIP, user = {}) => {
-  return source.map(pickSlip => {
-    const {
-      item = {},
-      request = {},
-      requester = {},
-      currentDateTime = null,
-    } = pickSlip;
-
-    const { username } = user;
-
-    return {
-      'staffSlip.Name': slipName,
-      'staffSlip.currentDateTime': buildLocaleDateAndTime(currentDateTime, timeZone, locale),
-      'staffSlip.staffUsername': username,
-      'requester.firstName': requester.firstName,
-      'requester.lastName': requester.lastName,
-      'requester.middleName': requester.middleName,
-      'requester.preferredFirstName': requester.preferredFirstName || requester.firstName,
-      'requester.patronGroup': requester.patronGroup,
-      'requester.addressLine1': requester.addressLine1,
-      'requester.addressLine2': requester.addressLine2,
-      'requester.country': requester.countryId
-        ? intl.formatMessage({ id: `stripes-components.countries.${requester.countryId}` })
-        : requester.countryId,
-      'requester.city': requester.city,
-      'requester.stateProvRegion': requester.region,
-      'requester.zipPostalCode': requester.postalCode,
-      'requester.barcode': requester.barcode,
-      'requester.barcodeImage': `<Barcode>${requester.barcode}</Barcode>`,
-      'requester.departments': requester.departments,
-      'item.title': item.title,
-      'item.primaryContributor': item.primaryContributor,
-      'item.allContributors': item.allContributors,
-      'item.barcode': item.barcode,
-      'item.barcodeImage': `<Barcode>${item.barcode}</Barcode>`,
-      'item.callNumber': item.callNumber,
-      'item.callNumberPrefix': item.callNumberPrefix,
-      'item.callNumberSuffix': item.callNumberSuffix,
-      'item.displaySummary': item.displaySummary,
-      'item.enumeration': item.enumeration,
-      'item.volume': item.volume,
-      'item.chronology': item.chronology,
-      'item.copy': item.copy,
-      'item.yearCaption': item.yearCaption,
-      'item.materialType': item.materialType,
-      'item.loanType': item.loanType,
-      'item.numberOfPieces': item.numberOfPieces,
-      'item.descriptionOfPieces': item.descriptionOfPieces,
-      'item.lastCheckedInDateTime': item.lastCheckedInDateTime
-        ? buildLocaleDateAndTime(item.lastCheckedInDateTime, timeZone, locale)
-        : item.lastCheckedInDateTime,
-      'item.fromServicePoint': item.fromServicePoint,
-      'item.toServicePoint': item.toServicePoint,
-      'item.accessionNumber': item.accessionNumber,
-      'item.administrativeNotes': item.administrativeNotes,
-      'item.datesOfPublication': item.datesOfPublication,
-      'item.editions': item.editions,
-      'item.physicalDescriptions': item.physicalDescriptions,
-      'item.instanceHrid': item.instanceHrid,
-      'item.instanceHridImage': `<Barcode>${item.instanceHrid}</Barcode>`,
-      'item.effectiveLocationInstitution': item.effectiveLocationInstitution,
-      'item.effectiveLocationCampus': item.effectiveLocationCampus,
-      'item.effectiveLocationLibrary': item.effectiveLocationLibrary,
-      'item.effectiveLocationSpecific': item.effectiveLocationSpecific,
-      'item.effectiveLocationPrimaryServicePointName': item.effectiveLocationPrimaryServicePointName,
-      'request.servicePointPickup': request.servicePointPickup,
-      'request.deliveryAddressType': request.deliveryAddressType,
-      'request.requestExpirationDate': request.requestExpirationDate
-        ? intl.formatDate(request.requestExpirationDate, { timeZone, locale })
-        : request.requestExpirationDate,
-      'request.requestDate': request.requestDate
-        ? intl.formatDate(request.requestDate, { timeZone, locale, year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' })
-        : request.requestDate,
-      'request.holdShelfExpirationDate': request.holdShelfExpirationDate
-        ? intl.formatDate(request.holdShelfExpirationDate, { timeZone, locale })
-        : request.holdShelfExpirationDate,
-      'request.requestID': request.requestID,
-      'request.patronComments': request.patronComments,
-      'request.barcodeImage': `<Barcode>${request.requestID}</Barcode>`,
-    };
-  });
 };
 
 export function buildUrl(location, values) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,13 +1,10 @@
 import {
   escape,
-  noop,
 } from 'lodash';
 
 import {
   buildTemplate,
   createUserHighlightBoxLink,
-  convertToSlipData,
-  buildLocaleDateAndTime,
   duplicateRequest,
   escapeValue,
   getTlrSettings,
@@ -49,7 +46,6 @@ import {
   DCB_HOLDINGS_RECORD_ID,
   REQUEST_ERROR_MESSAGE_CODE,
   REQUEST_ERROR_MESSAGE_TRANSLATION_KEYS,
-  SLIPS_TYPE,
 } from './constants';
 
 const pickSlipsForSinglePrint = [
@@ -804,212 +800,6 @@ describe('getSelectedSlipDataMulti', () => {
     const result = getSelectedSlipDataMulti(pickSlipsDataWithRequest, selectedRows);
 
     expect(result).toEqual([]);
-  });
-});
-
-describe('convertToSlipData', () => {
-  const intl = {
-    formatMessage: (o) => o.id,
-    formatDate: (d, options) => `${d} ${options.timeZone} ${options.locale}`,
-  };
-  const tz = 'America/New_York';
-  const locale = 'en';
-
-  const user = {
-    username: 'JonesPaul',
-  };
-  const item = {
-    title: 'The Long Way to a Small, Angry Planet',
-    barcode: '036000291452',
-    status: 'Paged',
-    primaryContributor: 'Chambers, Becky',
-    allContributors: 'Chambers, Becky',
-    enumeration: 'v.70:no.7-12',
-    volume: 'vol.1',
-    chronology: '1984:July-Dec.',
-    yearCaption: '1984; 1985',
-    materialType: 'Book',
-    loanType: 'Can Circulate',
-    copy: 'cp.2',
-    numberOfPieces: '3',
-    descriptionOfPieces: 'Description of three pieces',
-    effectiveLocationSpecific: '3rd Floor',
-    effectiveLocationLibrary: 'Djanogly Learning Resource Centre',
-    effectiveLocationCampus: 'Jubilee Campus',
-    effectiveLocationInstitution: 'Nottingham University',
-    effectiveLocationPrimaryServicePointName: 'Circulation Desk',
-    callNumber: '123456',
-    callNumberPrefix: 'PREFIX',
-    callNumberSuffix: 'SUFFIX',
-    displaySummary: 'Display summary',
-    lastCheckedInDateTime: '2020-02-17T12:12:33.374Z',
-    accessionNumber: 'CMHAT1901',
-    administrativeNotes: 'Plates must be kept with pages',
-    datesOfPublication: '1901',
-    editions: '1st, limited edition from Carnegie Museum',
-    physicalDescriptions: '63 pages plus plates I-XIII.',
-    instanceHrid: 'in00000012368',
-  };
-  const request = {
-    requestID: 'dd606ca6-a2cb-4723-9a8d-e73b05c42232',
-    servicePointPickup: 'Circ Desk 1',
-    requestExpirationDate: '2019-07-30T00:00:00.000+03:00',
-    holdShelfExpirationDate: '2019-08-31T00:00:00.000+03:00',
-    requestDate: '2019-08-31T00:00:00.000+03:00',
-    deliveryAddressType: 'Home',
-    patronComments: 'Please hurry!',
-  };
-  const requester = {
-    firstName: 'Steven',
-    lastName: 'Jones',
-    middleName: 'Jacob',
-    preferredFirstName: 'Paul',
-    patronGroup: 'Undergraduate',
-    barcode: '5694596854',
-    addressLine1: '16 Main St',
-    addressLine2: 'Apt 3a',
-    city: 'Northampton',
-    region: 'MA',
-    postalCode: '01060',
-    countryId: 'US',
-    departments: 'department1; department2',
-  };
-  const currentDateTime = '2023-04-28T06:04:54.296Z';
-  const pickSlips = [{
-    item,
-    request,
-    requester,
-    currentDateTime,
-  }];
-  const slipData = {
-    'staffSlip.Name': 'Pick slip',
-    'staffSlip.currentDateTime': buildLocaleDateAndTime(currentDateTime, tz, locale),
-    'staffSlip.staffUsername': 'JonesPaul',
-    'requester.firstName': 'Steven',
-    'requester.lastName': 'Jones',
-    'requester.middleName': 'Jacob',
-    'requester.preferredFirstName': 'Paul',
-    'requester.patronGroup': 'Undergraduate',
-    'requester.addressLine1': '16 Main St',
-    'requester.addressLine2': 'Apt 3a',
-    'requester.country': 'stripes-components.countries.US',
-    'requester.city': 'Northampton',
-    'requester.stateProvRegion': 'MA',
-    'requester.zipPostalCode': '01060',
-    'requester.barcode': '5694596854',
-    'requester.barcodeImage': '<Barcode>5694596854</Barcode>',
-    'requester.departments': 'department1; department2',
-    'item.fromServicePoint': undefined,
-    'item.toServicePoint': undefined,
-    'item.title': 'The Long Way to a Small, Angry Planet',
-    'item.primaryContributor': 'Chambers, Becky',
-    'item.allContributors': 'Chambers, Becky',
-    'item.barcode': '036000291452',
-    'item.barcodeImage': '<Barcode>036000291452</Barcode>',
-    'item.callNumber': '123456',
-    'item.callNumberPrefix': 'PREFIX',
-    'item.callNumberSuffix': 'SUFFIX',
-    'item.displaySummary': 'Display summary',
-    'item.enumeration': 'v.70:no.7-12',
-    'item.volume': 'vol.1',
-    'item.chronology': '1984:July-Dec.',
-    'item.copy': 'cp.2',
-    'item.yearCaption': '1984; 1985',
-    'item.materialType': 'Book',
-    'item.loanType': 'Can Circulate',
-    'item.numberOfPieces': '3',
-    'item.descriptionOfPieces': 'Description of three pieces',
-    'item.lastCheckedInDateTime': buildLocaleDateAndTime('2020-02-17T12:12:33.374Z', tz, locale),
-    'item.effectiveLocationInstitution': 'Nottingham University',
-    'item.effectiveLocationCampus': 'Jubilee Campus',
-    'item.effectiveLocationLibrary': 'Djanogly Learning Resource Centre',
-    'item.effectiveLocationSpecific': '3rd Floor',
-    'item.effectiveLocationPrimaryServicePointName': 'Circulation Desk',
-    'item.accessionNumber': 'CMHAT1901',
-    'item.administrativeNotes': 'Plates must be kept with pages',
-    'item.datesOfPublication': '1901',
-    'item.editions': '1st, limited edition from Carnegie Museum',
-    'item.physicalDescriptions': '63 pages plus plates I-XIII.',
-    'item.instanceHrid': 'in00000012368',
-    'item.instanceHridImage': '<Barcode>in00000012368</Barcode>',
-    'request.servicePointPickup': 'Circ Desk 1',
-    'request.deliveryAddressType': 'Home',
-    'request.requestExpirationDate': '2019-07-30T00:00:00.000+03:00 America/New_York en',
-    'request.holdShelfExpirationDate': '2019-08-31T00:00:00.000+03:00 America/New_York en',
-    'request.requestDate': '2019-08-31T00:00:00.000+03:00 America/New_York en',
-    'request.requestID': 'dd606ca6-a2cb-4723-9a8d-e73b05c42232',
-    'request.patronComments': 'Please hurry!',
-    'request.barcodeImage': '<Barcode>dd606ca6-a2cb-4723-9a8d-e73b05c42232</Barcode>',
-  };
-  const expectSlipData = [slipData];
-
-  it('substitutes values', () => {
-    expect(convertToSlipData(pickSlips, intl, tz, locale, SLIPS_TYPE.PICK_SLIP, user)).toEqual(expectSlipData);
-  });
-
-  it('should convert to slip data wth empty date', () => {
-    const pickSlipsWithEmptyDate = [{
-      item,
-      request: {
-        ...request,
-        requestExpirationDate: '',
-        holdShelfExpirationDate: '',
-      },
-      requester: {
-        ...requester,
-        countryId: '',
-      },
-      currentDateTime,
-    }];
-    const expectSlipDataWithEmptyDate = [{
-      ...slipData,
-      'request.requestExpirationDate': '',
-      'request.holdShelfExpirationDate': '',
-      'requester.country': '',
-    }];
-
-    expect(convertToSlipData(pickSlipsWithEmptyDate, intl, tz, locale, SLIPS_TYPE.PICK_SLIP, user)).toEqual(expectSlipDataWithEmptyDate);
-  });
-
-  it('handles missing elements', () => {
-    const emptySource = [];
-    const o = convertToSlipData(emptySource, intl, tz, locale);
-
-    expect(o['requester.country']).toBeUndefined();
-    expect(o['request.requestExpirationDate']).toBeUndefined();
-    expect(o['request.holdShelfExpirationDate']).toBeUndefined();
-  });
-
-  it('handles empty requester barcode', () => {
-    const sourceWithoutRequesterBarcode = [{
-      ...pickSlips,
-      requester: {
-        ...pickSlips.requester,
-        barcode: noop(),
-      },
-    }];
-    const o = convertToSlipData(sourceWithoutRequesterBarcode, intl, tz, locale, SLIPS_TYPE.PICK_SLIP, user);
-
-    expect(o['requester.barcodeImage']).toBeUndefined();
-  });
-
-  it('should handle preferred first name when preferred first name is null', () => {
-    const pickSlipsWithoutPreferredFirstName = [{
-      item,
-      request,
-      requester: {
-        ...requester,
-        preferredFirstName: null,
-      },
-      currentDateTime,
-    }];
-
-    const expectSlipDataWithoutPreferredFirstName = [{
-      ...slipData,
-      'requester.preferredFirstName': 'Steven',
-    }];
-
-    expect(convertToSlipData(pickSlipsWithoutPreferredFirstName, intl, tz, locale, SLIPS_TYPE.PICK_SLIP, user)).toEqual(expectSlipDataWithoutPreferredFirstName);
   });
 });
 


### PR DESCRIPTION
## Purpose
Use  convertToSlipData and supporting functions

## Approach

- In settings -> circulation -> staff slips we create template that contain token. When we try print this template in our modules checkin, requests, requests-mediated and etc we need match real data and token from template. For this match responsible convertToSlipData function and supporting functions. And in each of modules checkin, requests, requests-mediated and etc we have own exemplar of  convertToSlipData function and supporting functions. This mean that when we add new token in settings -> circulation -> staff slips we need updete convertToSlipData function in all modules checkin, requests, requests-mediated and etc. For resolve this problem we want move convertToSlipData function and supporting functions to one please and just reuse it in modules checkin, requests, requests-mediated and etc

- convertToSlipData and supporting functions from stripes-util is not currently used in other modules, but we want to use it in several modules and before this we need provide minor changes(https://folio-org.atlassian.net/browse/STUTL-55):
https://folio-org.atlassian.net/browse/UIREQ-1263
https://folio-org.atlassian.net/browse/UIREQMED-92
https://folio-org.atlassian.net/browse/UICHKIN-456

# Refs
https://issues.folio.org/browse/UIREQ-1263
