### PR TITLE
[UIREQ-1282] Display loan type/loan-policy in new-request form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * *BREAKING* Use `convertToSlipData` and supporting functions from `stripes-util`. Refs UIREQ-1263.
 * Replace moment with day.js. Refs UIREQ-1291.
 * Reduce count of eslint errors after update eslint-config-stripes. Refs UIREQ-1289.
+* Display loan type and "For use at location" loan-policy setting in new-request form. Fixes UIREQ-1282.
 
 ## [12.0.3] (https://github.com/folio-org/ui-requests/tree/v12.0.3) (2025-05-28)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v12.0.2...v12.0.3)

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
           "circulation-bff.pick-slips.collection.get",
           "circulation-storage.staff-slips.collection.get",
           "tags.collection.get",
+          "circulation-storage.loan-policies.item.get",
           "circulation.print-events-entry.item.post"
         ],
         "visible": true

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
       "request-storage": "6.0",
       "pick-slips": "0.1",
       "search-slips": "0.1",
-      "automated-patron-blocks": "0.1"
+      "automated-patron-blocks": "0.1",
+      "loan-policy-storage": "2.3"
     },
     "optionalOkapiInterfaces": {
       "circulation-bff-loans": "1.0"

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -105,9 +105,14 @@ const ItemDetail = ({
             {effectiveLocationName}
           </KeyValue>
         </Col>
-        <Col xs={8}>
+        <Col xs={4}>
           <KeyValue label={<FormattedMessage id="ui-requests.item.callNumber" />}>
             {effectiveCallNumberString}
+          </KeyValue>
+        </Col>
+        <Col xs={4}>
+          <KeyValue label={<FormattedMessage id="ui-requests.loanType" />}>
+            {item.temporaryLoanType?.name || item.permanentLoanType?.name}
           </KeyValue>
         </Col>
       </Row>

--- a/src/components/RequestInformation/RequestInformation.js
+++ b/src/components/RequestInformation/RequestInformation.js
@@ -1,8 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
+import { useOkapiKy } from '@folio/stripes/core';
 
 import {
   Col,
@@ -52,6 +53,7 @@ const RequestInformation = ({
   values,
   form,
   updateRequestPreferencesFields,
+  loan,
 }) => {
   const isEditForm = isFormEditing(request);
   const holdShelfExpireDate = get(request, ['status'], '') === requestStatuses.AWAITING_PICKUP
@@ -81,6 +83,19 @@ const RequestInformation = ({
     input.onChange(e);
     updateRequestPreferencesFields();
   };
+
+  const okapiKy = useOkapiKy();
+  const [loanPolicy, setLoanPolicy] = useState();
+
+  useEffect(() => {
+    if (loan?.loanPolicyId) {
+      okapiKy(`loan-policy-storage/loan-policies/${loan.loanPolicyId}`).then(res => {
+        res.json().then(policy => {
+          setLoanPolicy(policy);
+        });
+      });
+    }
+  }, [loan?.loanPolicyId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>
@@ -149,6 +164,7 @@ const RequestInformation = ({
                   }}
                 </Field>
               }
+              {loanPolicy?.loansPolicy?.forUseAtLocation && <b><FormattedMessage id="ui-requests.forUseAtLocation" /></b>}
             </Col>
             <Col xs={2}>
               {isEditForm &&

--- a/src/deprecated/components/RequestForm/RequestForm.js
+++ b/src/deprecated/components/RequestForm/RequestForm.js
@@ -1430,6 +1430,7 @@ class RequestForm extends React.Component {
                       isSelectedUser={Boolean(selectedUser?.id)}
                       values={values}
                       form={form}
+                      loan={selectedLoan}
                     />
                     {isFulfilmentPreferenceVisible &&
                       <FulfilmentPreference

--- a/translations/ui-requests/en.json
+++ b/translations/ui-requests/en.json
@@ -14,6 +14,7 @@
   "loanType": "Loan type",
   "fulfillmentPreference": "Request fulfillment preference",
   "requestType": "Request type",
+  "forUseAtLocation": "For use at location",
   "status": "Request status",
   "requestDate": "Request date",
   "requestExpirationDate": "Request expiration date",


### PR DESCRIPTION
When creating a new request and the item has been specified, the loan type is now shown in the Item Information accordion; and if the loan type's associated policy has the "For use at location" bit set, a message is displayed in the Request Information accordion.

To access this information, it was necessary to make an additional WSAPI request to `loan-policy-storage/loan-policies/${id}`. As this is only required under certain circumstances, I used `okapiKi` directly in a `useEffect` in `RequestInformation.js` rather than trying to pull it in as part of the stripes-connect manifest in the routing component. This approach avoid unnecessary calls and reduces "action at a distance" in the code.

The permission required for this new WSAPI call, `circulation-storage.loan-policies.item.get`, has been added to the `ui-requests.view` permission.

This WSAPI call is furnished by the `loan-policy-storage` interface, version 2.3 and later. I have added this interface to the UI modules's `okapiInterfaces`.

