### PR TITLE
[UIREQ-1328] Display loan type on the Request Detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Display Unknown user instead of link with undefined when a user record is deleted. Refs UIREQ-1312.
 * Add default value for `record` parameter when it is missing in `getFullNameForCsvRecords`. Add `getPrintedDetails` to display only the date in a CSV file when the user was deleted. Fixes UIREQ-1305.
 * Add missing subPermissions for "Requests: View, create" permission. Refs UIREQ-1296.
+* Display loan type on the Request Detail page, as well as New Request page. Refs UIREQ-1328.
 
 ## [12.0.3] (https://github.com/folio-org/ui-requests/tree/v12.0.3) (2025-05-28)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v12.0.2...v12.0.3)

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -179,6 +179,7 @@ ItemDetail.propTypes = {
         name: PropTypes.string,
       }),
     ]),
+    loanTypeName: PropTypes.string,
   }),
   loan: PropTypes.shape({
     dueDate: PropTypes.string,

--- a/src/ItemDetail.js
+++ b/src/ItemDetail.js
@@ -112,7 +112,7 @@ const ItemDetail = ({
         </Col>
         <Col xs={4}>
           <KeyValue label={<FormattedMessage id="ui-requests.loanType" />}>
-            {item.temporaryLoanType?.name || item.permanentLoanType?.name}
+            {item.loanTypeName || item.temporaryLoanType?.name || item.permanentLoanType?.name}
           </KeyValue>
         </Col>
       </Row>


### PR DESCRIPTION
(As well as New Request page, which worked before and still does.)

All we're doing here is looking at the field that's been added to the request record's `item` subrecord in https://github.com/folio-org/mod-circulation/pull/1607 so that when we're viewing an existing request, we're able to show the loan-type. We also still look at the fields we checked before (`item.temporaryLoanType?.name` and `item.permanentLoanType?.name`), as these are still where the information shows up in the item record itself during the process of creating a new request.