### PR TITLE
UIREQ-1306: Remove barcode hyperlink from the Central Tenant request Item information section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * *BREAKING* Use `convertToSlipData` and supporting functions from `stripes-util`. Refs UIREQ-1263.
 * Replace moment with day.js. Refs UIREQ-1291.
 * Reduce count of eslint errors after update eslint-config-stripes. Refs UIREQ-1289.
+* Remove barcode hyperlink from the Central tenant request Item information section. Refs UIREQ-1306.
 
 ## [12.0.2] (https://github.com/folio-org/ui-requests/tree/v12.0.2) (2025-04-15)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v12.0.1...v12.0.2)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -4,6 +4,10 @@ import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
 import {
+  checkIfUserInCentralTenant,
+  useStripes,
+} from '@folio/stripes/core';
+import {
   Col,
   KeyValue,
   Row,
@@ -31,6 +35,7 @@ const ItemDetail = ({
   loan,
   requestCount,
 }) => {
+  const stripes = useStripes();
   const itemId = request?.itemId || item.id;
 
   if (!itemId && !item.barcode) {
@@ -59,7 +64,7 @@ const ItemDetail = ({
   const isRequestValid = isValidRequest({ instanceId, holdingsRecordId });
   const recordLink = () => {
     if (itemId) {
-      return isRequestValid && !isVirtualItem(instanceId, holdingsRecordId)
+      return isRequestValid && !isVirtualItem(instanceId, holdingsRecordId) && !checkIfUserInCentralTenant(stripes)
         ? <Link to={`/inventory/view/${instanceId}/${holdingsRecordId}/${itemId}`}>{item.barcode || itemId}</Link>
         : (item.barcode || itemId);
     }


### PR DESCRIPTION
## Purpose
Remove barcode hyperlink from the Central Tenant request Item information section

# Refs
https://issues.folio.org/browse/UIREQ-1306
