### PR TITLE
B12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-requests
 
+## 12.1.0 IN PROGRESS
+
+* Fix issue when creating a request with an item that does not have a barcode. Refs UIREQ-1275.
+
 ## [12.0.0] (https://github.com/folio-org/ui-requests/tree/v12.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v11.0.6...v12.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * *BREAKING* Use `convertToSlipData` and supporting functions from `stripes-util`. Refs UIREQ-1263.
 * Replace moment with day.js. Refs UIREQ-1291.
+
+## [12.0.2] (https://github.com/folio-org/ui-requests/tree/v12.0.2) (2025-04-15)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v12.0.1...v12.0.2)
 * [Retrieval SP filter] Move related code to make the filter enabled for ecs/non-ecs UI. Refs UIREQ-1294.
 
 ## [12.0.1] (https://github.com/folio-org/ui-requests/tree/v12.0.1) (2025-03-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * *BREAKING* Use `convertToSlipData` and supporting functions from `stripes-util`. Refs UIREQ-1263.
 * Replace moment with day.js. Refs UIREQ-1291.
 
+## [12.0.3](https://github.com/folio-org/ui-requests/tree/v12.0.3) (PROGRESS)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v12.0.2...v12.0.3)
+
+* Upgrade `@folio/stripes` dependency to ^10.0.7 (the most recent release). The previous dependency was on ^10.0.0, which required `@folio/stripes-util` v7.0.0, and that did not include the `convertToSlipData` function which this package uses).
+
 ## [12.0.2] (https://github.com/folio-org/ui-requests/tree/v12.0.2) (2025-04-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v12.0.1...v12.0.2)
 * [Retrieval SP filter] Move related code to make the filter enabled for ecs/non-ecs UI. Refs UIREQ-1294.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-requests
 
-## 12.1.0 IN PROGRESS
+## [12.0.1] (https://github.com/folio-org/ui-requests/tree/v12.0.1) (2025-03-21)
+[Full Changelog](https://github.com/folio-org/ui-requests/compare/v12.0.0...v12.0.1)
 
 * Fix issue when creating a request with an item that does not have a barcode. Refs UIREQ-1275.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history for ui-requests
 
+## 13.0.0 IN PROGRESS
+
+* *BREAKING* Use `convertToSlipData` and supporting functions from `stripes-util`. Refs UIREQ-1263.
+* Replace moment with day.js. Refs UIREQ-1291.
+* [Retrieval SP filter] Move related code to make the filter enabled for ecs/non-ecs UI. Refs UIREQ-1294.
+
 ## [12.0.1] (https://github.com/folio-org/ui-requests/tree/v12.0.1) (2025-03-21)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v12.0.0...v12.0.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/requests",
-  "version": "12.1.0",
+  "version": "12.0.1",
   "description": "Requests manager",
   "repository": "folio-org/ui-requests",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "@babel/plugin-transform-runtime": "^7.13.10",
     "@folio/eslint-config-stripes": "^8.0.0",
     "@folio/jest-config-stripes": "^3.0.0",
-    "@folio/stripes": "^10.0.0",
+    "@folio/stripes": "^10.0.7",
     "@folio/stripes-cli": "^4.0.0",
     "@folio/stripes-components": "^13.0.0",
     "@folio/stripes-core": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/requests",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "description": "Requests manager",
   "repository": "folio-org/ui-requests",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/requests",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "description": "Requests manager",
   "repository": "folio-org/ui-requests",
   "publishConfig": {

--- a/src/RequestForm.js
+++ b/src/RequestForm.js
@@ -1074,6 +1074,10 @@ class RequestForm extends React.Component {
       this.setState({
         isItemIdRequest: false,
       });
+    } else {
+      this.setState({
+        isItemIdRequest: true,
+      });
     }
 
     this.findItem(RESOURCE_KEYS.id, item.id, false, isBarcodeRequired);

--- a/src/RequestForm.test.js
+++ b/src/RequestForm.test.js
@@ -21,6 +21,7 @@ import FulfilmentPreference from './components/FulfilmentPreference';
 import RequesterInformation from './components/RequesterInformation';
 import ItemInformation from './components/ItemInformation';
 import InstanceInformation from './components/InstanceInformation';
+import ItemsDialog from './ItemsDialog';
 
 import {
   REQUEST_LEVEL_TYPES,
@@ -1834,25 +1835,63 @@ describe('RequestForm', () => {
   });
 
   describe('Items dialog', () => {
-    beforeEach(() => {
-      renderComponent();
+    describe('When item has a barcode', () => {
+      beforeEach(() => {
+        renderComponent();
+      });
+
+      it('should get information about selected item', () => {
+        const expectedArgs = [RESOURCE_TYPES.ITEM, item.id, RESOURCE_KEYS.id];
+        const itemDialogRow = screen.getByTestId(testIds.itemDialogRow);
+
+        fireEvent.click(itemDialogRow);
+
+        expect(basicProps.findResource).toHaveBeenCalledWith(...expectedArgs);
+      });
+
+      it('should reset selected instance', () => {
+        const itemDialogCloseButton = screen.getByTestId(testIds.itemDialogCloseButton);
+
+        fireEvent.click(itemDialogCloseButton);
+
+        expect(basicProps.onSetSelectedInstance).toHaveBeenCalledWith(undefined);
+      });
     });
 
-    it('should get information about selected item', () => {
-      const expectedArgs = [RESOURCE_TYPES.ITEM, item.id, RESOURCE_KEYS.id];
-      const itemDialogRow = screen.getByTestId(testIds.itemDialogRow);
+    describe('When item does not have a barcode', () => {
+      const selectedItem = {
+        id: 'itemId',
+      };
 
-      fireEvent.click(itemDialogRow);
+      beforeEach(() => {
+        ItemsDialog.mockImplementationOnce(({
+          onRowClick,
+        }) => {
+          const handleRowClick = () => {
+            onRowClick({}, selectedItem);
+          };
 
-      expect(basicProps.findResource).toHaveBeenCalledWith(...expectedArgs);
-    });
+          return (
+            <button
+              data-testid={testIds.itemDialogRow}
+              type="button"
+              onClick={handleRowClick}
+            >
+              Item
+            </button>
+          );
+        });
+        renderComponent();
+      });
 
-    it('should reset selected instance', () => {
-      const itemDialogCloseButton = screen.getByTestId(testIds.itemDialogCloseButton);
+      it('should get information about selected item', () => {
+        const expectedArgs = [RESOURCE_TYPES.ITEM, item.id, RESOURCE_KEYS.id];
+        const itemDialogRow = screen.getByTestId(testIds.itemDialogRow);
 
-      fireEvent.click(itemDialogCloseButton);
+        fireEvent.click(itemDialogRow);
 
-      expect(basicProps.onSetSelectedInstance).toHaveBeenCalledWith(undefined);
+        expect(basicProps.findResource).toHaveBeenCalledWith(...expectedArgs);
+      });
     });
   });
 

--- a/src/deprecated/components/RequestForm/RequestForm.js
+++ b/src/deprecated/components/RequestForm/RequestForm.js
@@ -1066,6 +1066,10 @@ class RequestForm extends React.Component {
       this.setState({
         isItemIdRequest: false,
       });
+    } else {
+      this.setState({
+        isItemIdRequest: true,
+      });
     }
 
     this.findItem(RESOURCE_KEYS.id, item.id, false, isBarcodeRequired);

--- a/src/deprecated/components/RequestForm/RequestForm.test.js
+++ b/src/deprecated/components/RequestForm/RequestForm.test.js
@@ -19,6 +19,7 @@ import RequestForm, {
 } from './RequestForm';
 import FulfilmentPreference from '../../../components/FulfilmentPreference';
 import RequesterInformation from '../../../components/RequesterInformation';
+import ItemsDialog from '../ItemsDialog/ItemsDialog';
 
 import {
   REQUEST_LEVEL_TYPES,
@@ -1788,25 +1789,63 @@ describe('RequestForm', () => {
   });
 
   describe('Items dialog', () => {
-    beforeEach(() => {
-      renderComponent();
+    describe('When item has a barcode', () => {
+      beforeEach(() => {
+        renderComponent();
+      });
+
+      it('should get information about selected item', () => {
+        const expectedArgs = [RESOURCE_TYPES.ITEM, item.id, RESOURCE_KEYS.id];
+        const itemDialogRow = screen.getByTestId(testIds.itemDialogRow);
+
+        fireEvent.click(itemDialogRow);
+
+        expect(basicProps.findResource).toHaveBeenCalledWith(...expectedArgs);
+      });
+
+      it('should reset selected instance', () => {
+        const itemDialogCloseButton = screen.getByTestId(testIds.itemDialogCloseButton);
+
+        fireEvent.click(itemDialogCloseButton);
+
+        expect(basicProps.onSetSelectedInstance).toHaveBeenCalledWith(undefined);
+      });
     });
 
-    it('should get information about selected item', () => {
-      const expectedArgs = [RESOURCE_TYPES.ITEM, item.id, RESOURCE_KEYS.id];
-      const itemDialogRow = screen.getByTestId(testIds.itemDialogRow);
+    describe('When item does not have a barcode', () => {
+      const selectedItem = {
+        id: 'itemId',
+      };
 
-      fireEvent.click(itemDialogRow);
+      beforeEach(() => {
+        ItemsDialog.mockImplementationOnce(({
+          onRowClick,
+        }) => {
+          const handleRowClick = () => {
+            onRowClick({}, selectedItem);
+          };
 
-      expect(basicProps.findResource).toHaveBeenCalledWith(...expectedArgs);
-    });
+          return (
+            <button
+              data-testid={testIds.itemDialogRow}
+              type="button"
+              onClick={handleRowClick}
+            >
+              Item
+            </button>
+          );
+        });
+        renderComponent();
+      });
 
-    it('should reset selected instance', () => {
-      const itemDialogCloseButton = screen.getByTestId(testIds.itemDialogCloseButton);
+      it('should get information about selected item', () => {
+        const expectedArgs = [RESOURCE_TYPES.ITEM, item.id, RESOURCE_KEYS.id];
+        const itemDialogRow = screen.getByTestId(testIds.itemDialogRow);
 
-      fireEvent.click(itemDialogCloseButton);
+        fireEvent.click(itemDialogRow);
 
-      expect(basicProps.onSetSelectedInstance).toHaveBeenCalledWith(undefined);
+        expect(basicProps.findResource).toHaveBeenCalledWith(...expectedArgs);
+      });
     });
   });
 

--- a/src/deprecated/components/RequestsFilters/RequestsFilters.js
+++ b/src/deprecated/components/RequestsFilters/RequestsFilters.js
@@ -26,6 +26,7 @@ import {
 
 import { PickupServicePointFilter } from '../../../components/RequestsFilters/PickupServicePointFilter';
 import { RequestLevelFilter } from '../../../components/RequestsFilters/RequestLevelFilter';
+import { RetrievalServicePointFilter } from '../../../components/RequestsFilters/RetrievalServicePointFilter';
 
 export default class RequestsFilters extends React.Component {
   static propTypes = {
@@ -35,6 +36,7 @@ export default class RequestsFilters extends React.Component {
       requestType: PropTypes.arrayOf(PropTypes.string),
       tags: PropTypes.arrayOf(PropTypes.string),
       pickupServicePoints: PropTypes.arrayOf(PropTypes.string),
+      retrievalServicePoints: PropTypes.arrayOf(PropTypes.string),
       printStatus: PropTypes.arrayOf(PropTypes.string),
     }).isRequired,
     resources: PropTypes.object.isRequired,
@@ -65,6 +67,7 @@ export default class RequestsFilters extends React.Component {
         requestType = [],
         requestStatus = [],
         pickupServicePoints = [],
+        retrievalServicePoints = [],
         requestLevels = [],
         printStatus = [],
       },
@@ -143,6 +146,12 @@ export default class RequestsFilters extends React.Component {
           data-testid="pickupServicePointFilter"
           activeValues={pickupServicePoints}
           servicePoints={this.props.resources?.servicePoints?.records}
+          onChange={onChange}
+          onClear={onClear}
+        />
+        <RetrievalServicePointFilter
+          data-testid="retrievalServicePointFilter"
+          activeValues={retrievalServicePoints}
           onChange={onChange}
           onClear={onClear}
         />

--- a/src/deprecated/components/RequestsFilters/RequestsFilters.test.js
+++ b/src/deprecated/components/RequestsFilters/RequestsFilters.test.js
@@ -15,6 +15,7 @@ import {
 import RequestsFilters from './RequestsFilters';
 import { RequestLevelFilter } from '../../../components/RequestsFilters/RequestLevelFilter';
 import { PickupServicePointFilter } from '../../../components/RequestsFilters/PickupServicePointFilter';
+import { RetrievalServicePointFilter } from '../../../components/RequestsFilters/RetrievalServicePointFilter';
 
 import {
   requestFilterTypes,
@@ -25,6 +26,9 @@ jest.mock('../../../components/RequestsFilters/RequestLevelFilter', () => ({
 }));
 jest.mock('../../../components/RequestsFilters/PickupServicePointFilter', () => ({
   PickupServicePointFilter: jest.fn((props) => (<div {...props} />)),
+}));
+jest.mock('../../../components/RequestsFilters/RetrievalServicePointFilter', () => ({
+  RetrievalServicePointFilter: jest.fn((props) => (<div {...props} />)),
 }));
 jest.mock('@folio/stripes/smart-components', () => ({
   CheckboxFilter: jest.fn((props) => (<div {...props} />)),
@@ -38,6 +42,7 @@ const props = {
     requestStatus: ['Open'],
     requestType: ['Hold'],
     pickupServicePoints: ['1'],
+    retrievalServicePoints: ['1', '2'],
     tags: ['Urgent'],
     requestLevels: [],
     printStatus: ['Printed'],
@@ -71,6 +76,7 @@ const testIds = {
   requestLevelFilter: 'requestLevelFilter',
   multiSelectionFilter: 'multiSelectionFilter',
   pickupServicePointFilter: 'pickupServicePointFilter',
+  retrievalServicePointFilter: 'retrievalServicePointFilter',
 };
 const labelIds = {
   [requestFilterTypes.REQUEST_TYPE]: 'ui-requests.requestMeta.type',
@@ -255,6 +261,21 @@ describe('RequestsFilters', () => {
         'data-testid': testIds.pickupServicePointFilter,
         activeValues: props.activeFilters.pickupServicePoints,
         servicePoints: props.resources.servicePoints.records,
+        onChange,
+        onClear,
+      }), {});
+    });
+  });
+
+  describe('RetrievalServicePointFilter', () => {
+    it('should render RetrievalServicePointFilter', () => {
+      expect(screen.getByTestId(testIds.retrievalServicePointFilter)).toBeInTheDocument();
+    });
+
+    it('should trigger retrievalServicePointFilter with correct props', () => {
+      expect(RetrievalServicePointFilter).toHaveBeenCalledWith(expect.objectContaining({
+        'data-testid': testIds.retrievalServicePointFilter,
+        activeValues: props.activeFilters.retrievalServicePoints,
         onChange,
         onClear,
       }), {});

--- a/src/deprecated/components/RequestsFilters/RequestsFiltersConfig.js
+++ b/src/deprecated/components/RequestsFilters/RequestsFiltersConfig.js
@@ -1,4 +1,6 @@
-import { requestFilterTypes } from '../../../constants';
+import {
+  requestFilterTypes,
+} from '../../../constants';
 
 export const escapingForSpecialCharactersWhichCanBreakCQL = (string = '') => string.replace(/[\\"?*]/g, '\\$&');
 
@@ -38,6 +40,12 @@ export default [
   {
     name: requestFilterTypes.PICKUP_SERVICE_POINT,
     cql: 'pickupServicePointId',
+    values: [],
+    operator: '==',
+  },
+  {
+    name: requestFilterTypes.RETRIEVAL_SERVICE_POINT,
+    cql: 'item.retrievalServicePointId',
     values: [],
     operator: '==',
   },

--- a/src/deprecated/components/RequestsFilters/RequestsFiltersConfig.test.js
+++ b/src/deprecated/components/RequestsFilters/RequestsFiltersConfig.test.js
@@ -81,6 +81,18 @@ describe('RequestsFiltersConfig', () => {
     expect(pickupServicePointFilter).toEqual(expectedResult);
   });
 
+  it('should have a filter for retrieval service point', () => {
+    const retrievalServicePointFilter = filtersConfig.find(f => f.name === requestFilterTypes.RETRIEVAL_SERVICE_POINT);
+    const expectedResult = {
+      name: 'retrievalServicePoints',
+      cql: 'item.retrievalServicePointId',
+      values: [],
+      operator: '==',
+    };
+
+    expect(retrievalServicePointFilter).toEqual(expectedResult);
+  });
+
   describe('Print Status Filter configuration', () => {
     it('should correctly match the filter configuration for printStatus', () => {
       const printStatusFilter = filtersConfig.find(f => f.name === 'printStatus');

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.js
@@ -107,6 +107,7 @@ import SinglePrintButtonForPickSlip from '../../../components/SinglePrintButtonF
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
+const DEFAULT_FORMATTER_VALUE = '';
 
 export const getPrintHoldRequestsEnabled = (printHoldRequests) => {
   const value = printHoldRequests.records[0]?.value;
@@ -271,6 +272,7 @@ export const getListFormatter = (
   'year': rq => (getFormattedYears(rq.instance?.publication, DEFAULT_DISPLAYED_YEARS_AMOUNT) || <NoValue />),
   'callNumber': rq => (effectiveCallNumber(rq.item) || <NoValue />),
   'servicePoint': rq => get(rq, 'pickupServicePoint.name', <NoValue />),
+  'retrievalServicePoint': rq => get(rq, 'item.retrievalServicePointName', DEFAULT_FORMATTER_VALUE),
   'copies': rq => get(rq, PRINT_DETAILS_COLUMNS.COPIES, <NoValue />),
   'printed': rq => (rq.printDetails ? getLastPrintedDetails(rq.printDetails, intl) : <NoValue />),
 });
@@ -332,6 +334,7 @@ class RequestsRoute extends React.Component {
               'requestStatus': 'status',
               'servicePoint': 'searchIndex.pickupServicePointName',
               'requesterBarcode': 'requester.barcode',
+              'retrievalServicePoint': 'item.retrievalServicePointName',
               'requestDate': 'requestDate',
               'position': 'position/number',
               'proxy': 'proxy',
@@ -939,6 +942,9 @@ class RequestsRoute extends React.Component {
         const { addressLine1, city, region, postalCode, countryId } = record.deliveryAddress;
         record.deliveryAddress = `${addressLine1 || ''} ${city || ''} ${region || ''} ${countryId || ''} ${postalCode || ''}`;
       }
+      if (record?.item?.retrievalServicePointName) {
+        record.retrievalServicePointName = record.item.retrievalServicePointName;
+      }
       record.instance.contributorNames = contributorNamesMap.join('; ');
       if (record.tags) record.tags.tagList = tagListMap.join('; ');
     });
@@ -1401,6 +1407,7 @@ class RequestsRoute extends React.Component {
       servicePoint: <FormattedMessage id="ui-requests.requests.servicePoint" />,
       requester: <FormattedMessage id="ui-requests.requests.requester" />,
       requesterBarcode: <FormattedMessage id="ui-requests.requests.requesterBarcode" />,
+      retrievalServicePoint: <FormattedMessage id="ui-requests.requests.retrievalServicePoint" />,
       singlePrint: <FormattedMessage id="ui-requests.requests.singlePrint" />,
       proxy: <FormattedMessage id="ui-requests.requests.proxy" />,
       ...(isViewPrintDetailsEnabled && {
@@ -1678,7 +1685,7 @@ class RequestsRoute extends React.Component {
               renderFilters={this.renderFilters}
               onFilterChange={this.handleFilterChange}
               sortableColumns={['requestDate', 'title', 'year', 'itemBarcode', 'callNumber', 'type', 'requestStatus',
-                'position', 'servicePoint', 'requester', 'requesterBarcode', 'proxy', 'copies', 'printed']}
+                'position', 'servicePoint', 'requester', 'requesterBarcode', 'retrievalServicePoint', 'proxy', 'copies', 'printed']}
               pageAmount={100}
               pagingType={MCLPagingTypes.PREV_NEXT}
             />

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
@@ -231,6 +231,8 @@ const mockedRequest = {
   instanceId: 'instanceId',
   item: {
     barcode: 'itemBarcode',
+    retrievalServicePointId: '3a40852d-49fd-4df2-a1f9-6e2641a6e91f',
+    retrievalServicePointName: 'Circ Desk 1',
   },
   requester: {
     barcode: 'requesterBarcode',
@@ -332,6 +334,10 @@ describe('RequestsRoute', () => {
             name: 'Jane Smith',
           }
         ],
+      },
+      item: {
+        retrievalServicePointId: '3a40852d-49fd-4df2-a1f9-6e2641a6e91f',
+        retrievalServicePointName: 'Circ Desk 1',
       },
       tags: {
         tagList: ['tag1', 'tag2'],
@@ -1139,6 +1145,8 @@ describe('RequestsRoute', () => {
       select: 'test value',
       item: {
         barcode: 'itemBarcode',
+        retrievalServicePointId: '3a40852d-49fd-4df2-a1f9-6e2641a6e91f',
+        retrievalServicePointName: 'Circ Desk 1',
       },
       position: 'position',
       proxy: {},
@@ -1370,6 +1378,12 @@ describe('RequestsRoute', () => {
     describe('servicePoint', () => {
       it('should return service point', () => {
         expect(listFormatter.servicePoint(requestWithData)).toBe(requestWithData.pickupServicePoint.name);
+      });
+    });
+
+    describe('retrieval service point', () => {
+      it('should return retrieval service point', () => {
+        expect(listFormatter.retrievalServicePoint(requestWithData)).toBe(requestWithData.item.retrievalServicePointName);
       });
     });
 

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -1001,7 +1001,7 @@ class RequestsRoute extends React.Component {
         const { addressLine1, city, region, postalCode, countryId } = record.deliveryAddress;
         record.deliveryAddress = `${addressLine1 || ''} ${city || ''} ${region || ''} ${countryId || ''} ${postalCode || ''}`;
       }
-      if (record.item.retrievalServicePointName) {
+      if (record?.item?.retrievalServicePointName) {
         record.retrievalServicePointName = record.item.retrievalServicePointName;
       }
       record.instance.contributorNames = contributorNamesMap.join('; ');


### PR DESCRIPTION
Upgrade `@folio/stripes` dependency to ^10.0.7 (the most recent release). The previous dependency was on ^10.0.0, which required `@folio/stripes-util` v7.0.0, and that did not include the `convertToSlipData` function which this package uses).