### PR TITLE
UIREQ-1365: Fix displaying a dash placeholder instead of an empty link when instance title is missing in the requests list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [13.1.0] IN_PROGRESS
 
+* Fix displaying a dash placeholder instead of an empty link when instance title is missing in the requests list. Refs UIREQ-1365.
+
 ## [13.0.2] (https://github.com/folio-org/ui-requests/tree/v13.0.2) (2026-06-02)
 [Full Changelog](https://github.com/folio-org/ui-requests/compare/v13.0.1...v13.0.2)
 

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.js
@@ -265,7 +265,7 @@ export const getListFormatter = (
     ? <FormattedMessage id={requestStatusesTranslations[rq.status]} />
     : <NoValue />),
   'type': rq => <FormattedMessage id={requestTypesTranslations[rq.requestType]} />,
-  'title': rq => <TextLink to={getRowURL(rq.id)}>{(rq.instance ? rq.instance.title : <NoValue />)}</TextLink>,
+  'title': rq => (rq.instance?.title ? <TextLink to={getRowURL(rq.id)}>{rq.instance.title}</TextLink> : <NoValue />),
   'year': rq => (getFormattedYears(rq.instance?.publication, DEFAULT_DISPLAYED_YEARS_AMOUNT) || <NoValue />),
   'callNumber': rq => (effectiveCallNumber(rq.item) || <NoValue />),
   'servicePoint': rq => get(rq, 'pickupServicePoint.name', <NoValue />),

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
@@ -1370,6 +1370,20 @@ describe('RequestsRoute', () => {
 
         expect(TextLink).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
       });
+
+      it('should render "NoValue" and not "TextLink" when instance is missing', () => {
+        render(listFormatter.title(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
+        expect(TextLink).not.toHaveBeenCalled();
+      });
+
+      it('should render "NoValue" and not "TextLink" when instance title is missing', () => {
+        render(listFormatter.title({ ...requestWithData, instance: {} }));
+
+        expect(NoValue).toHaveBeenCalled();
+        expect(TextLink).not.toHaveBeenCalled();
+      });
     });
 
     describe('type', () => {

--- a/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
+++ b/src/deprecated/routes/RequestsRoute/RequestsRoute.test.js
@@ -1353,6 +1353,11 @@ describe('RequestsRoute', () => {
     });
 
     describe('title', () => {
+      afterEach(() => {
+        TextLink.mockClear();
+        NoValue.mockClear();
+      });
+
       it('should render instance title', () => {
         render(listFormatter.title(requestWithData));
 

--- a/src/routes/RequestsRoute.js
+++ b/src/routes/RequestsRoute.js
@@ -281,7 +281,7 @@ export const getListFormatter = (
     ? <FormattedMessage id={requestStatusesTranslations[rq.status]} />
     : <NoValue />),
   'type': rq => <FormattedMessage id={requestTypesTranslations[rq.requestType]} />,
-  'title': rq => <TextLink to={getRowURL(rq.id)}>{(rq.instance ? rq.instance.title : <NoValue />)}</TextLink>,
+  'title': rq => (rq.instance?.title ? <TextLink to={getRowURL(rq.id)}>{rq.instance.title}</TextLink> : <NoValue />),
   'year': rq => (getFormattedYears(rq.instance?.publication, DEFAULT_DISPLAYED_YEARS_AMOUNT) || <NoValue />),
   'callNumber': rq => (effectiveCallNumber(rq.item) || <NoValue />),
   'servicePoint': rq => get(rq, 'pickupServicePoint.name', <NoValue />),

--- a/src/routes/RequestsRoute.test.js
+++ b/src/routes/RequestsRoute.test.js
@@ -1507,6 +1507,11 @@ describe('RequestsRoute', () => {
     });
 
     describe('title', () => {
+      afterEach(() => {
+        TextLink.mockClear();
+        NoValue.mockClear();
+      });
+
       it('should render instance title', () => {
         render(listFormatter.title(requestWithData));
 
@@ -1523,6 +1528,20 @@ describe('RequestsRoute', () => {
         render(listFormatter.title(requestWithData));
 
         expect(TextLink).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
+      });
+
+      it('should render "NoValue" and not "TextLink" when instance is missing', () => {
+        render(listFormatter.title(requestWithoutData));
+
+        expect(NoValue).toHaveBeenCalled();
+        expect(TextLink).not.toHaveBeenCalled();
+      });
+
+      it('should render "NoValue" and not "TextLink" when instance title is missing', () => {
+        render(listFormatter.title({ ...requestWithData, instance: {} }));
+
+        expect(NoValue).toHaveBeenCalled();
+        expect(TextLink).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## Purpose
Fix displaying a dash placeholder instead of an empty link when instance title is missing in the requests list

# Refs
https://folio-org.atlassian.net/browse/UIREQ-1365