### PR TITLE
[FOLLOW UP] UIREQ-1217: Printing of request slips is unavailable with only "Requests: View" permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
           "circulation-bff.search-slips.collection.get",
           "circulation-bff.pick-slips.collection.get",
           "circulation-storage.staff-slips.collection.get",
-          "tags.collection.get"
+          "tags.collection.get",
+          "circulation.print-events-entry.item.post"
         ],
         "visible": true
       },
@@ -141,7 +142,6 @@
           "circulation-bff.requests.allowed-service-points.get",
           "circulation-storage.requests.item.post",
           "circulation-storage.request-preferences.collection.get",
-          "circulation.print-events-entry.item.post",
           "inventory-storage.locations.item.get",
           "circulation-bff.requests.search-instances.get",
           "circulation-bff.requests.post"
@@ -156,7 +156,6 @@
           "circulation.requests.item.put",
           "circulation.requests.allowed-service-points.get",
           "circulation-bff.requests.allowed-service-points.get",
-          "circulation.print-events-entry.item.post",
           "circulation-storage.requests.collection.delete",
           "circulation-storage.requests.item.put",
           "circulation-storage.requests.item.delete",


### PR DESCRIPTION
## Purpose
Follow up PR of https://github.com/folio-org/ui-requests/pull/1278

## Refs
[UIREQ-1217](https://folio-org.atlassian.net/browse/UIREQ-1217)